### PR TITLE
prevent duplicate key eviction in SizedCache::cache_set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 ## Added
+
+## Changed
+
+## removed
+
+
+## [0.6.1]
+## Added
+
+## Changed
+- Fixed duplicate key eviction in `SizedCache::cache_set`. This would manifest when
+  `cached` functions called with duplicate keys would race set an uncached key,
+  or if `SizedCache` was used directly.
+
+## Removed
+
+## [0.6.0]
+## Added
 - Add `cached_result` and `cached_key_result` to allow the caching of success for a function that returns `Result`.
 - Add `cached_control` macro to allow specifying functionality
   at key points of the macro

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cached"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["James Kominick <james@kominick.com>"]
 description = "Generic cache implementations and simplified function memoization"
 repository = "https://github.com/jaemk/cached"


### PR DESCRIPTION
- addresses issue #7 and pr #8 
- SizedCache was not preventing duplicate keys from existing
  in the internal `ordering` list. When SizedCache::cache_set
  was called with an existing key, the key would still be
  prepended onto the ordering-list. When it came time for a
  duplicate key to be evicted, it would be missing from the
  hashmap and cause a panic.