### PR TITLE
Make all caches' `store` public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 ## Added
+- For all caches, add a function to get an immutable reference to their
+  contents. This makes it possible to manually dump a cache, so its contents
+  can be saved and restored later.
 ## Changed
 ## Removed
 

--- a/src/lru_list.rs
+++ b/src/lru_list.rs
@@ -1,6 +1,6 @@
 /// Limited functionality doubly linked list using Vec as storage.
 #[derive(Clone, Debug)]
-pub(crate) struct LRUList<T> {
+pub struct LRUList<T> {
     values: Vec<ListEntry<T>>,
 }
 

--- a/src/stores/sized.rs
+++ b/src/stores/sized.rs
@@ -245,6 +245,11 @@ impl<K: Hash + Eq + Clone, V> SizedCache<K, V> {
             Ok((false, false, &mut self.order.get_mut(index).1))
         }
     }
+
+    /// Returns a reference to the cache's `order`
+    pub fn get_order(&self) -> &LRUList<(K, V)> {
+        &self.order
+    }
 }
 
 #[cfg(feature = "async")]

--- a/src/stores/timed.rs
+++ b/src/stores/timed.rs
@@ -77,6 +77,11 @@ impl<K: Hash + Eq, V> TimedCache<K, V> {
     fn new_store(capacity: Option<usize>) -> HashMap<K, (Instant, V)> {
         capacity.map_or_else(HashMap::new, HashMap::with_capacity)
     }
+
+    /// Returns a reference to the cache's `store`
+    pub fn get_store(&self) -> &HashMap<K, (Instant, V)> {
+        &self.store
+    }
 }
 
 impl<K: Hash + Eq, V> Cached<K, V> for TimedCache<K, V> {

--- a/src/stores/timed_sized.rs
+++ b/src/stores/timed_sized.rs
@@ -80,6 +80,11 @@ impl<K: Hash + Eq + Clone, V> TimedSizedCache<K, V> {
     pub fn set_refresh(&mut self, refresh: bool) {
         self.refresh = refresh
     }
+
+    /// Returns a reference to the cache's `store`
+    pub fn get_store(&self) -> &SizedCache<K, (Instant, V)> {
+        &self.store
+    }
 }
 
 impl<K: Hash + Eq + Clone, V> Cached<K, V> for TimedSizedCache<K, V> {

--- a/src/stores/unbound.rs
+++ b/src/stores/unbound.rs
@@ -63,6 +63,11 @@ impl<K: Hash + Eq, V> UnboundCache<K, V> {
     fn new_store(capacity: Option<usize>) -> HashMap<K, V> {
         capacity.map_or_else(HashMap::new, HashMap::with_capacity)
     }
+
+    /// Returns a reference to the cache's `store`
+    pub fn get_store(&self) -> &HashMap<K, V> {
+        &self.store
+    }
 }
 
 impl<K: Hash + Eq, V> Cached<K, V> for UnboundCache<K, V> {


### PR DESCRIPTION
(was `pub(super)`). This makes it possible to manually dump a cache, so
its contents can be saved and restored later.

Related to (but does not directly fix) #20.