### PR TITLE
stores: add `cache_set_lifetime`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ## Added
+- add `cache_set_lifespan` to change the cache lifespace, old value returned.
 ## Changed
 ## Removed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,4 +356,9 @@ pub trait Cached<K, V> {
     fn cache_lifespan(&self) -> Option<u64> {
         None
     }
+
+    /// Set the lifespan of cached values, returns the old value
+    fn cache_set_lifespan(&mut self, _seconds: u64) -> Option<u64> {
+        None
+    }
 }

--- a/src/stores.rs
+++ b/src/stores.rs
@@ -599,6 +599,12 @@ impl<K: Hash + Eq, V> Cached<K, V> for TimedCache<K, V> {
     fn cache_lifespan(&self) -> Option<u64> {
         Some(self.seconds)
     }
+
+    fn cache_set_lifespan(&mut self, seconds: u64) -> Option<u64> {
+        let old = self.seconds;
+        self.seconds = seconds;
+        Some(old)
+    }
 }
 
 impl<K: Hash + Eq, V> Cached<K, V> for HashMap<K, V> {
@@ -723,6 +729,20 @@ mod tests {
         assert!(c.cache_get(&1).is_none());
         let misses = c.cache_misses().unwrap();
         assert_eq!(2, misses);
+
+        let old = c.cache_set_lifespan(1).unwrap();
+        assert_eq!(2, old);
+        assert_eq!(c.cache_set(1, 100), None);
+        assert!(c.cache_get(&1).is_some());
+        let hits = c.cache_hits().unwrap();
+        let misses = c.cache_misses().unwrap();
+        assert_eq!(2, hits);
+        assert_eq!(2, misses);
+
+        sleep(Duration::new(1, 0));
+        assert!(c.cache_get(&1).is_none());
+        let misses = c.cache_misses().unwrap();
+        assert_eq!(3, misses);
     }
 
     #[test]

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -66,6 +66,18 @@ fn test_timed_cache() {
         assert_eq!(2, cache.cache_misses().unwrap());
         assert_eq!(1, cache.cache_hits().unwrap());
     }
+    {
+        let mut cache = TIMED.lock().unwrap();
+        assert_eq!(2, cache.cache_set_lifespan(1).unwrap());
+    }
+    timed(1);
+    sleep(Duration::new(1, 0));
+    timed(1);
+    {
+        let cache = TIMED.lock().unwrap();
+        assert_eq!(3, cache.cache_misses().unwrap());
+        assert_eq!(2, cache.cache_hits().unwrap());
+    }
 }
 
 cached! {


### PR DESCRIPTION
Allows changing the cache's lifetime at runtime. Useful for setting the lifetime to `0` at compile time and then changing to value passed in by user at runtime.