### PR TITLE
Add cached_key_result macro for caching success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.6.0]
+## Added
+-- Add `cached_result` and `cached_key_result` to allow the caching of success for a function that returns `Result`.
+
 ## [0.5.0]
 ## Added
 - Add `cached_key` macro to allow defining the caching key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.6.0]
+## [Unreleased]
 ## Added
 -- Add `cached_result` and `cached_key_result` to allow the caching of success for a function that returns `Result`.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cached"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["James Kominick <james.kominick@gmail.com>"]
 description = "Generic cache implementations and simplified function memoization"
 repository = "https://github.com/jaemk/cached"
@@ -10,7 +10,7 @@ categories = ["caching"]
 keywords = ["caching", "cache", "memoize", "lru"]
 license = "MIT"
 
-[badges]
+[badges]    
 travis-ci = { repository = "jaemk/cached", branch = "master" }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cached"
-version = "0.6.0"
+version = "0.5.0"
 authors = ["James Kominick <james.kominick@gmail.com>"]
 description = "Generic cache implementations and simplified function memoization"
 repository = "https://github.com/jaemk/cached"
@@ -10,7 +10,7 @@ categories = ["caching"]
 keywords = ["caching", "cache", "memoize", "lru"]
 license = "MIT"
 
-[badges]    
+[badges]
 travis-ci = { repository = "jaemk/cached", branch = "master" }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -113,13 +113,13 @@ cached_key!{
    is cached, but errors are not. Note that the error type does _not_ need to implement `Clone`,
    only the success type however the cache type cannot be derived and must always be
    explicitly specified.
-   
+
 ```rust
    #[macro_use] extern crate cached;
    #[macro_use] extern crate lazy_static;
-   
+
    use cached::UnboundCache;
-   
+
    /// Cache the successes of a function.
    /// To use `cached_key_result` add a key function as in `cached_key`.
    cached_result!{
@@ -140,7 +140,7 @@ cached_key!{
 The complete macro syntax is:
 
 
-```rust
+```rust,ignore
 cached_key!{
     CACHE_NAME: CacheType = CacheInstance;
     Key = KeyExpression;

--- a/README.md
+++ b/README.md
@@ -107,6 +107,33 @@ cached_key!{
 }
 ```
 
+4. The `cached_result` and `cached_key_result` macros function similarly to `cached`
+   and `cached_key` respectively but the cached function needs to return `Result`
+   (or some type alias like `io::Result`). If the function returns `Ok(val)` then `val`
+   is cached, but errors are not. Note that the error type does _not_ need to implement `Clone`,
+   only the success type however the cache type cannot be derived and must always be
+   explicitly specified.
+   
+```rust
+   #[macro_use] extern crate cached;
+   #[macro_use] extern crate lazy_static;
+   
+   use cached::UnboundCache;
+   
+   /// Cache the successes of a function.
+   /// To use `cached_key_result` add a key function as in `cached_key`.
+   cached_result!{
+       FIB: UnboundCache<(u64, u64), u64> = UnboundCache::new(); // Type must always be specified
+       fn fib(a: u64, b: u64) -> Result<u64, ()> = {
+            if a == 0 || b == 0 {
+                return Err(());
+            } else {
+                return Ok(a * b);
+            }
+       }
+   }
+   ```
+
 
 ## Syntax
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,24 +117,25 @@ cached_key!{
    explicitly specified.
 
 ```rust,no_run
-   #[macro_use] extern crate cached;
-   #[macro_use] extern crate lazy_static;
+#[macro_use] extern crate cached;
+#[macro_use] extern crate lazy_static;
 
-   use cached::UnboundCache;
+use cached::UnboundCache;
 
-   /// Cache the successes of a function.
-   /// To use `cached_key_result` add a key function as in `cached_key`.
-   cached_result!{
-       FIB: UnboundCache<(u64, u64), u64> = UnboundCache::new(); // Type must always be specified
-       fn fib(a: u64, b: u64) -> Result<u64, ()> = {
-            if a == 0 || b == 0 {
-                return Err(());
-            } else {
-                return Ok(a * b);
-            }
-       }
+/// Cache the successes of a function.
+/// To use `cached_key_result` add a key function as in `cached_key`.
+cached_result!{
+   FIB: UnboundCache<(u64, u64), u64> = UnboundCache::new(); // Type must always be specified
+   fn fib(a: u64, b: u64) -> Result<u64, ()> = {
+        if a == 0 || b == 0 {
+            return Err(());
+        } else {
+            return Ok(a * b);
+        }
    }
-   ```
+}
+# pub fn main() { }
+```
 
 
 ## Syntax

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,33 @@ cached_key!{
 # pub fn main() { }
 ```
 
+4. The `cached_result` and `cached_key_result` macros function similarly to `cached`
+   and `cached_key` respectively but the cached function needs to return `Result`
+   (or some type alias like `io::Result`). If the function returns `Ok(val)` then `val`
+   is cached, but errors are not. Note that the error type does _not_ need to implement `Clone`,
+   only the success type however the cache type cannot be derived and must always be
+   explicitly specified.
+
+```rust,no_run
+   #[macro_use] extern crate cached;
+   #[macro_use] extern crate lazy_static;
+
+   use cached::UnboundCache;
+
+   /// Cache the successes of a function.
+   /// To use `cached_key_result` add a key function as in `cached_key`.
+   cached_result!{
+       FIB: UnboundCache<(u64, u64), u64> = UnboundCache::new(); // Type must always be specified
+       fn fib(a: u64, b: u64) -> Result<u64, ()> = {
+            if a == 0 || b == 0 {
+                return Err(());
+            } else {
+                return Ok(a * b);
+            }
+       }
+   }
+   ```
+
 
 ## Syntax
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -66,6 +66,32 @@ macro_rules! cached_key {
 }
 
 #[macro_export]
+macro_rules! cached_result {
+    // Unfortunately it's impossible to infer the cache type because it's not the function return type
+    ($cachename:ident : $cachetype:ty = $cacheinstance:expr ;
+     fn $name:ident ($($arg:ident : $argtype:ty),*) -> $ret:ty = $body:expr) => {
+        lazy_static! {
+            static ref $cachename: ::std::sync::Mutex<$cachetype> = {
+                ::std::sync::Mutex::new($cacheinstance)
+            };
+        }
+        #[allow(unused_parens)]
+        pub fn $name($($arg: $argtype),*) -> $ret {
+            let key = ($($arg.clone()),*);
+            {
+                let mut cache = $cachename.lock().unwrap();
+                let res = $crate::Cached::cache_get(&mut *cache, &key);
+                if let Some(res) = res { return Ok(res.clone()); }
+            }
+            let val = (||$body)()?;
+            let mut cache = $cachename.lock().unwrap();
+            $crate::Cached::cache_set(&mut *cache, key, val.clone());
+            Ok(val)
+        }
+    };
+}
+
+#[macro_export]
 macro_rules! cached_key_result {
     // Use a specified cache-type and an explicitly created cache-instance
     ($cachename:ident : $cachetype:ty = $cacheinstance:expr ;

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -6,7 +6,7 @@ Full tests of macro-defined functions
 
 use std::time::Duration;
 use std::thread::sleep;
-use cached::{Cached, SizedCache, TimedCache};
+use cached::{UnboundCache, Cached, SizedCache, TimedCache};
 
 
 cached!{
@@ -149,3 +149,26 @@ fn test_sized_cache_key() {
     }
 }
 
+cached_key_result!{
+    RESULT_CACHE: UnboundCache<(u32), u32> = UnboundCache::new();
+    Key = { n };
+    fn test_result(n: u32) -> Result<u32, ()> = {
+        if n < 5 { Ok(n) } else { Err(()) }
+    }
+}
+
+#[test]
+fn cache_result() {
+    assert!(test_result(2).is_ok());
+    assert!(test_result(4).is_ok());
+    assert!(test_result(6).is_err());
+    assert!(test_result(6).is_err());
+    assert!(test_result(2).is_ok());
+    assert!(test_result(4).is_ok());
+    {
+        let cache = RESULT_CACHE.lock().unwrap();
+        assert_eq!(2, cache.cache_size());
+        assert_eq!(2, cache.cache_hits().unwrap());
+        assert_eq!(4, cache.cache_misses().unwrap());
+    }
+}

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -150,21 +150,44 @@ fn test_sized_cache_key() {
 }
 
 cached_key_result!{
-    RESULT_CACHE: UnboundCache<(u32), u32> = UnboundCache::new();
+    RESULT_CACHE_KEY: UnboundCache<(u32), u32> = UnboundCache::new();
     Key = { n };
-    fn test_result(n: u32) -> Result<u32, ()> = {
+    fn test_result_key(n: u32) -> Result<u32, ()> = {
         if n < 5 { Ok(n) } else { Err(()) }
     }
 }
 
 #[test]
-fn cache_result() {
-    assert!(test_result(2).is_ok());
-    assert!(test_result(4).is_ok());
-    assert!(test_result(6).is_err());
-    assert!(test_result(6).is_err());
-    assert!(test_result(2).is_ok());
-    assert!(test_result(4).is_ok());
+fn cache_result_key() {
+    assert!(test_result_key(2).is_ok());
+    assert!(test_result_key(4).is_ok());
+    assert!(test_result_key(6).is_err());
+    assert!(test_result_key(6).is_err());
+    assert!(test_result_key(2).is_ok());
+    assert!(test_result_key(4).is_ok());
+    {
+        let cache = RESULT_CACHE_KEY.lock().unwrap();
+        assert_eq!(2, cache.cache_size());
+        assert_eq!(2, cache.cache_hits().unwrap());
+        assert_eq!(4, cache.cache_misses().unwrap());
+    }
+}
+
+cached_result!{
+    RESULT_CACHE: UnboundCache<(u32), u32> = UnboundCache::new();
+    fn test_result_no_default(n: u32) -> Result<u32, ()> = {
+        if n < 5 { Ok(n) } else { Err(()) }
+    }
+}
+
+#[test]
+fn cache_result_no_default() {
+    assert!(test_result_no_default(2).is_ok());
+    assert!(test_result_no_default(4).is_ok());
+    assert!(test_result_no_default(6).is_err());
+    assert!(test_result_no_default(6).is_err());
+    assert!(test_result_no_default(2).is_ok());
+    assert!(test_result_no_default(4).is_ok());
     {
         let cache = RESULT_CACHE.lock().unwrap();
         assert_eq!(2, cache.cache_size());


### PR DESCRIPTION
Hi, I recently came across the situation where I was trying to call a function which could fail. The function returned `io::Result<Foo>` which is _not_ clonable because io::Error is not.

However `Foo` itself _is_ so I made a macro that takes a function that returns a result and caches the success value. I only needed `cached_key_result` but if there's interest in including it I'll happily write `cached_result`.