### PR TITLE
Add `value_order`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
 
 ## Removed
 
+## [0.11.0]
+## Added
+- Add `value_order` method to SizedCache, similar to `key_order`
+
+## Changed
+
+## Removed
+
 ## [0.10.0]
 ## Added
 - add `cache_reset` trait method for resetting cache collections to

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cached"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["James Kominick <james@kominick.com>"]
 description = "Generic cache implementations and simplified function memoization"
 repository = "https://github.com/jaemk/cached"

--- a/src/stores.rs
+++ b/src/stores.rs
@@ -260,6 +260,12 @@ impl<K: Hash + Eq, V> SizedCache<K, V> {
     pub fn key_order(&self) -> impl Iterator<Item = &K> {
         self.order.iter().map(|(k, _v)| k)
     }
+
+    /// Return an iterator of values in the current order from most
+    /// to least recently used.
+    pub fn value_order(&self) -> impl Iterator<Item = &V> {
+        self.order.iter().map(|(_k, v)| v)
+    }
 }
 
 impl<K: Hash + Eq + Clone, V> Cached<K, V> for SizedCache<K, V> {

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -144,12 +144,14 @@ fn test_sized_cache_key() {
         assert_eq!(2, cache.cache_hits().unwrap());
         assert_eq!(2, cache.cache_size());
         assert_eq!(vec!["a2", "a1"], cache.key_order().collect::<Vec<_>>());
+        assert_eq!(vec![&2, &2], cache.value_order().collect::<Vec<_>>());
     }
     sized_key("a", "3");
     {
         let cache = SIZED_CACHE.lock().unwrap();
         assert_eq!(2, cache.cache_size());
         assert_eq!(vec!["a3", "a2"], cache.key_order().collect::<Vec<_>>());
+        assert_eq!(vec![&2, &2], cache.value_order().collect::<Vec<_>>());
     }
     sized_key("a", "4");
     sized_key("a", "5");
@@ -157,6 +159,15 @@ fn test_sized_cache_key() {
         let cache = SIZED_CACHE.lock().unwrap();
         assert_eq!(2, cache.cache_size());
         assert_eq!(vec!["a5", "a4"], cache.key_order().collect::<Vec<_>>());
+        assert_eq!(vec![&2, &2], cache.value_order().collect::<Vec<_>>());
+    }
+    sized_key("a", "67");
+    sized_key("a", "8");
+    {
+        let cache = SIZED_CACHE.lock().unwrap();
+        assert_eq!(2, cache.cache_size());
+        assert_eq!(vec!["a8", "a67"], cache.key_order().collect::<Vec<_>>());
+        assert_eq!(vec![&2, &3], cache.value_order().collect::<Vec<_>>());
     }
 }
 


### PR DESCRIPTION
Allow `SizedCache` user to iterate over all values without touching `cache`.