### PR TITLE
Cloneless Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 ## Added
+## Changed
+- Store inner values when `result=true` or `option=true`. The `Error` type in the
+`Result` now no longer needs to implement `Clone`.
+## Removed
+
+## [Unreleased]
+## Added
 - add `cache_set_lifespan` to change the cache lifespace, old value returned.
 ## Changed
 ## Removed

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -294,16 +294,18 @@ fn test_racing_duplicate_keys_do_not_duplicate_sized_cache_ordering() {
     slow_small_cache("g", "h");
 }
 
-// String is not cloneable. So this also tests that the Result type
+// NoClone is not cloneable. So this also tests that the Result type
 // itself does not have to be cloneable, just the type for the Ok
 // value.
 // Vec has Clone, but not Copy, to make sure Copy isn't required.
+struct NoClone {}
+
 #[cached(result = true)]
-fn proc_cached_result(n: u32) -> Result<Vec<u32>, String> {
+fn proc_cached_result(n: u32) -> Result<Vec<u32>, NoClone> {
     if n < 5 {
         Ok(vec![n])
     } else {
-        Err("5 or higher".to_string())
+        Err(NoClone {})
     }
 }
 


### PR DESCRIPTION
This started because I was using a Result type that did not implement Clone (`anyhow::Result`, not super uncommon, I gather :) ). The first commit makes using a Result like that possible. 

Then I figured why even store the Result/Option, if we can just store the value and re-wrap before returning. That is the second commit.

Added a test for Option, and made both Option and Result tests a little more challenging.