### PR TITLE
Improve documentation generation

### DIFF
--- a/cached_proc_macro/src/lib.rs
+++ b/cached_proc_macro/src/lib.rs
@@ -438,12 +438,15 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
         }
     };
 
+    // make prime cached function doc comment
+    let prime_fn_indent_doc = format!("Primes the cached function [`{}`].", fn_ident);
+
     // put it all together
     let expanded = if asyncness.is_some() {
         quote! {
-            /// Cached static
+            // Cached static
             #visibility static #cache_ident: ::cached::once_cell::sync::Lazy<::cached::async_mutex::Mutex<#cache_ty>> = ::cached::once_cell::sync::Lazy::new(|| ::cached::async_mutex::Mutex::new(#cache_create));
-            /// Cached function
+            // Cached function
             #visibility #signature_no_muts {
                 use cached::Cached;
                 let key = #key_convert_block;
@@ -456,7 +459,8 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
                 }
                 #do_set_return_block
             }
-            /// Prime cached function
+            // Prime cached function
+            #[doc = #prime_fn_indent_doc]
             #visibility #prime_sig {
                 use cached::Cached;
                 let key = #key_convert_block;
@@ -465,9 +469,9 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
         }
     } else {
         quote! {
-            /// Cached static
+            // Cached static
             #visibility static #cache_ident: ::cached::once_cell::sync::Lazy<std::sync::Mutex<#cache_ty>> = ::cached::once_cell::sync::Lazy::new(|| std::sync::Mutex::new(#cache_create));
-            /// Cached function
+            // Cached function
             #visibility #signature_no_muts {
                 use cached::Cached;
                 let key = #key_convert_block;
@@ -480,7 +484,8 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
                 }
                 #do_set_return_block
             }
-            /// Prime cached function
+            // Prime cached function
+            #[doc = #prime_fn_indent_doc]
             #visibility #prime_sig {
                 use cached::Cached;
                 let key = #key_convert_block;
@@ -868,12 +873,15 @@ pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
         }
     };
 
+    // make prime cached function doc comment
+    let prime_fn_indent_doc = format!("Primes the cached function [`{}`].", fn_ident);
+
     // put it all together
     let expanded = if asyncness.is_some() {
         quote! {
-            /// Cached static
+            // Cached static
             #visibility static #cache_ident: ::cached::once_cell::sync::Lazy<::cached::async_rwlock::RwLock<#cache_ty>> = ::cached::once_cell::sync::Lazy::new(|| ::cached::async_rwlock::RwLock::new(#cache_create));
-            /// Cached function
+            // Cached function
             #visibility #signature_no_muts {
                 let now = std::time::Instant::now();
                 {
@@ -885,7 +893,8 @@ pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
                 }
                 #do_set_return_block
             }
-            /// Prime cached function
+            // Prime cached function
+            #[doc = #prime_fn_indent_doc]
             #visibility #prime_sig {
                 let now = std::time::Instant::now();
                 #prime_do_set_return_block
@@ -893,9 +902,9 @@ pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
         }
     } else {
         quote! {
-            /// Cached static
+            // Cached static
             #visibility static #cache_ident: ::cached::once_cell::sync::Lazy<std::sync::RwLock<#cache_ty>> = ::cached::once_cell::sync::Lazy::new(|| std::sync::RwLock::new(#cache_create));
-            /// Cached function
+            // Cached function
             #visibility #signature_no_muts {
                 let now = std::time::Instant::now();
                 {
@@ -907,7 +916,8 @@ pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
                 }
                 #do_set_return_block
             }
-            /// Prime cached function
+            // Prime cached function
+            #[doc = #prime_fn_indent_doc]
             #visibility #prime_sig {
                 let now = std::time::Instant::now();
                 #prime_do_set_return_block
@@ -1386,16 +1396,19 @@ pub fn io_cached(args: TokenStream, input: TokenStream) -> TokenStream {
         }
     };
 
+    // make prime cached function doc comment
+    let prime_fn_indent_doc = format!("Primes the cached function [`{}`].", fn_ident);
+
     // put it all together
     let expanded = if asyncness.is_some() {
         quote! {
-            /// Cached static
+            // Cached static
             ::cached::lazy_static::lazy_static! {
                 #visibility static ref #cache_ident: ::cached::async_once::AsyncOnce<#cache_ty> = ::cached::async_once::AsyncOnce::new(async move { #cache_create });
             }
             // #visibility static #cache_ident: ::cached::once_cell::sync::Lazy<::cached::async_once::AsyncOnce<#cache_ty>> = ::cached::once_cell::sync::Lazy::new(move || ::cached::async_once::AsyncOnce::new(async move { #cache_create }));
             // #visibility static #cache_ident: ::cached::async_once_cell::Lazy<#cache_ty> = ::cached::async_once_cell::Lazy::new(async move { #cache_create });
-            /// Cached function
+            // Cached function
             #visibility #signature_no_muts {
                 use cached::IOCachedAsync;
                 let key = #key_convert_block;
@@ -1408,7 +1421,8 @@ pub fn io_cached(args: TokenStream, input: TokenStream) -> TokenStream {
                 }
                 #do_set_return_block
             }
-            /// Prime cached function
+            // Prime cached function
+            #[doc = #prime_fn_indent_doc]
             #visibility #prime_sig {
                 use cached::IOCachedAsync;
                 let key = #key_convert_block;
@@ -1417,9 +1431,9 @@ pub fn io_cached(args: TokenStream, input: TokenStream) -> TokenStream {
         }
     } else {
         quote! {
-            /// Cached static
+            // Cached static
             #visibility static #cache_ident: ::cached::once_cell::sync::Lazy<#cache_ty> = ::cached::once_cell::sync::Lazy::new(|| #cache_create);
-            /// Cached function
+            // Cached function
             #visibility #signature_no_muts {
                 use cached::IOCached;
                 let key = #key_convert_block;
@@ -1432,7 +1446,8 @@ pub fn io_cached(args: TokenStream, input: TokenStream) -> TokenStream {
                 }
                 #do_set_return_block
             }
-            /// Prime cached function
+            // Prime cached function
+            #[doc = #prime_fn_indent_doc]
             #visibility #prime_sig {
                 use cached::IOCached;
                 let key = #key_convert_block;

--- a/cached_proc_macro/src/lib.rs
+++ b/cached_proc_macro/src/lib.rs
@@ -438,13 +438,15 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
         }
     };
 
-    // make prime cached function doc comment
+    // make cached static and prime cached function doc comments
+    let cache_ident_doc = format!("Cached static for the [`{}`] function.", fn_ident);
     let prime_fn_indent_doc = format!("Primes the cached function [`{}`].", fn_ident);
 
     // put it all together
     let expanded = if asyncness.is_some() {
         quote! {
             // Cached static
+            #[doc = #cache_ident_doc]
             #visibility static #cache_ident: ::cached::once_cell::sync::Lazy<::cached::async_mutex::Mutex<#cache_ty>> = ::cached::once_cell::sync::Lazy::new(|| ::cached::async_mutex::Mutex::new(#cache_create));
             // Cached function
             #visibility #signature_no_muts {
@@ -470,6 +472,7 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
     } else {
         quote! {
             // Cached static
+            #[doc = #cache_ident_doc]
             #visibility static #cache_ident: ::cached::once_cell::sync::Lazy<std::sync::Mutex<#cache_ty>> = ::cached::once_cell::sync::Lazy::new(|| std::sync::Mutex::new(#cache_create));
             // Cached function
             #visibility #signature_no_muts {
@@ -873,13 +876,15 @@ pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
         }
     };
 
-    // make prime cached function doc comment
+    // make cached static and prime cached function doc comments
+    let cache_ident_doc = format!("Cached static for the [`{}`] function.", fn_ident);
     let prime_fn_indent_doc = format!("Primes the cached function [`{}`].", fn_ident);
 
     // put it all together
     let expanded = if asyncness.is_some() {
         quote! {
             // Cached static
+            #[doc = #cache_ident_doc]
             #visibility static #cache_ident: ::cached::once_cell::sync::Lazy<::cached::async_rwlock::RwLock<#cache_ty>> = ::cached::once_cell::sync::Lazy::new(|| ::cached::async_rwlock::RwLock::new(#cache_create));
             // Cached function
             #visibility #signature_no_muts {
@@ -903,6 +908,7 @@ pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
     } else {
         quote! {
             // Cached static
+            #[doc = #cache_ident_doc]
             #visibility static #cache_ident: ::cached::once_cell::sync::Lazy<std::sync::RwLock<#cache_ty>> = ::cached::once_cell::sync::Lazy::new(|| std::sync::RwLock::new(#cache_create));
             // Cached function
             #visibility #signature_no_muts {
@@ -1396,13 +1402,15 @@ pub fn io_cached(args: TokenStream, input: TokenStream) -> TokenStream {
         }
     };
 
-    // make prime cached function doc comment
+    // make cached static and prime cached function doc comments
+    let cache_ident_doc = format!("Cached static for the [`{}`] function.", fn_ident);
     let prime_fn_indent_doc = format!("Primes the cached function [`{}`].", fn_ident);
 
     // put it all together
     let expanded = if asyncness.is_some() {
         quote! {
             // Cached static
+            #[doc = #cache_ident_doc]
             ::cached::lazy_static::lazy_static! {
                 #visibility static ref #cache_ident: ::cached::async_once::AsyncOnce<#cache_ty> = ::cached::async_once::AsyncOnce::new(async move { #cache_create });
             }
@@ -1432,6 +1440,7 @@ pub fn io_cached(args: TokenStream, input: TokenStream) -> TokenStream {
     } else {
         quote! {
             // Cached static
+            #[doc = #cache_ident_doc]
             #visibility static #cache_ident: ::cached::once_cell::sync::Lazy<#cache_ty> = ::cached::once_cell::sync::Lazy::new(|| #cache_create);
             // Cached function
             #visibility #signature_no_muts {


### PR DESCRIPTION
Currently, if the function on which the `#[once]` or `#[cached]` attribute is placed has any documentation, it gets completely wiped. This PR attempts to fix that and adds some minor extra things:

* It passes on any existing documentation for the function that is now a cached function
* It sets or appends to the documentation for the cached function, linking to the cached static that is used.
* It injects a "Caching" section in the documentation of the cached function if there already was some documentation
* It improves the doc comment of the cached static to link to the function that uses it
* It improves the doc comment of the cache priming function to link to the function that gets primed