### PR TITLE
wasm-bindgen & stdweb feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,9 @@ travis-ci = { repository = "jaemk/cached", branch = "master" }
 
 [dependencies]
 once_cell = "1"
+instant-wasm-bindgen = { package = "instant", version = "0.1.3", optional = true, default-features = false, features = ["wasm-bindgen", "now"] }
+instant-stdweb = { package = "instant", version = "0.1.3", optional = true, default-features = false, features = ["stdweb", "now"] }
+
+[features]
+wasm-bindgen = ["instant-wasm-bindgen"]
+stdweb = ["instant-stdweb"]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -6,20 +6,24 @@ Macro for defining functions that wrap a static-ref cache object.
 macro_rules! cached {
     // Use default cached::Cache
     ($cachename:ident;
+     $($($meta:meta)+)*
      fn $name:ident ($($arg:ident : $argtype:ty),*) -> $ret:ty = $body:expr) => {
         cached!(
             $cachename : $crate::UnboundCache<($($argtype),*), $ret> = $crate::UnboundCache::new();
+            $($($meta)+)*
             fn $name($($arg : $argtype),*) -> $ret = $body
         );
     };
 
     // Use a specified cache-type and an explicitly created cache-instance
     ($cachename:ident : $cachetype:ty = $cacheinstance:expr ;
+     $($($meta:meta)+)*
      fn $name:ident ($($arg:ident : $argtype:ty),*) -> $ret:ty = $body:expr) => {
         static $cachename: $crate::once_cell::sync::Lazy<::std::sync::Mutex<$cachetype>>
             = $crate::once_cell::sync::Lazy::new(|| ::std::sync::Mutex::new($cacheinstance));
 
         #[allow(unused_parens)]
+        $($($meta)+)*
         pub fn $name($($arg: $argtype),*) -> $ret {
             let key = ($($arg.clone()),*);
             {
@@ -40,11 +44,13 @@ macro_rules! cached_key {
     // Use a specified cache-type and an explicitly created cache-instance
     ($cachename:ident : $cachetype:ty = $cacheinstance:expr ;
      Key = $key:expr;
+     $($($meta:meta)+)*
      fn $name:ident ($($arg:ident : $argtype:ty),*) -> $ret:ty = $body:expr) => {
         static $cachename: $crate::once_cell::sync::Lazy<::std::sync::Mutex<$cachetype>>
             = $crate::once_cell::sync::Lazy::new(|| ::std::sync::Mutex::new($cacheinstance));
 
         #[allow(unused_parens)]
+        $($($meta)+)*
         pub fn $name($($arg: $argtype),*) -> $ret {
             let key = $key;
             {
@@ -64,11 +70,13 @@ macro_rules! cached_key {
 macro_rules! cached_result {
     // Unfortunately it's impossible to infer the cache type because it's not the function return type
     ($cachename:ident : $cachetype:ty = $cacheinstance:expr ;
+     $($($meta:meta)+)*
      fn $name:ident ($($arg:ident : $argtype:ty),*) -> $ret:ty = $body:expr) => {
         static $cachename: $crate::once_cell::sync::Lazy<::std::sync::Mutex<$cachetype>>
             = $crate::once_cell::sync::Lazy::new(|| ::std::sync::Mutex::new($cacheinstance));
 
         #[allow(unused_parens)]
+        $($($meta)+)*
         pub fn $name($($arg: $argtype),*) -> $ret {
             let key = ($($arg.clone()),*);
             {
@@ -89,11 +97,13 @@ macro_rules! cached_key_result {
     // Use a specified cache-type and an explicitly created cache-instance
     ($cachename:ident : $cachetype:ty = $cacheinstance:expr ;
      Key = $key:expr;
+     $($($meta:meta)+)*
      fn $name:ident ($($arg:ident : $argtype:ty),*) -> $ret:ty = $body:expr) => {
         static $cachename: $crate::once_cell::sync::Lazy<::std::sync::Mutex<$cachetype>>
             = $crate::once_cell::sync::Lazy::new(|| ::std::sync::Mutex::new($cacheinstance));
 
         #[allow(unused_parens)]
+        $($($meta)+)*
         pub fn $name($($arg: $argtype),*) -> $ret {
             let key = $key;
             {
@@ -118,11 +128,13 @@ macro_rules! cached_control {
      PostExec($body_value:ident) = $post_exec:expr;
      Set($set_value:ident) = $pre_set:expr;
      Return($ret_value:ident) = $return:expr;
+     $($($meta:meta)+)*
      fn $name:ident ($($arg:ident : $argtype:ty),*) -> $ret:ty = $body:expr) => {
         static $cachename: $crate::once_cell::sync::Lazy<::std::sync::Mutex<$cachetype>>
             = $crate::once_cell::sync::Lazy::new(|| ::std::sync::Mutex::new($cacheinstance));
 
         #[allow(unused_parens)]
+        $($($meta)+)*
         pub fn $name($($arg: $argtype),*) -> $ret {
             let key = $key;
             {

--- a/src/stores.rs
+++ b/src/stores.rs
@@ -6,6 +6,12 @@ Implementation of various caches
 use std::cmp::Eq;
 use std::collections::HashMap;
 use std::hash::Hash;
+
+#[cfg(feature = "wasm-bindgen")]
+use instant_wasm_bindgen::Instant;
+#[cfg(feature = "stdweb")]
+use instant_stdweb::Instant;
+#[cfg(all(not(feature = "stdweb"), not(feature = "wasm-bindgen")))]
 use std::time::Instant;
 
 use super::Cached;


### PR DESCRIPTION
The `TimedCache` doesn't work in wasm builds due `std::time::Instant` not being supported

The `instant` crate adds support for both `stdweb` and `wasm-bindgen` (I've only tried with the later).

In non-wasm builds the crate is a pass-through to `std::time`