### PR TITLE
Don't require trait to be imported

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ See `examples` for example of implementing a custom cache-store.
 use std::time::Duration;
 use std::thread::sleep;
 
-use cached::{Cached, SizedCache}; // trait must be in scope
+use cached::SizedCache;
 
 
 cached!{ SLOW: SizedCache = SizedCache::with_capacity(50); >>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub fn main() { }
 #[macro_use] extern crate cached;
 #[macro_use] extern crate lazy_static;
 
-use cached::{Cached, UnboundCache};
+use cached::UnboundCache;
 
 cached!{FIB: UnboundCache >>
 fib(n: u64) -> u64 = {
@@ -51,8 +51,6 @@ pub fn main() { }
 ```rust
 #[macro_use] extern crate cached;
 #[macro_use] extern crate lazy_static;
-
-use cached::{Cached};
 
 cached!{FIB >>
 fib(n: u64) -> u64 = {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -16,12 +16,12 @@ macro_rules! cached {
             let key = ($($arg.clone()),*);
             {
                 let mut cache = $cachename.lock().unwrap();
-                let res = cache.cache_get(&key);
+                let res = $crate::Cached::cache_get(&mut *cache, &key);
                 if let Some(res) = res { return res.clone(); }
             }
             let val = (||$body)();
             let mut cache = $cachename.lock().unwrap();
-            cache.cache_set(key, val.clone());
+            $crate::Cached::cache_set(&mut *cache, key, val.clone());
             val
         }
     };
@@ -39,12 +39,12 @@ macro_rules! cached {
             {
                 let mut cache = $cachename.lock().unwrap();
                 cached::enforce_cached_impl(&cache);
-                let res = cache.cache_get(&key);
+                let res = $crate::Cached::cache_get(&mut *cache, &key);
                 if let Some(res) = res { return res.clone(); }
             }
             let val = (||$body)();
             let mut cache = $cachename.lock().unwrap();
-            cache.cache_set(key, val.clone());
+            $crate::Cached::cache_set(&mut *cache, key, val.clone());
             val
         }
     };
@@ -62,12 +62,12 @@ macro_rules! cached {
             {
                 let mut cache = $cachename.lock().unwrap();
                 cached::enforce_cached_impl(&cache);
-                let res = cache.cache_get(&key);
+                let res = $crate::Cached::cache_get(&mut *cache, &key);
                 if let Some(res) = res { return res.clone(); }
             }
             let val = (||$body)();
             let mut cache = $cachename.lock().unwrap();
-            cache.cache_set(key, val.clone());
+            $crate::Cached::cache_set(&mut *cache, key, val.clone());
             val
         }
     };


### PR DESCRIPTION
We can use UFCS so that it doesn't need to be imported.