### PR TITLE
chore: bump hashbrown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ proc_macro = ["async-mutex", "cached_proc_macro", "cached_proc_macro_types"]
 async = ["futures", "async-trait"]
 
 [dependencies.hashbrown]
-version = "0.9.1"
+version = "0.11.2"
 default-features = false
 features = ["raw"]
 


### PR DESCRIPTION
Bump hashbrown to reduce the number of duplicate dependencies with just different versions.