### PR TITLE
Remove `#[doc(hidden)]` attribute from the `stores` module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,7 +196,6 @@ mod lru_list;
 pub mod macros;
 #[cfg(feature = "proc_macro")]
 pub mod proc_macro;
-#[doc(hidden)]
 pub mod stores;
 #[doc(hidden)]
 pub use instant;


### PR DESCRIPTION
I have checked that with this change `cargo doc` does create a page for `stores`, so it fixes #160

Thank you for maintaining this crate!