### PR TITLE
Timed LRU cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ## Added
+- Add a TimedSizedCache combining and LRU and a timed/ttl cache
 ## Changed
 ## Removed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,10 +19,10 @@ Thanks for contributing!
   Changes should be made to the crate documentation in `src/lib.rs` and the `readme.sh` script run.
 
 
-## Running Tests
+## Running Lints/Formatting/Tests
 
 ```bash
-cargo test
+./lint-test.sh
 ```
 
 

--- a/cached_proc_macro/src/lib.rs
+++ b/cached_proc_macro/src/lib.rs
@@ -195,7 +195,9 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
         }
         (false, None, None, Some(_), None) => panic!("type requires create to also be set"),
         (false, None, None, None, Some(_)) => panic!("create requires type to also be set"),
-        _ => panic!("cache types (unbound, size and/or time, or type and create) are mutually exclusive"),
+        _ => panic!(
+            "cache types (unbound, size and/or time, or type and create) are mutually exclusive"
+        ),
     };
 
     // make the set cache and return cache blocks

--- a/cached_proc_macro/src/lib.rs
+++ b/cached_proc_macro/src/lib.rs
@@ -33,7 +33,7 @@ struct MacroArgs {
 /// # Attributes
 /// - **Cache Name:** Use `name = "CACHE_NAME"` to specify the name for the generated cache.
 /// - **Cache Type:** The default cache type is `UnboundCache`.
-/// You specify which of the built-in cache types to use with `unbound`, `size = cache_size`, or `time = lifetime_in_seconds`
+/// You specify which of the built-in cache types to use with `unbound`, `size = cache_size`, and `time = lifetime_in_seconds`
 /// - **Cache Create:** You can specify the cache creation with `create = "{ CacheType::new() }"`.
 /// - **Custom Cache Type:** You can use `type = "CacheType"` to specify the type of cache to use.
 /// This requires create to also be set.
@@ -174,6 +174,12 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
             let cache_create = quote! {cached::TimedCache::with_lifespan(#time)};
             (cache_ty, cache_create)
         }
+        (false, Some(size), Some(time), None, None) => {
+            let cache_ty = quote! {cached::TimedSizedCache<#cache_key_ty, #cache_value_ty>};
+            let cache_create =
+                quote! {cached::TimedSizedCache::with_size_and_lifespan(#size, #time)};
+            (cache_ty, cache_create)
+        }
         (false, None, None, None, None) => {
             let cache_ty = quote! {cached::UnboundCache<#cache_key_ty, #cache_value_ty>};
             let cache_create = quote! {cached::UnboundCache::new()};
@@ -189,7 +195,7 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
         }
         (false, None, None, Some(_), None) => panic!("type requires create to also be set"),
         (false, None, None, None, Some(_)) => panic!("create requires type to also be set"),
-        _ => panic!("cache types (unbound, size, time, or type and create) are mutually exclusive"),
+        _ => panic!("cache types (unbound, size and/or time, or type and create) are mutually exclusive"),
     };
 
     // make the set cache and return cache blocks

--- a/examples/kitchen_sink.rs
+++ b/examples/kitchen_sink.rs
@@ -36,7 +36,7 @@ cached! {
     SLOW: SizedCache<(u32, u32), u32> = SizedCache::with_size(100);
     fn slow(a: u32, b: u32) -> u32 = {
         sleep(Duration::new(2, 0));
-        return a * b;
+        a * b
     }
 }
 

--- a/examples/kitchen_sink_proc_macro.rs
+++ b/examples/kitchen_sink_proc_macro.rs
@@ -46,7 +46,7 @@ fn fib_specific(n: u32) -> u32 {
 )]
 fn slow(a: u32, b: u32) -> u32 {
     sleep(Duration::new(2, 0));
-    return a * b;
+    a * b
 }
 
 // Specify a specific cache type and an explicit key expression
@@ -115,7 +115,7 @@ fn custom(n: u32) -> () {
 #[cached(result = true)]
 fn slow_result(a: u32, b: u32) -> Result<u32, ()> {
     sleep(Duration::new(2, 0));
-    return Ok(a * b);
+    Ok(a * b)
 }
 
 pub fn main() {

--- a/lint-test.sh
+++ b/lint-test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -ex
+
+export RUST_BACKTRACE=1
+
+cargo fmt -- --check
+./readme.sh check
+
+cargo clippy --all-features --all-targets --examples --tests
+cargo test --all-features
+

--- a/readme.sh
+++ b/readme.sh
@@ -1,1 +1,17 @@
-cargo readme --no-indent-headings > README.md
+set -e
+
+if [ "$1" = "check" ]; then
+    echo "Checking if README.md is up to date with src/lib.rs"
+    lib_hash=$(cargo readme --no-indent-headings | sha256sum)
+    readme_hash=$(cat README.md | sha256sum)
+    if [ "$lib_hash" = "$readme_hash" ]; then
+        echo "README.md is up to date"
+    else
+        echo "README.md is out of date."
+        echo "Please run $0 script."
+        exit 1
+    fi
+else
+    echo "Generating README.md"
+    cargo readme --no-indent-headings > README.md
+fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,7 +307,7 @@ pub extern crate once_cell;
 pub mod macros;
 pub mod stores;
 
-pub use stores::{SizedCache, TimedCache, UnboundCache};
+pub use stores::{SizedCache, TimedCache, TimedSizedCache, UnboundCache};
 
 #[cfg(feature = "proc_macro")]
 pub mod proc_macro {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,54 @@ fn keyed(a: String, b: String) -> usize {
 use std::thread::sleep;
 use std::time::Duration;
 use cached::proc_macro::cached;
+
+/// Use a timed-lru cache with size 1, a TTL of 60s,
+/// and a `(usize, usize)` cache key
+#[cached(size=1, time=60)]
+fn keyed(a: usize, b: usize) -> usize {
+    let total = a + b;
+    sleep(Duration::new(total as u64, 0));
+    total
+}
+pub fn main() {
+    let val = keyed(1, 2);  // Not cached, will sleep (1+2)s
+
+    let val = keyed(1, 2);  // Cached, no sleep
+
+    sleep(Duration::new(60, 0));  // Sleep for the TTL
+
+    let val = keyed(1, 2);  // 60s TTL has passed so the cached
+                            // value has expired, will sleep (1+2)s
+
+    let val = keyed(1, 2);  // Cached, no sleep
+
+    let val = keyed(2, 1);  // New args, not cached, will sleep (2+1)s
+
+    let val = keyed(1, 2);  // Was evicted because of lru size of 1,
+                            // will sleep (1+2)s
+}
+```
+
+```rust,no_run
+use std::thread::sleep;
+use std::time::Duration;
+use cached::proc_macro::cached;
+
+/// Use a timed cache with a TTL of 60s
+/// and a `(String, String)` cache key
+#[cached(time=60)]
+fn keyed(a: String, b: String) -> usize {
+    let size = a.len() + b.len();
+    sleep(Duration::new(size as u64, 0));
+    size
+}
+# pub fn main() { }
+```
+
+```rust,no_run
+use std::thread::sleep;
+use std::time::Duration;
+use cached::proc_macro::cached;
 use cached::SizedCache;
 
 /// Use an explicit cache-type with a custom creation block and custom cache-key generating block

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -4,7 +4,7 @@ Full tests of macro-defined functions
 #[macro_use]
 extern crate cached;
 
-use cached::{proc_macro::cached, Cached, SizedCache, TimedCache, UnboundCache};
+use cached::{proc_macro::cached, Cached, SizedCache, TimedCache, TimedSizedCache, UnboundCache};
 use std::thread::{self, sleep};
 use std::time::Duration;
 
@@ -77,6 +77,91 @@ fn test_timed_cache() {
         let cache = TIMED.lock().unwrap();
         assert_eq!(3, cache.cache_misses().unwrap());
         assert_eq!(2, cache.cache_hits().unwrap());
+    }
+}
+
+cached! {
+    TIMED_SIZED: TimedSizedCache<u32, u32> = TimedSizedCache::with_size_and_lifespan(3, 2);
+    fn timefac(n: u32) -> u32 = {
+        sleep(Duration::new(1, 0));
+        if n > 1 {
+            n * timefac(n - 1)
+        } else {
+            n
+        }
+    }
+}
+
+#[test]
+fn test_timed_sized_cache() {
+    timefac(1);
+    timefac(1);
+    {
+        let cache = TIMED_SIZED.lock().unwrap();
+        assert_eq!(1, cache.cache_misses().unwrap());
+        assert_eq!(1, cache.cache_hits().unwrap());
+    }
+    sleep(Duration::new(3, 0));
+    timefac(1);
+    {
+        let cache = TIMED_SIZED.lock().unwrap();
+        assert_eq!(2, cache.cache_misses().unwrap());
+        assert_eq!(1, cache.cache_hits().unwrap());
+    }
+    {
+        let mut cache = TIMED_SIZED.lock().unwrap();
+        assert_eq!(2, cache.cache_set_lifespan(1).unwrap());
+    }
+    timefac(1);
+    sleep(Duration::new(1, 0));
+    timefac(1);
+    {
+        let cache = TIMED_SIZED.lock().unwrap();
+        assert_eq!(3, cache.cache_misses().unwrap());
+        assert_eq!(2, cache.cache_hits().unwrap());
+    }
+    {
+        let mut cache = TIMED_SIZED.lock().unwrap();
+        assert_eq!(1, cache.cache_set_lifespan(6).unwrap());
+    }
+    timefac(2);
+    {
+        let cache = TIMED_SIZED.lock().unwrap();
+        assert_eq!(4, cache.cache_misses().unwrap());
+        assert_eq!(3, cache.cache_hits().unwrap());
+    }
+    timefac(3);
+    {
+        let cache = TIMED_SIZED.lock().unwrap();
+        assert_eq!(5, cache.cache_misses().unwrap());
+        assert_eq!(4, cache.cache_hits().unwrap());
+    }
+    timefac(3);
+    timefac(2);
+    timefac(1);
+    {
+        let cache = TIMED_SIZED.lock().unwrap();
+        assert_eq!(5, cache.cache_misses().unwrap());
+        assert_eq!(7, cache.cache_hits().unwrap());
+    }
+    timefac(4);
+    {
+        let cache = TIMED_SIZED.lock().unwrap();
+        assert_eq!(6, cache.cache_misses().unwrap());
+        assert_eq!(8, cache.cache_hits().unwrap());
+    }
+    timefac(6);
+    {
+        let cache = TIMED_SIZED.lock().unwrap();
+        assert_eq!(8, cache.cache_misses().unwrap());
+        assert_eq!(9, cache.cache_hits().unwrap());
+    }
+    timefac(1);
+    {
+        let cache = TIMED_SIZED.lock().unwrap();
+        assert_eq!(9, cache.cache_misses().unwrap());
+        assert_eq!(9, cache.cache_hits().unwrap());
+        assert_eq!(3, cache.cache_size());
     }
 }
 


### PR DESCRIPTION
As mentioned in issue #1 

Adds a new cache struct which is essentially a SizedCache that timestamps each entry in the store. Expired items are evicted as well as the least-used items, and common functions from the other types are all implemented. I've copied generic tests over and added some unique testing for the type, but it could always use more.

Some questions which remain are whether the order functions (key_order, value_order) should include expired values in the list or remain naive, as well as whether any new type-specific functions should be included.

I haven't done any performance testing so this might not be the fastest solution, but the issue has been there since 2017 so I figured I might as well submit something. This currently only adds the struct, I haven't looked into how it integrates with the rest of the crate.