### PR TITLE
remove unused features of `futures`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ version = "1"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
 optional = true
 
 [dependencies.async-trait]


### PR DESCRIPTION
Removed `futures-executor` and `futures-macro` by default. Just a small change.

[CI passed](https://github.com/kkocdko/cached/actions). Seems more acceptable than [pull/75](https://github.com/jaemk/cached/pull/75) because many `futures-*` crates like `futures-utils` were widely used in async ecosystem, keep these deps will not increase size a lot.