### PR TITLE
Switch to futures_lite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,11 @@ travis-ci = { repository = "jaemk/cached", branch = "master" }
 [features]
 default = ["proc_macro", "async"]
 proc_macro = ["async-mutex", "cached_proc_macro", "cached_proc_macro_types"]
-async = ["futures", "async-trait"]
+async = ["futures-lite", "async-trait"]
+
+[dependencies.futures-lite]
+version = "1.11.3"
+optional = true
 
 [dependencies.hashbrown]
 version = "0.9.1"
@@ -39,10 +43,6 @@ optional = true
 [dependencies.cached_proc_macro_types]
 version = "0.1.0"
 path = "cached_proc_macro_types"
-optional = true
-
-[dependencies.futures]
-version = "0.3"
 optional = true
 
 [dependencies.async-trait]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -468,7 +468,7 @@ pub use async_mutex;
 pub use proc_macro::Return;
 
 #[cfg(feature = "async")]
-use {async_trait::async_trait, futures::Future};
+use {async_trait::async_trait, futures_lite::Future};
 
 /// Cache operations
 pub trait Cached<K, V> {

--- a/src/stores/mod.rs
+++ b/src/stores/mod.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 
 #[cfg(feature = "async")]
-use {super::CachedAsync, async_trait::async_trait, futures::Future};
+use {super::CachedAsync, async_trait::async_trait, futures_lite::Future};
 
 mod sized;
 mod timed;

--- a/src/stores/sized.rs
+++ b/src/stores/sized.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use std::hash::{BuildHasher, Hash, Hasher};
 
 #[cfg(feature = "async")]
-use {super::CachedAsync, async_trait::async_trait, futures::Future};
+use {super::CachedAsync, async_trait::async_trait, futures_lite::Future};
 
 /// Least Recently Used / `Sized` Cache
 ///

--- a/src/stores/timed.rs
+++ b/src/stores/timed.rs
@@ -6,7 +6,7 @@ use std::hash::Hash;
 use std::time::Instant;
 
 #[cfg(feature = "async")]
-use {super::CachedAsync, async_trait::async_trait, futures::Future};
+use {super::CachedAsync, async_trait::async_trait, futures_lite::Future};
 
 /// Enum used for defining the status of time-cached values
 #[derive(Debug)]

--- a/src/stores/timed_sized.rs
+++ b/src/stores/timed_sized.rs
@@ -4,7 +4,7 @@ use std::hash::Hash;
 use std::time::Instant;
 
 #[cfg(feature = "async")]
-use {super::CachedAsync, async_trait::async_trait, futures::Future};
+use {super::CachedAsync, async_trait::async_trait, futures_lite::Future};
 
 /// Timed LRU Cache
 ///

--- a/src/stores/unbound.rs
+++ b/src/stores/unbound.rs
@@ -6,7 +6,7 @@ use std::hash::Hash;
 use std::collections::hash_map::Entry;
 
 #[cfg(feature = "async")]
-use {super::CachedAsync, async_trait::async_trait, futures::Future};
+use {super::CachedAsync, async_trait::async_trait, futures_lite::Future};
 
 /// Default unbounded cache
 ///


### PR DESCRIPTION
Fantastic project!

This small PR makes `cached` use [`futures_lite`](https://github.com/smol-rs/futures-lite), a fully compatible alternative to [`futures`](https://github.com/rust-lang/futures-rs) that is safer, faster and smaller.

On my system, this change made `cached` compile 9% faster and saved 8 crates.