### PR TITLE
"Refactor" documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 ## Added
 ## Changed
+- Show proc-macro documentation on docs.rs
+- Document needed feature flags
+- Hide implementation details in documentation
 ## Removed
 
 ## [0.43.0]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["proc_macro", "async"]

--- a/cached_proc_macro/src/cached.rs
+++ b/cached_proc_macro/src/cached.rs
@@ -35,32 +35,6 @@ struct MacroArgs {
     cache_create: Option<String>,
 }
 
-/// # Attributes
-/// - `name`: (optional, string) specify the name for the generated cache, defaults to the function name uppercase.
-/// - `size`: (optional, usize) specify an LRU max size, implies the cache type is a `SizedCache` or `TimedSizedCache`.
-/// - `time`: (optional, u64) specify a cache TTL in seconds, implies the cache type is a `TimedCache` or `TimedSizedCache`.
-/// - `time_refresh`: (optional, bool) specify whether to refresh the TTL on cache hits.
-/// - `sync_writes`: (optional, bool) specify whether to synchronize the execution of writing of uncached values.
-/// - `type`: (optional, string type) The cache store type to use. Defaults to `UnboundCache`. When `unbound` is
-///   specified, defaults to `UnboundCache`. When `size` is specified, defaults to `SizedCache`.
-///   When `time` is specified, defaults to `TimedCached`.
-///   When `size` and `time` are specified, defaults to `TimedSizedCache`. When `type` is
-///   specified, `create` must also be specified.
-/// - `create`: (optional, string expr) specify an expression used to create a new cache store, e.g. `create = r##"{ CacheType::new() }"##`.
-/// - `key`: (optional, string type) specify what type to use for the cache key, e.g. `key = "u32"`.
-///    When `key` is specified, `convert` must also be specified.
-/// - `convert`: (optional, string expr) specify an expression used to convert function arguments to a cache
-///   key, e.g. `convert = r##"{ format!("{}:{}", arg1, arg2) }"##`. When `convert` is specified,
-///   `key` or `type` must also be set.
-/// - `result`: (optional, bool) If your function returns a `Result`, only cache `Ok` values returned by the function.
-/// - `option`: (optional, bool) If your function returns an `Option`, only cache `Some` values returned by the function.
-/// - `with_cached_flag`: (optional, bool) If your function returns a `cached::Return` or `Result<cached::Return, E>`,
-///   the `cached::Return.was_cached` flag will be updated when a cached value is returned.
-///
-/// ## Note
-/// The `type`, `create`, `key`, and `convert` attributes must be in a `String`
-/// This is because darling, which is used for parsing the attributes, does not support directly parsing
-/// attributes into `Type`s or `Block`s.
 pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
     let attr_args = parse_macro_input!(args as AttributeArgs);
     let args = match MacroArgs::from_list(&attr_args) {

--- a/cached_proc_macro/src/io_cached.rs
+++ b/cached_proc_macro/src/io_cached.rs
@@ -33,32 +33,6 @@ struct IOMacroArgs {
     cache_create: Option<String>,
 }
 
-/// # Attributes
-/// - `map_error`: (string, expr closure) specify a closure used to map any IO-store errors into
-///   the error type returned by your function.
-/// - `name`: (optional, string) specify the name for the generated cache, defaults to the function name uppercase.
-/// - `redis`: (optional, bool) default to a `RedisCache` or `AsyncRedisCache`
-/// - `time`: (optional, u64) specify a cache TTL in seconds, implies the cache type is a `TimedCached` or `TimedSizedCache`.
-/// - `time_refresh`: (optional, bool) specify whether to refresh the TTL on cache hits.
-/// - `type`: (optional, string type) explicitly specify the cache store type to use.
-/// - `cache_prefix_block`: (optional, string expr) specify an expression used to create the string used as a
-///   prefix for all cache keys of this function, e.g. `cache_prefix_block = r##"{ "my_prefix" }"##`.
-///   When not specified, the cache prefix will be constructed from the name of the function. This
-///   could result in unexpected conflicts between io_cached-functions of the same name, so it's
-///   recommended that you specify a prefix you're sure will be unique.
-/// - `create`: (optional, string expr) specify an expression used to create a new cache store, e.g. `create = r##"{ CacheType::new() }"##`.
-/// - `key`: (optional, string type) specify what type to use for the cache key, e.g. `type = "TimedCached<u32, u32>"`.
-///    When `key` is specified, `convert` must also be specified.
-/// - `convert`: (optional, string expr) specify an expression used to convert function arguments to a cache
-///   key, e.g. `convert = r##"{ format!("{}:{}", arg1, arg2) }"##`. When `convert` is specified,
-///   `key` or `type` must also be set.
-/// - `with_cached_flag`: (optional, bool) If your function returns a `cached::Return` or `Result<cached::Return, E>`,
-///   the `cached::Return.was_cached` flag will be updated when a cached value is returned.
-///
-/// ## Note
-/// The `type`, `create`, `key`, and `convert` attributes must be in a `String`
-/// This is because darling, which is used for parsing the attributes, does not support directly parsing
-/// attributes into `Type`s or `Block`s.
 pub fn io_cached(args: TokenStream, input: TokenStream) -> TokenStream {
     let attr_args = parse_macro_input!(args as AttributeArgs);
     let args = match IOMacroArgs::from_list(&attr_args) {

--- a/cached_proc_macro/src/lib.rs
+++ b/cached_proc_macro/src/lib.rs
@@ -5,16 +5,86 @@ mod once;
 
 use proc_macro::TokenStream;
 
+/// Define a memoized function using a cache store that implements `cached::Cached` (and
+/// `cached::CachedAsync` for async functions)
+///
+/// # Attributes
+/// - `name`: (optional, string) specify the name for the generated cache, defaults to the function name uppercase.
+/// - `size`: (optional, usize) specify an LRU max size, implies the cache type is a `SizedCache` or `TimedSizedCache`.
+/// - `time`: (optional, u64) specify a cache TTL in seconds, implies the cache type is a `TimedCache` or `TimedSizedCache`.
+/// - `time_refresh`: (optional, bool) specify whether to refresh the TTL on cache hits.
+/// - `sync_writes`: (optional, bool) specify whether to synchronize the execution of writing of uncached values.
+/// - `type`: (optional, string type) The cache store type to use. Defaults to `UnboundCache`. When `unbound` is
+///   specified, defaults to `UnboundCache`. When `size` is specified, defaults to `SizedCache`.
+///   When `time` is specified, defaults to `TimedCached`.
+///   When `size` and `time` are specified, defaults to `TimedSizedCache`. When `type` is
+///   specified, `create` must also be specified.
+/// - `create`: (optional, string expr) specify an expression used to create a new cache store, e.g. `create = r##"{ CacheType::new() }"##`.
+/// - `key`: (optional, string type) specify what type to use for the cache key, e.g. `key = "u32"`.
+///    When `key` is specified, `convert` must also be specified.
+/// - `convert`: (optional, string expr) specify an expression used to convert function arguments to a cache
+///   key, e.g. `convert = r##"{ format!("{}:{}", arg1, arg2) }"##`. When `convert` is specified,
+///   `key` or `type` must also be set.
+/// - `result`: (optional, bool) If your function returns a `Result`, only cache `Ok` values returned by the function.
+/// - `option`: (optional, bool) If your function returns an `Option`, only cache `Some` values returned by the function.
+/// - `with_cached_flag`: (optional, bool) If your function returns a `cached::Return` or `Result<cached::Return, E>`,
+///   the `cached::Return.was_cached` flag will be updated when a cached value is returned.
+///
+/// ## Note
+/// The `type`, `create`, `key`, and `convert` attributes must be in a `String`
+/// This is because darling, which is used for parsing the attributes, does not support directly parsing
+/// attributes into `Type`s or `Block`s.
 #[proc_macro_attribute]
 pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
     cached::cached(args, input)
 }
 
+/// Define a memoized function using a cache store that implements `cached::Cached` (and
+/// `cached::CachedAsync` for async functions). Function arguments are not used to identify
+/// a cached value, only one value is cached unless a `time` expiry is specified.
+///
+/// # Attributes
+/// - `name`: (optional, string) specify the name for the generated cache, defaults to the function name uppercase.
+/// - `time`: (optional, u64) specify a cache TTL in seconds, implies the cache type is a `TimedCached` or `TimedSizedCache`.
+/// - `sync_writes`: (optional, bool) specify whether to synchronize the execution of writing of uncached values.
+/// - `result`: (optional, bool) If your function returns a `Result`, only cache `Ok` values returned by the function.
+/// - `option`: (optional, bool) If your function returns an `Option`, only cache `Some` values returned by the function.
+/// - `with_cached_flag`: (optional, bool) If your function returns a `cached::Return` or `Result<cached::Return, E>`,
+///   the `cached::Return.was_cached` flag will be updated when a cached value is returned.
 #[proc_macro_attribute]
 pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
     once::once(args, input)
 }
 
+/// Define a memoized function using a cache store that implements `cached::IOCached` (and
+/// `cached::IOCachedAsync` for async functions)
+///
+/// # Attributes
+/// - `map_error`: (string, expr closure) specify a closure used to map any IO-store errors into
+///   the error type returned by your function.
+/// - `name`: (optional, string) specify the name for the generated cache, defaults to the function name uppercase.
+/// - `redis`: (optional, bool) default to a `RedisCache` or `AsyncRedisCache`
+/// - `time`: (optional, u64) specify a cache TTL in seconds, implies the cache type is a `TimedCached` or `TimedSizedCache`.
+/// - `time_refresh`: (optional, bool) specify whether to refresh the TTL on cache hits.
+/// - `type`: (optional, string type) explicitly specify the cache store type to use.
+/// - `cache_prefix_block`: (optional, string expr) specify an expression used to create the string used as a
+///   prefix for all cache keys of this function, e.g. `cache_prefix_block = r##"{ "my_prefix" }"##`.
+///   When not specified, the cache prefix will be constructed from the name of the function. This
+///   could result in unexpected conflicts between io_cached-functions of the same name, so it's
+///   recommended that you specify a prefix you're sure will be unique.
+/// - `create`: (optional, string expr) specify an expression used to create a new cache store, e.g. `create = r##"{ CacheType::new() }"##`.
+/// - `key`: (optional, string type) specify what type to use for the cache key, e.g. `type = "TimedCached<u32, u32>"`.
+///    When `key` is specified, `convert` must also be specified.
+/// - `convert`: (optional, string expr) specify an expression used to convert function arguments to a cache
+///   key, e.g. `convert = r##"{ format!("{}:{}", arg1, arg2) }"##`. When `convert` is specified,
+///   `key` or `type` must also be set.
+/// - `with_cached_flag`: (optional, bool) If your function returns a `cached::Return` or `Result<cached::Return, E>`,
+///   the `cached::Return.was_cached` flag will be updated when a cached value is returned.
+///
+/// ## Note
+/// The `type`, `create`, `key`, and `convert` attributes must be in a `String`
+/// This is because darling, which is used for parsing the attributes, does not support directly parsing
+/// attributes into `Type`s or `Block`s.
 #[proc_macro_attribute]
 pub fn io_cached(args: TokenStream, input: TokenStream) -> TokenStream {
     io_cached::io_cached(args, input)

--- a/cached_proc_macro/src/once.rs
+++ b/cached_proc_macro/src/once.rs
@@ -21,14 +21,6 @@ struct OnceMacroArgs {
     with_cached_flag: bool,
 }
 
-/// # Attributes
-/// - `name`: (optional, string) specify the name for the generated cache, defaults to the function name uppercase.
-/// - `time`: (optional, u64) specify a cache TTL in seconds, implies the cache type is a `TimedCached` or `TimedSizedCache`.
-/// - `sync_writes`: (optional, bool) specify whether to synchronize the execution of writing of uncached values.
-/// - `result`: (optional, bool) If your function returns a `Result`, only cache `Ok` values returned by the function.
-/// - `option`: (optional, bool) If your function returns an `Option`, only cache `Some` values returned by the function.
-/// - `with_cached_flag`: (optional, bool) If your function returns a `cached::Return` or `Result<cached::Return, E>`,
-///   the `cached::Return.was_cached` flag will be updated when a cached value is returned.
 pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
     let attr_args = parse_macro_input!(args as AttributeArgs);
     let args = match OnceMacroArgs::from_list(&attr_args) {

--- a/cached_proc_macro_types/src/lib.rs
+++ b/cached_proc_macro_types/src/lib.rs
@@ -1,8 +1,10 @@
+/// Used to wrap a function result so callers can see whether the result was cached.
 #[derive(Clone)]
 pub struct Return<T> {
     pub was_cached: bool,
     pub value: T,
 }
+
 impl<T> Return<T> {
     pub fn new(value: T) -> Self {
         Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,9 +167,12 @@ Due to the requirements of storing arguments and return values in a global cache
 */
 
 #[cfg(feature = "async")]
+#[doc(hidden)]
 pub extern crate async_once;
 #[cfg(feature = "async")]
+#[doc(hidden)]
 pub extern crate lazy_static;
+#[doc(hidden)]
 pub extern crate once_cell;
 
 #[cfg(feature = "proc_macro")]
@@ -188,10 +191,13 @@ mod lru_list;
 pub mod macros;
 #[cfg(feature = "proc_macro")]
 pub mod proc_macro;
+#[doc(hidden)]
 pub mod stores;
+#[doc(hidden)]
 pub use instant;
 
 #[cfg(any(feature = "proc_macro", feature = "async"))]
+#[doc(hidden)]
 pub mod async_sync {
     pub use tokio::sync::Mutex;
     pub use tokio::sync::RwLock;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,8 @@ Due to the requirements of storing arguments and return values in a global cache
 
 */
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 #[cfg(feature = "async")]
 #[doc(hidden)]
 pub extern crate async_once;
@@ -176,15 +178,22 @@ pub extern crate lazy_static;
 pub extern crate once_cell;
 
 #[cfg(feature = "proc_macro")]
+#[cfg_attr(docsrs, doc(cfg(feature = "proc_macro")))]
 pub use proc_macro::Return;
 #[cfg(any(feature = "redis_async_std", feature = "redis_tokio"))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(feature = "redis_async_std", feature = "redis_tokio")))
+)]
 pub use stores::AsyncRedisCache;
 pub use stores::{
     CanExpire, ExpiringValueCache, SizedCache, TimedCache, TimedSizedCache, UnboundCache,
 };
 #[cfg(feature = "redis_store")]
+#[cfg_attr(docsrs, doc(cfg(feature = "redis_store")))]
 pub use stores::{RedisCache, RedisCacheError};
 #[cfg(feature = "async")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 use {async_trait::async_trait, futures::Future};
 
 mod lru_list;
@@ -259,6 +268,7 @@ pub trait Cached<K, V> {
 }
 
 #[cfg(feature = "async")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 #[async_trait]
 pub trait CachedAsync<K, V> {
     async fn get_or_set_with<F, Fut>(&mut self, k: K, f: F) -> &mut V
@@ -314,6 +324,7 @@ pub trait IOCached<K, V> {
 }
 
 #[cfg(feature = "async")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 #[async_trait]
 pub trait IOCachedAsync<K, V> {
     type Error;

--- a/src/proc_macro.rs
+++ b/src/proc_macro.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, doc(cfg(feature = "proc_macro")))]
+
 /*!
 Procedural macros for defining functions that wrap a static-ref cache object.
 

--- a/src/proc_macro.rs
+++ b/src/proc_macro.rs
@@ -322,18 +322,7 @@ pub fn main() {
 
 */
 
-/// Define a memoized function using a cache store that implements `cached::Cached` (and
-/// `cached::CachedAsync` for async functions)
-pub use cached_proc_macro::cached;
-
-/// Define a memoized function using a cache store that implements `cached::Cached` (and
-/// `cached::CachedAsync` for async functions). Function arguments are not used to identify
-/// a cached value, only one value is cached unless a `time` expiry is specified.
-pub use cached_proc_macro::once;
-
-/// Define a memoized function using a cache store that implements `cached::IOCached` (and
-/// `cached::IOCachedAsync` for async functions)
-pub use cached_proc_macro::io_cached;
-
-/// Used to wrap a function result so callers can see whether the result was cached.
+#[doc(inline)]
+pub use cached_proc_macro::{cached, io_cached, once};
+#[doc(inline)]
 pub use cached_proc_macro_types::Return;

--- a/src/stores/mod.rs
+++ b/src/stores/mod.rs
@@ -17,6 +17,7 @@ mod timed_sized;
 mod unbound;
 
 #[cfg(feature = "redis_store")]
+#[cfg_attr(docsrs, doc(cfg(feature = "redis_store")))]
 pub use crate::stores::redis::{
     RedisCache, RedisCacheBuildError, RedisCacheBuilder, RedisCacheError,
 };
@@ -31,6 +32,14 @@ pub use unbound::UnboundCache;
     feature = "redis_store",
     any(feature = "redis_async_std", feature = "redis_tokio")
 ))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(
+        feature = "async",
+        feature = "redis_store",
+        any(feature = "redis_async_std", feature = "redis_tokio")
+    )))
+)]
 pub use crate::stores::redis::{AsyncRedisCache, AsyncRedisCacheBuilder};
 
 impl<K, V, S> Cached<K, V> for HashMap<K, V, S>

--- a/src/stores/redis.rs
+++ b/src/stores/redis.rs
@@ -673,6 +673,13 @@ mod async_redis {
     feature = "async",
     any(feature = "redis_async_std", feature = "redis_tokio")
 ))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(
+        feature = "async",
+        any(feature = "redis_async_std", feature = "redis_tokio")
+    )))
+)]
 pub use async_redis::{AsyncRedisCache, AsyncRedisCacheBuilder};
 
 #[cfg(test)]


### PR DESCRIPTION
* Currently the bulk of the documentation was hidden in the source code, and it is not visible to rustdoc or rust-analyzer, i.e. when hovering over `#[cached(…)]` in e.g. vscode. This PR moves the documentation to the point of their definition, and makes the re-exports `#[doc(inline)]`.

* Hide implementation details used by `cached_proc_macro`

*  Document needed feature flags