### PR TITLE
bump redis from 0.22 to 0.23; serial_test from 0.10 to 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ version = "0.1"
 optional = true
 
 [dependencies.redis]
-version = "0.22"
+version = "0.23"
 features = ["r2d2"]
 optional = true
 
@@ -100,7 +100,7 @@ version = "1"
 version = "1"
 
 [dev-dependencies.serial_test]
-version = "0.10"
+version = "2"
 
 [workspace]
 members = ["cached_proc_macro","examples/wasm"]


### PR DESCRIPTION
Hi @jaemk , just bump Redis and serial_test to their latest releases.