### PR TITLE
proc_macro: fix regression from api change

### DIFF
--- a/cached_proc_macro/src/lib.rs
+++ b/cached_proc_macro/src/lib.rs
@@ -167,13 +167,13 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
         (false, false) => quote! { cache.cache_set(key, result.clone()); },
         (true, false) => quote! {
             match result.clone() {
-                Ok(result) => cache.cache_set(key, Ok(result)),
+                Ok(result) => { cache.cache_set(key, Ok(result)); },
                 _ => {},
             }
         },
         (false, true) => quote! {
             match result.clone() {
-                Some(result) => cache.cache_set(key, Some(result)),
+                Some(result) => { cache.cache_set(key, Some(result)); },
                 _ => {},
             }
         },

--- a/examples/kitchen_sink_proc_macro.rs
+++ b/examples/kitchen_sink_proc_macro.rs
@@ -112,6 +112,13 @@ fn custom(n: u32) -> () {
     custom(n - 1)
 }
 
+
+#[cached(result = true)]
+fn slow_result(a: u32, b: u32) -> Result<u32, ()> {
+    sleep(Duration::new(2, 0));
+    return Ok(a * b);
+}
+
 pub fn main() {
     println!("\n ** default cache with default name **");
     fib(3);
@@ -163,6 +170,18 @@ pub fn main() {
     slow(10, 10);
     {
         let cache = SLOW.lock().unwrap();
+        println!("hits: {:?}", cache.cache_hits());
+        println!("misses: {:?}", cache.cache_misses());
+        // make sure the cache-lock is dropped
+    }
+
+    println!("\n ** slow result func **");
+    println!(" - first run `slow_result(10)`");
+    let _ = slow_result(10, 10);
+    println!(" - second run `slow_result(10)`");
+    let _ = slow_result(10, 10);
+    {
+        let cache = SLOW_RESULT.lock().unwrap();
         println!("hits: {:?}", cache.cache_hits());
         println!("misses: {:?}", cache.cache_misses());
         // make sure the cache-lock is dropped


### PR DESCRIPTION
In PR #42 `cache_set` was changed to return the previous value. This
broke the proc macro when using `result = true`. Wrap all `match` blocks
such that the return is always ignored.

Tests and examples updated to catch this in the future.