### PR TITLE
Update and remove deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ version = "0.1"
 optional = true
 
 [dev-dependencies.tokio]
-version = "0.3"
+version = "1.12"
 features = ["macros", "time", "rt-multi-thread"]
 
 [dev-dependencies.async-std]

--- a/cached_proc_macro/Cargo.toml
+++ b/cached_proc_macro/Cargo.toml
@@ -18,8 +18,7 @@ proc-macro = true
 
 [dependencies]
 quote = "1.0.6"
-darling = "0.10.2"
-async-mutex = "1.1.5"
+darling = "0.13.0"
 
 [dependencies.syn]
 version = "1.0.27"


### PR DESCRIPTION
I updated everything that was out of date on https://deps.rs/repo/github/jaemk/cached

Notes:
  * Removed async-mutex as it is not used. `quotes!` are only expanded in the crate that uses the macro, so the async-mutex dependency is not needed in cached_proc_macro
* I left hashbrown version update for https://github.com/jaemk/cached/pull/90
* The user should not observe any changes so I did not touch the changelog