### PR TITLE
First try of serde implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,11 @@ version = "0.3.0"
 path = "cached_proc_macro"
 optional = true
 
+[dependencies.serde]
+version = "1"
+optional = true
+features = ["derive"]
+
 [dev-dependencies.tokio]
 version = "0.2.21"
 features = ["macros", "time"]
@@ -37,6 +42,9 @@ features = ["macros", "time"]
 [dev-dependencies.async-std]
 version = "1.6.2"
 features = ["attributes"]
+
+[dev-dependencies.serde_json]
+version = "1"
 
 [workspace]
 members = ["cached_proc_macro"]


### PR DESCRIPTION
About  https://github.com/jaemk/cached/issues/49

This is a draft of a serde feature

1. This is a strait forward implementation
2. We could maybe do custom serialize and deserialize implementation to optimize the serialization and deserialization, for example `store` is not strictly needed, order could be serialize without next and prev, just a ordered vector.
3. This trust the input, this crate doesn't use unsafe so it's "ok" but that another reason to do a manual implementation.