### PR TITLE
Relax ownership requirements on Cached<K,V>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 ## Added
 ## Changed
+- Relax `Cached` trait's `cache_get`, `cache_get_mut` and `cache_remove` key parameter. Allow `K: Borrow<Q>`
+  like `std::collections::HashMap` and friends. Avoids copies particularly on `Cached<String, _>` where now
+  you can do `cache.cache_get("key")` and before you had to `cache.cache_get("key".to_string())`.
 ## Removed
 
 ## [0.43.0]

--- a/examples/kitchen_sink.rs
+++ b/examples/kitchen_sink.rs
@@ -66,10 +66,18 @@ impl<K: Hash + Eq, V> MyCache<K, V> {
     }
 }
 impl<K: Hash + Eq, V> Cached<K, V> for MyCache<K, V> {
-    fn cache_get(&mut self, k: &K) -> Option<&V> {
+    fn cache_get<Q>(&mut self, k: &Q) -> Option<&V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         self.store.get(k)
     }
-    fn cache_get_mut(&mut self, k: &K) -> Option<&mut V> {
+    fn cache_get_mut<Q>(&mut self, k: &Q) -> Option<&mut V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         self.store.get_mut(k)
     }
     fn cache_get_or_set_with<F: FnOnce() -> V>(&mut self, k: K, f: F) -> &mut V {
@@ -78,7 +86,11 @@ impl<K: Hash + Eq, V> Cached<K, V> for MyCache<K, V> {
     fn cache_set(&mut self, k: K, v: V) -> Option<V> {
         self.store.insert(k, v)
     }
-    fn cache_remove(&mut self, k: &K) -> Option<V> {
+    fn cache_remove<Q>(&mut self, k: &Q) -> Option<V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         self.store.remove(k)
     }
     fn cache_clear(&mut self) {

--- a/examples/kitchen_sink_proc_macro.rs
+++ b/examples/kitchen_sink_proc_macro.rs
@@ -83,10 +83,18 @@ impl<K: Hash + Eq, V> MyCache<K, V> {
     }
 }
 impl<K: Hash + Eq, V> Cached<K, V> for MyCache<K, V> {
-    fn cache_get(&mut self, k: &K) -> Option<&V> {
+    fn cache_get<Q>(&mut self, k: &Q) -> Option<&V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         self.store.get(k)
     }
-    fn cache_get_mut(&mut self, k: &K) -> Option<&mut V> {
+    fn cache_get_mut<Q>(&mut self, k: &Q) -> Option<&mut V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         self.store.get_mut(k)
     }
     fn cache_get_or_set_with<F: FnOnce() -> V>(&mut self, k: K, f: F) -> &mut V {
@@ -95,7 +103,11 @@ impl<K: Hash + Eq, V> Cached<K, V> for MyCache<K, V> {
     fn cache_set(&mut self, k: K, v: V) -> Option<V> {
         self.store.insert(k, v)
     }
-    fn cache_remove(&mut self, k: &K) -> Option<V> {
+    fn cache_remove<Q>(&mut self, k: &Q) -> Option<V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         self.store.remove(k)
     }
     fn cache_clear(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,12 +198,58 @@ pub mod async_sync {
 }
 
 /// Cache operations
+///
+/// ```rust
+/// use cached::{Cached, UnboundCache};
+///
+/// let mut cache: UnboundCache<String, String> = UnboundCache::new();
+///
+/// // When writing, keys and values are owned:
+/// cache.cache_set("key".to_string(), "owned value".to_string());
+///
+/// // When reading, keys are only borrowed for lookup:
+/// let borrowed_cache_value = cache.cache_get("key");
+///
+/// assert_eq!(borrowed_cache_value, Some(&"owned value".to_string()))
+/// ```
 pub trait Cached<K, V> {
     /// Attempt to retrieve a cached value
-    fn cache_get(&mut self, k: &K) -> Option<&V>;
+    ///
+    /// ```rust
+    /// # use cached::{Cached, UnboundCache};
+    /// # let mut cache: UnboundCache<String, String> = UnboundCache::new();
+    /// # cache.cache_set("key".to_string(), "owned value".to_string());
+    /// // You can use borrowed data, or the data's borrowed type:
+    /// let borrow_lookup_1 = cache.cache_get("key")
+    ///     .map(String::clone);
+    /// let borrow_lookup_2 = cache.cache_get(&"key".to_string())
+    ///     .map(String::clone); // copy the values for test asserts
+    ///
+    /// # assert_eq!(borrow_lookup_1, borrow_lookup_2);
+    /// ```
+    fn cache_get<Q>(&mut self, k: &Q) -> Option<&V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized;
 
     /// Attempt to retrieve a cached value with mutable access
-    fn cache_get_mut(&mut self, k: &K) -> Option<&mut V>;
+    ///
+    /// ```rust
+    /// # use cached::{Cached, UnboundCache};
+    /// # let mut cache: UnboundCache<String, String> = UnboundCache::new();
+    /// # cache.cache_set("key".to_string(), "owned value".to_string());
+    /// // You can use borrowed data, or the data's borrowed type:
+    /// let borrow_lookup_1 = cache.cache_get_mut("key")
+    ///     .map(|value| value.clone());
+    /// let borrow_lookup_2 = cache.cache_get_mut(&"key".to_string())
+    ///     .map(|value| value.clone()); // copy the values for test asserts
+    ///
+    /// # assert_eq!(borrow_lookup_1, borrow_lookup_2);
+    /// ```
+    fn cache_get_mut<Q>(&mut self, k: &Q) -> Option<&mut V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized;
 
     /// Insert a key, value pair and return the previous value
     fn cache_set(&mut self, k: K, v: V) -> Option<V>;
@@ -212,7 +258,23 @@ pub trait Cached<K, V> {
     fn cache_get_or_set_with<F: FnOnce() -> V>(&mut self, k: K, f: F) -> &mut V;
 
     /// Remove a cached value
-    fn cache_remove(&mut self, k: &K) -> Option<V>;
+    ///
+    /// ```rust
+    /// # use cached::{Cached, UnboundCache};
+    /// # let mut cache: UnboundCache<String, String> = UnboundCache::new();
+    /// # cache.cache_set("key1".to_string(), "owned value 1".to_string());
+    /// # cache.cache_set("key2".to_string(), "owned value 2".to_string());
+    /// // You can use borrowed data, or the data's borrowed type:
+    /// let remove_1 = cache.cache_remove("key1");
+    /// let remove_2 = cache.cache_remove(&"key2".to_string());
+    ///
+    /// # assert_eq!(remove_1, Some("owned value 1".to_string()));
+    /// # assert_eq!(remove_2, Some("owned value 2".to_string()));
+    /// ```
+    fn cache_remove<Q>(&mut self, k: &Q) -> Option<V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized;
 
     /// Remove all cached values. Keeps the allocated memory for reuse.
     fn cache_clear(&mut self);

--- a/src/stores/expiring_value_cache.rs
+++ b/src/stores/expiring_value_cache.rs
@@ -35,7 +35,11 @@ impl<K: Clone + Hash + Eq, V: CanExpire> ExpiringValueCache<K, V> {
         }
     }
 
-    fn status(&mut self, k: &K) -> Status {
+    fn status<Q>(&mut self, k: &Q) -> Status
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         let v = self.store.cache_get(k);
         match v {
             Some(v) => {
@@ -57,7 +61,11 @@ impl<K: Clone + Hash + Eq, V: CanExpire> ExpiringValueCache<K, V> {
 
 // https://docs.rs/cached/latest/cached/trait.Cached.html
 impl<K: Hash + Eq + Clone, V: CanExpire> Cached<K, V> for ExpiringValueCache<K, V> {
-    fn cache_get(&mut self, k: &K) -> Option<&V> {
+    fn cache_get<Q>(&mut self, k: &Q) -> Option<&V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         match self.status(k) {
             Status::NotFound => {
                 self.misses += 1;
@@ -75,7 +83,11 @@ impl<K: Hash + Eq + Clone, V: CanExpire> Cached<K, V> for ExpiringValueCache<K, 
         }
     }
 
-    fn cache_get_mut(&mut self, k: &K) -> Option<&mut V> {
+    fn cache_get_mut<Q>(&mut self, k: &Q) -> Option<&mut V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         match self.status(k) {
             Status::NotFound => {
                 self.misses += 1;
@@ -107,7 +119,11 @@ impl<K: Hash + Eq + Clone, V: CanExpire> Cached<K, V> for ExpiringValueCache<K, 
     fn cache_set(&mut self, k: K, v: V) -> Option<V> {
         self.store.cache_set(k, v)
     }
-    fn cache_remove(&mut self, k: &K) -> Option<V> {
+    fn cache_remove<Q>(&mut self, k: &Q) -> Option<V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         self.store.cache_remove(k)
     }
     fn cache_clear(&mut self) {

--- a/src/stores/mod.rs
+++ b/src/stores/mod.rs
@@ -38,10 +38,18 @@ where
     K: Hash + Eq,
     S: std::hash::BuildHasher + Default,
 {
-    fn cache_get(&mut self, k: &K) -> Option<&V> {
+    fn cache_get<Q>(&mut self, k: &Q) -> Option<&V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         self.get(k)
     }
-    fn cache_get_mut(&mut self, k: &K) -> Option<&mut V> {
+    fn cache_get_mut<Q>(&mut self, k: &Q) -> Option<&mut V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         self.get_mut(k)
     }
     fn cache_set(&mut self, k: K, v: V) -> Option<V> {
@@ -50,7 +58,11 @@ where
     fn cache_get_or_set_with<F: FnOnce() -> V>(&mut self, key: K, f: F) -> &mut V {
         self.entry(key).or_insert_with(f)
     }
-    fn cache_remove(&mut self, k: &K) -> Option<V> {
+    fn cache_remove<Q>(&mut self, k: &Q) -> Option<V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         self.remove(k)
     }
     fn cache_clear(&mut self) {

--- a/src/stores/timed.rs
+++ b/src/stores/timed.rs
@@ -99,7 +99,11 @@ impl<K: Hash + Eq, V> TimedCache<K, V> {
 }
 
 impl<K: Hash + Eq, V> Cached<K, V> for TimedCache<K, V> {
-    fn cache_get(&mut self, key: &K) -> Option<&V> {
+    fn cache_get<Q>(&mut self, key: &Q) -> Option<&V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         let status = {
             let mut val = self.store.get_mut(key);
             if let Some(&mut (instant, _)) = val.as_mut() {
@@ -132,7 +136,11 @@ impl<K: Hash + Eq, V> Cached<K, V> for TimedCache<K, V> {
         }
     }
 
-    fn cache_get_mut(&mut self, key: &K) -> Option<&mut V> {
+    fn cache_get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         let status = {
             let mut val = self.store.get_mut(key);
             if let Some(&mut (instant, _)) = val.as_mut() {
@@ -198,7 +206,11 @@ impl<K: Hash + Eq, V> Cached<K, V> for TimedCache<K, V> {
             }
         })
     }
-    fn cache_remove(&mut self, k: &K) -> Option<V> {
+    fn cache_remove<Q>(&mut self, k: &Q) -> Option<V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         self.store.remove(k).and_then(|(instant, v)| {
             if instant.elapsed().as_secs() < self.seconds {
                 Some(v)

--- a/src/stores/timed_sized.rs
+++ b/src/stores/timed_sized.rs
@@ -130,7 +130,11 @@ impl<K: Hash + Eq + Clone, V> TimedSizedCache<K, V> {
 }
 
 impl<K: Hash + Eq + Clone, V> Cached<K, V> for TimedSizedCache<K, V> {
-    fn cache_get(&mut self, key: &K) -> Option<&V> {
+    fn cache_get<Q>(&mut self, key: &Q) -> Option<&V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         let status = {
             let mut val = self.store.get_mut_if(key, |_| true);
             if let Some(&mut (instant, _)) = val.as_mut() {
@@ -163,7 +167,11 @@ impl<K: Hash + Eq + Clone, V> Cached<K, V> for TimedSizedCache<K, V> {
         }
     }
 
-    fn cache_get_mut(&mut self, key: &K) -> std::option::Option<&mut V> {
+    fn cache_get_mut<Q>(&mut self, key: &Q) -> std::option::Option<&mut V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         let status = {
             let mut val = self.store.get_mut_if(key, |_| true);
             if let Some(&mut (instant, _)) = val.as_mut() {
@@ -225,7 +233,11 @@ impl<K: Hash + Eq + Clone, V> Cached<K, V> for TimedSizedCache<K, V> {
         })
     }
 
-    fn cache_remove(&mut self, k: &K) -> Option<V> {
+    fn cache_remove<Q>(&mut self, k: &Q) -> Option<V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         let stamped = self.store.cache_remove(k);
         stamped.and_then(|(instant, v)| {
             if instant.elapsed().as_secs() < self.seconds {

--- a/src/stores/unbound.rs
+++ b/src/stores/unbound.rs
@@ -74,7 +74,11 @@ impl<K: Hash + Eq, V> UnboundCache<K, V> {
 }
 
 impl<K: Hash + Eq, V> Cached<K, V> for UnboundCache<K, V> {
-    fn cache_get(&mut self, key: &K) -> Option<&V> {
+    fn cache_get<Q>(&mut self, key: &Q) -> Option<&V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         if let Some(v) = self.store.get(key) {
             self.hits += 1;
             Some(v)
@@ -83,7 +87,11 @@ impl<K: Hash + Eq, V> Cached<K, V> for UnboundCache<K, V> {
             None
         }
     }
-    fn cache_get_mut(&mut self, key: &K) -> std::option::Option<&mut V> {
+    fn cache_get_mut<Q>(&mut self, key: &Q) -> std::option::Option<&mut V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         if let Some(v) = self.store.get_mut(key) {
             self.hits += 1;
             Some(v)
@@ -108,7 +116,11 @@ impl<K: Hash + Eq, V> Cached<K, V> for UnboundCache<K, V> {
             }
         }
     }
-    fn cache_remove(&mut self, k: &K) -> Option<V> {
+    fn cache_remove<Q>(&mut self, k: &Q) -> Option<V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         self.store.remove(k)
     }
     fn cache_clear(&mut self) {


### PR DESCRIPTION
# About
I didn't see an open borrow issue, but I ran into an issue where my Cache lookups were taking up too much CPU time. Looking into it, I saw that formatting keys for lookups was a significant outlay of effort.

My cache is just `Cached<String, Arc<MyBusinessType>>`. I receive `&str` from parsing request headers. So this change is to allow me to pass `&str` to `cache_get()` when the key type is `String`.

My Criterion test with real data shows the difference here; the only change is from:
`auth_cache.cache_get(claims_key.to_string())`
to:
`auth_cache.cache_get(claims_key)`
(and of course setting a `path = "../cached"` in Cargo.toml to try this)

| Before | After |
| ----- | ----- |
|![image](https://user-images.githubusercontent.com/86278669/233238745-b8a1ff40-4caf-491f-8a47-952d6fb4e8be.png)|![image](https://user-images.githubusercontent.com/86278669/233238796-6b1bd474-8621-4f1c-b678-410bfb26c6a9.png)|

# Change notes
This change relaxes the requirement of &K on get-style functions
to accept a &Q that K can be borrowed as, and that meets the minimum
reasonable needs of the Cached trait.

It follows the model of the Rust standard HashMap. Each function is
generic over the key type.

This enables you to have caches with String keys, while querying
with only an &str. This reduces copies in user code, and helps real-
world use cases pay as little as possible for each cache hit.

In practice, this reduces the auth cache latency in my service's
frontend from 387ns to 338ns (for hits) by avoiding the string copy
for the authorization header. While the absolute amount per
invocation is not much, this reduces the memory pressure on every
api call we service.

Downstream implementations of Cached<K,V> will need to update their
bounds on cache_get, cache_get_mut and cache_remove. User code that
works with the current Cached trait should continue to work with
the new bounds, as it is a relaxing of the constraint. Only folks
who are directly integrated with the trait will need to update, and
it should just make their apps slightly quicker or at worst no slower.

I've taken the liberty of adding a couple simple doctests for the
Cached trait and the functions I've adjusted to demonstrate their
use and to ensure they keep working that way.

I've left the macros alone for now. I don't use them anymore, and
I'm not very familiar with them. It was not readily apparent to me
how to take advantage of borrowable trait copy-avoidance in them,
but I'm sure someone else will be able to add it!