### PR TITLE
Switch to once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ license = "MIT"
 [badges]
 travis-ci = { repository = "jaemk/cached", branch = "master" }
 
-[dev-dependencies]
-lazy_static = "1"
+[dependencies]
+once_cell = "0.1.6"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,6 +1,4 @@
 #[macro_use] extern crate cached;
-// `cached!` macro requires the `lazy_static!` macro
-#[macro_use] extern crate lazy_static;
 
 use std::time::{Instant, Duration};
 use std::thread::sleep;

--- a/examples/kitchen_sink.rs
+++ b/examples/kitchen_sink.rs
@@ -1,5 +1,4 @@
 #[macro_use] extern crate cached;
-#[macro_use] extern crate lazy_static;
 
 use std::collections::HashMap;
 use std::hash::Hash;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,6 @@ There are several options depending on how explicit you want to be. See below fo
 
 ```rust,no_run
 #[macro_use] extern crate cached;
-#[macro_use] extern crate lazy_static;
 
 /// Defines a function named `fib` that uses a cache named `FIB`
 cached!{
@@ -71,7 +70,6 @@ cached!{
 
 ```rust,no_run
 #[macro_use] extern crate cached;
-#[macro_use] extern crate lazy_static;
 
 use std::thread::sleep;
 use std::time::Duration;
@@ -96,7 +94,6 @@ cached!{
 
 ```rust,no_run
 #[macro_use] extern crate cached;
-#[macro_use] extern crate lazy_static;
 
 use std::thread::sleep;
 use std::time::Duration;
@@ -127,7 +124,6 @@ cached_key!{
 
 ```rust,no_run
 #[macro_use] extern crate cached;
-#[macro_use] extern crate lazy_static;
 
 use cached::UnboundCache;
 
@@ -185,7 +181,6 @@ scenarios, it can be useful to have the ability to customize the macro's functio
 
 ```rust,no_run
 #[macro_use] extern crate cached;
-#[macro_use] extern crate lazy_static;
 
 use cached::UnboundCache;
 
@@ -235,6 +230,8 @@ cached_control!{
 ```
 
 */
+
+pub extern crate once_cell;
 
 pub mod macros;
 pub mod stores;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -16,11 +16,14 @@ macro_rules! cached {
     // Use a specified cache-type and an explicitly created cache-instance
     ($cachename:ident : $cachetype:ty = $cacheinstance:expr ;
      fn $name:ident ($($arg:ident : $argtype:ty),*) -> $ret:ty = $body:expr) => {
-        lazy_static! {
-            static ref $cachename: ::std::sync::Mutex<$cachetype> = {
-                ::std::sync::Mutex::new($cacheinstance)
-            };
-        }
+        static $cachename: $crate::once_cell::sync::Lazy<::std::sync::Mutex<$cachetype>>
+            = $crate::once_cell::sync::Lazy {
+                __cell: $crate::once_cell::sync::OnceCell::INIT,
+                __init: || {
+                    ::std::sync::Mutex::new($cacheinstance)
+                },
+        };
+
         #[allow(unused_parens)]
         pub fn $name($($arg: $argtype),*) -> $ret {
             let key = ($($arg.clone()),*);
@@ -44,11 +47,14 @@ macro_rules! cached_key {
     ($cachename:ident : $cachetype:ty = $cacheinstance:expr ;
      Key = $key:expr;
      fn $name:ident ($($arg:ident : $argtype:ty),*) -> $ret:ty = $body:expr) => {
-        lazy_static! {
-            static ref $cachename: ::std::sync::Mutex<$cachetype> = {
-                ::std::sync::Mutex::new($cacheinstance)
-            };
-        }
+        static $cachename: $crate::once_cell::sync::Lazy<::std::sync::Mutex<$cachetype>>
+            = $crate::once_cell::sync::Lazy {
+                __cell: $crate::once_cell::sync::OnceCell::INIT,
+                __init: || {
+                    ::std::sync::Mutex::new($cacheinstance)
+                },
+        };
+
         #[allow(unused_parens)]
         pub fn $name($($arg: $argtype),*) -> $ret {
             let key = $key;
@@ -71,11 +77,14 @@ macro_rules! cached_result {
     // Unfortunately it's impossible to infer the cache type because it's not the function return type
     ($cachename:ident : $cachetype:ty = $cacheinstance:expr ;
      fn $name:ident ($($arg:ident : $argtype:ty),*) -> $ret:ty = $body:expr) => {
-        lazy_static! {
-            static ref $cachename: ::std::sync::Mutex<$cachetype> = {
-                ::std::sync::Mutex::new($cacheinstance)
-            };
-        }
+        static $cachename: $crate::once_cell::sync::Lazy<::std::sync::Mutex<$cachetype>>
+            = $crate::once_cell::sync::Lazy {
+                __cell: $crate::once_cell::sync::OnceCell::INIT,
+                __init: || {
+                    ::std::sync::Mutex::new($cacheinstance)
+                },
+        };
+
         #[allow(unused_parens)]
         pub fn $name($($arg: $argtype),*) -> $ret {
             let key = ($($arg.clone()),*);
@@ -99,11 +108,14 @@ macro_rules! cached_key_result {
     ($cachename:ident : $cachetype:ty = $cacheinstance:expr ;
      Key = $key:expr;
      fn $name:ident ($($arg:ident : $argtype:ty),*) -> $ret:ty = $body:expr) => {
-        lazy_static! {
-            static ref $cachename: ::std::sync::Mutex<$cachetype> = {
-                ::std::sync::Mutex::new($cacheinstance)
-            };
-        }
+        static $cachename: $crate::once_cell::sync::Lazy<::std::sync::Mutex<$cachetype>>
+            = $crate::once_cell::sync::Lazy {
+                __cell: $crate::once_cell::sync::OnceCell::INIT,
+                __init: || {
+                    ::std::sync::Mutex::new($cacheinstance)
+                },
+        };
+
         #[allow(unused_parens)]
         pub fn $name($($arg: $argtype),*) -> $ret {
             let key = $key;
@@ -131,11 +143,14 @@ macro_rules! cached_control {
      Set($set_value:ident) = $pre_set:expr;
      Return($ret_value:ident) = $return:expr;
      fn $name:ident ($($arg:ident : $argtype:ty),*) -> $ret:ty = $body:expr) => {
-        lazy_static! {
-            static ref $cachename: ::std::sync::Mutex<$cachetype> = {
-                ::std::sync::Mutex::new($cacheinstance)
-            };
-        }
+        static $cachename: $crate::once_cell::sync::Lazy<::std::sync::Mutex<$cachetype>>
+            = $crate::once_cell::sync::Lazy {
+                __cell: $crate::once_cell::sync::OnceCell::INIT,
+                __init: || {
+                    ::std::sync::Mutex::new($cacheinstance)
+                },
+        };
+
         #[allow(unused_parens)]
         pub fn $name($($arg: $argtype),*) -> $ret {
             let key = $key;

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -2,7 +2,6 @@
 Full tests of macro-defined functions
 */
 #[macro_use] extern crate cached;
-#[macro_use] extern crate lazy_static;
 
 use std::time::Duration;
 use std::thread::{self, sleep};


### PR DESCRIPTION
Switching to `once_cell` removes the need for `lazy_static` to be imported in user code.