### PR TITLE
feat(cache_get_mut): Allow mutable access to values in cache.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
 
 ## Removed
 
+## [0.12.0]
+## Added
+- Add `cache_get_mut` to `Cached` trait, to allow mutable access for values in the cache.
+
+## Changed
+
+## Removed
+
 ## [0.11.0]
 ## Added
 - Add `value_order` method to SizedCache, similar to `key_order`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cached"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["James Kominick <james@kominick.com>"]
 description = "Generic cache implementations and simplified function memoization"
 repository = "https://github.com/jaemk/cached"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use cached::SizedCache;
 
 cached! {
-    SLOW_FN: SizedCache<(u32), String> = SizedCache::with_size(50);
+    SLOW_FN: SizedCache<u32, String> = SizedCache::with_size(50);
     fn slow_fn(n: u32) -> String = {
         if n == 0 { return "done".to_string(); }
         sleep(Duration::new(1, 0));

--- a/examples/kitchen_sink.rs
+++ b/examples/kitchen_sink.rs
@@ -23,7 +23,7 @@ cached! {
 // Same as above, but preallocates some space.
 // Note that the cache key type is a tuple of function argument types.
 cached! {
-    FIB_SPECIFIC: UnboundCache<(u32), u32> = UnboundCache::with_capacity(50);
+    FIB_SPECIFIC: UnboundCache<u32, u32> = UnboundCache::with_capacity(50);
     fn fib_specific(n: u32) -> u32 = {
         if n == 0 || n == 1 { return n; }
         fib_specific(n-1) + fib_specific(n-2)
@@ -69,6 +69,9 @@ impl<K: Hash + Eq, V> Cached<K, V> for MyCache<K, V> {
     fn cache_get(&mut self, k: &K) -> Option<&V> {
         self.store.get(k)
     }
+    fn cache_get_mut(&mut self, k: &K) -> Option<&mut V> {
+        self.store.get_mut(k)
+    }
     fn cache_set(&mut self, k: K, v: V) {
         self.store.insert(k, v);
     }
@@ -88,7 +91,7 @@ impl<K: Hash + Eq, V> Cached<K, V> for MyCache<K, V> {
 
 // Specify our custom cache and supply an instance to use
 cached! {
-    CUSTOM: MyCache<(u32), ()> = MyCache::with_capacity(50);
+    CUSTOM: MyCache<u32, ()> = MyCache::with_capacity(50);
     fn custom(n: u32) -> () = {
         if n == 0 { return; }
         custom(n-1)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ Due to the requirements of storing arguments and return values in a global cache
 - Arguments and return values will be `cloned` in the process of insertion and retrieval.
 - `cached!` functions should not be used to produce side-effectual results!
 - `cached!` functions cannot live directly under `impl` blocks since `cached!` expands to a
-  `once_cell` initialization and a funtion definition.
+  `once_cell` initialization and a function definition.
 
 **NOTE**: Any custom cache that implements `cached::Cached` can be used with the `cached` macros in place of the built-ins.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,6 +243,9 @@ pub trait Cached<K, V> {
     /// Attempt to retrieve a cached value
     fn cache_get(&mut self, k: &K) -> Option<&V>;
 
+    /// Attempt to retrieve a cached value with mutable access
+    fn cache_get_mut(&mut self, k: &K) -> Option<&mut V>;
+
     /// Insert a key, value pair
     fn cache_set(&mut self, k: K, v: V);
 

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -26,7 +26,7 @@ fn test_unbound_cache() {
 }
 
 cached! {
-    SIZED_FIB: SizedCache<(u32), u32> = SizedCache::with_size(3);
+    SIZED_FIB: SizedCache<u32, u32> = SizedCache::with_size(3);
     fn fib1(n: u32) -> u32 = {
         if n == 0 || n == 1 { return n }
         fib1(n-1) + fib1(n-2)
@@ -43,7 +43,7 @@ fn test_sized_cache() {
 }
 
 cached! {
-    TIMED: TimedCache<(u32), u32> = TimedCache::with_lifespan_and_capacity(2, 5);
+    TIMED: TimedCache<u32, u32> = TimedCache::with_lifespan_and_capacity(2, 5);
     fn timed(n: u32) -> u32 = {
         sleep(Duration::new(3, 0));
         n
@@ -85,7 +85,7 @@ fn test_string_cache() {
 }
 
 cached_key! {
-    TIMED_CACHE: TimedCache<(u32), u32> = TimedCache::with_lifespan_and_capacity(2, 5);
+    TIMED_CACHE: TimedCache<u32, u32> = TimedCache::with_lifespan_and_capacity(2, 5);
     Key = { n };
     fn timed_2(n: u32) -> u32 = {
         sleep(Duration::new(3, 0));
@@ -172,7 +172,7 @@ fn test_sized_cache_key() {
 }
 
 cached_key_result! {
-    RESULT_CACHE_KEY: UnboundCache<(u32), u32> = UnboundCache::new();
+    RESULT_CACHE_KEY: UnboundCache<u32, u32> = UnboundCache::new();
     Key = { n };
     fn test_result_key(n: u32) -> Result<u32, ()> = {
         if n < 5 { Ok(n) } else { Err(()) }
@@ -196,7 +196,7 @@ fn cache_result_key() {
 }
 
 cached_result! {
-    RESULT_CACHE: UnboundCache<(u32), u32> = UnboundCache::new();
+    RESULT_CACHE: UnboundCache<u32, u32> = UnboundCache::new();
     fn test_result_no_default(n: u32) -> Result<u32, ()> = {
         if n < 5 { Ok(n) } else { Err(()) }
     }


### PR DESCRIPTION
Add `cache_get_mut` to the `Cached` trait. It works similar to `cache_get` but provides mutable access to the retrieved value instead.