### PR TITLE
Free memory when clear

### DIFF
--- a/src/stores.rs
+++ b/src/stores.rs
@@ -60,7 +60,7 @@ impl <K: Hash + Eq, V> Cached<K, V> for UnboundCache<K, V> {
         self.store.insert(key, val);
     }
     fn cache_remove(&mut self, k: &K) -> Option<V> { self.store.remove(k) }
-    fn cache_clear(&mut self) { self.store.clear(); }
+    fn cache_clear(&mut self) { self.store = HashMap::new(); }
     fn cache_size(&self) -> usize { self.store.len() }
     fn cache_hits(&self) -> Option<u32> { Some(self.hits) }
     fn cache_misses(&self) -> Option<u32> { Some(self.misses) }


### PR DESCRIPTION
UnboundCache is not limited in size, so we want to release the memory when clearing after a large amount of caching.
so I changed it to initialize the old cache memory by initializing with HashMap::new.
`HashMap::clear` is keeps the allocated memory.

https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.clear
> Clears the map, removing all key-value pairs. Keeps the allocated memory for reuse.

What do you think?

I tested it with the following code.

```rust
    #[test]
    fn clear_heavy_cache() {
        let mut c = UnboundCache::new();

        for i in 0..5_000_000 {
            if i % 1_000_000 == 0 {
                println!("{}", i);
            }
            c.cache_set(format!("Key: {}", i), format!("Value: {}", i));
        }

        println!("before clear");

        c.cache_clear();

        println!("after clear");

        std::thread::sleep(std::time::Duration::from_secs(15));

        println!("done");

    }
```



# before

![before](https://user-images.githubusercontent.com/690760/60478238-e8800700-9cbc-11e9-908f-f81e2fbdabde.gif)

# after

![after](https://user-images.githubusercontent.com/690760/60478242-eddd5180-9cbc-11e9-83b9-772a5fb2ca71.gif)




