### PR TITLE
add reset method for hits/misses

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -493,6 +493,9 @@ pub trait Cached<K, V> {
     /// Remove all cached values. Free memory and return to initial state
     fn cache_reset(&mut self);
 
+    /// Reset misses/hits counters
+    fn cache_reset_metrics(&mut self) {}
+
     /// Return the current cache size (number of elements)
     fn cache_size(&self) -> usize;
 

--- a/src/stores/sized.rs
+++ b/src/stores/sized.rs
@@ -373,6 +373,10 @@ impl<K: Hash + Eq + Clone, V> Cached<K, V> for SizedCache<K, V> {
         // SizedCache uses cache_clear because capacity is fixed.
         self.cache_clear();
     }
+    fn cache_reset_metrics(&mut self) {
+        self.misses = 0;
+        self.hits = 0;
+    }
     fn cache_size(&self) -> usize {
         self.store.len()
     }

--- a/src/stores/sized.rs
+++ b/src/stores/sized.rs
@@ -458,6 +458,14 @@ mod tests {
         let size = c.cache_size();
         assert_eq!(5, size);
 
+        c.cache_reset_metrics();
+        let hits = c.cache_hits().unwrap();
+        let misses = c.cache_misses().unwrap();
+        let size = c.cache_size();
+        assert_eq!(0, hits);
+        assert_eq!(0, misses);
+        assert_eq!(5, size);
+
         assert_eq!(c.cache_set(7, 200), Some(100));
 
         #[derive(Hash, Clone, Eq, PartialEq)]

--- a/src/stores/timed.rs
+++ b/src/stores/timed.rs
@@ -151,6 +151,10 @@ impl<K: Hash + Eq, V> Cached<K, V> for TimedCache<K, V> {
     fn cache_clear(&mut self) {
         self.store.clear();
     }
+    fn cache_reset_metrics(&mut self) {
+        self.misses = 0;
+        self.hits = 0;
+    }
     fn cache_reset(&mut self) {
         self.store = Self::new_store(self.initial_capacity);
     }

--- a/src/stores/timed_sized.rs
+++ b/src/stores/timed_sized.rs
@@ -125,6 +125,10 @@ impl<K: Hash + Eq + Clone, V> Cached<K, V> for TimedSizedCache<K, V> {
     fn cache_reset(&mut self) {
         self.cache_clear();
     }
+    fn cache_reset_metrics(&mut self) {
+        self.misses = 0;
+        self.hits = 0;
+    }
     fn cache_size(&self) -> usize {
         self.store.cache_size()
     }

--- a/src/stores/unbound.rs
+++ b/src/stores/unbound.rs
@@ -115,6 +115,10 @@ impl<K: Hash + Eq, V> Cached<K, V> for UnboundCache<K, V> {
     fn cache_reset(&mut self) {
         self.store = Self::new_store(self.initial_capacity);
     }
+    fn cache_reset_metrics(&mut self) {
+        self.misses = 0;
+        self.hits = 0;
+    }
     fn cache_size(&self) -> usize {
         self.store.len()
     }


### PR DESCRIPTION
Add a method to reset the hits and misses counters.  This helps avoid overflows in long running caches - instead, it's possible to periodically check the stats and then reset them