### PR TITLE
Change the type of hits and misses to be u64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 ## Added
 
 ## Changed
-
+- Change the type of `hits` and `misses` to be `u64`.
+ 
 ## Removed
 
 ## [0.11.0]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,12 +259,12 @@ pub trait Cached<K, V> {
     fn cache_size(&self) -> usize;
 
     /// Return the number of times a cached value was successfully retrieved
-    fn cache_hits(&self) -> Option<u32> {
+    fn cache_hits(&self) -> Option<u64> {
         None
     }
 
     /// Return the number of times a cached value was unable to be retrieved
-    fn cache_misses(&self) -> Option<u32> {
+    fn cache_misses(&self) -> Option<u64> {
         None
     }
 

--- a/src/stores.rs
+++ b/src/stores.rs
@@ -17,8 +17,8 @@ use super::Cached;
 /// Note: This cache is in-memory only
 pub struct UnboundCache<K, V> {
     store: HashMap<K, V>,
-    hits: u32,
-    misses: u32,
+    hits: u64,
+    misses: u64,
     initial_capacity: Option<usize>,
 }
 
@@ -79,10 +79,10 @@ impl<K: Hash + Eq, V> Cached<K, V> for UnboundCache<K, V> {
     fn cache_size(&self) -> usize {
         self.store.len()
     }
-    fn cache_hits(&self) -> Option<u32> {
+    fn cache_hits(&self) -> Option<u64> {
         Some(self.hits)
     }
-    fn cache_misses(&self) -> Option<u32> {
+    fn cache_misses(&self) -> Option<u64> {
         Some(self.misses)
     }
 }
@@ -231,8 +231,8 @@ pub struct SizedCache<K, V> {
     store: HashMap<K, usize>,
     order: LRUList<(K, V)>,
     capacity: usize,
-    hits: u32,
-    misses: u32,
+    hits: u64,
+    misses: u64,
 }
 
 impl<K: Hash + Eq, V> SizedCache<K, V> {
@@ -321,10 +321,10 @@ impl<K: Hash + Eq + Clone, V> Cached<K, V> for SizedCache<K, V> {
     fn cache_size(&self) -> usize {
         self.store.len()
     }
-    fn cache_hits(&self) -> Option<u32> {
+    fn cache_hits(&self) -> Option<u64> {
         Some(self.hits)
     }
-    fn cache_misses(&self) -> Option<u32> {
+    fn cache_misses(&self) -> Option<u64> {
         Some(self.misses)
     }
     fn cache_capacity(&self) -> Option<usize> {
@@ -348,8 +348,8 @@ enum Status {
 pub struct TimedCache<K, V> {
     store: HashMap<K, (Instant, V)>,
     seconds: u64,
-    hits: u32,
-    misses: u32,
+    hits: u64,
+    misses: u64,
     initial_capacity: Option<usize>,
 }
 
@@ -431,10 +431,10 @@ impl<K: Hash + Eq, V> Cached<K, V> for TimedCache<K, V> {
     fn cache_size(&self) -> usize {
         self.store.len()
     }
-    fn cache_hits(&self) -> Option<u32> {
+    fn cache_hits(&self) -> Option<u64> {
         Some(self.hits)
     }
-    fn cache_misses(&self) -> Option<u32> {
+    fn cache_misses(&self) -> Option<u64> {
         Some(self.misses)
     }
     fn cache_lifespan(&self) -> Option<u64> {


### PR DESCRIPTION
We have some heavy usage of caches and it overflowed the counter for cache hits in a matter of days. I think it is better if `hits` is of type `u64` rather than `u32`.