### PR TITLE
Fix 'cannot infer type' error when missing result arm

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -76,7 +76,11 @@ macro_rules! cached_result {
                 let res = $crate::Cached::cache_get(&mut *cache, &key);
                 if let Some(res) = res { return Ok(res.clone()); }
             }
-            let val = (||$body)()?;
+
+            // Store return in temporary typed variable in case type cannot be inferred
+            let ret : $ret = (||$body)();
+            let val = ret?;
+
             let mut cache = $cachename.lock().unwrap();
             $crate::Cached::cache_set(&mut *cache, key, val.clone());
             Ok(val)
@@ -101,7 +105,11 @@ macro_rules! cached_key_result {
                 let res = $crate::Cached::cache_get(&mut *cache, &key);
                 if let Some(res) = res { return Ok(res.clone()); }
             }
-            let val = (||$body)()?;
+
+            // Store return in temporary typed variable in case type cannot be inferred
+            let ret : $ret = (||$body)();
+            let val = ret?;
+
             let mut cache = $cachename.lock().unwrap();
             $crate::Cached::cache_set(&mut *cache, key, val.clone());
             Ok(val)

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -351,3 +351,18 @@ fn test_proc_cached_option() {
         assert_eq!(5, cache.cache_misses().unwrap());
     }
 }
+
+cached_result! {
+    RESULT_CACHE_RETARM: UnboundCache<u32, u32> = UnboundCache::new();
+    fn test_result_missing_result_arm(n: u32) -> Result<u32, ()> = {
+        Ok(n)
+    }
+}
+
+cached_key_result! {
+    RESULT_CACHE_KEY_RETARM: UnboundCache<u32, u32> = UnboundCache::new();
+    Key = { n };
+    fn test_result_key_missing_result_arm(n: u32) -> Result<u32, ()> = {
+        Ok(n)
+    }
+}


### PR DESCRIPTION
Added a temporary typed variable in case the return type cannot be inferred.

There are two tests failing, but they fail on master as well.