### PR TITLE
add fallback feature

### DIFF
--- a/cached_proc_macro/src/cached.rs
+++ b/cached_proc_macro/src/cached.rs
@@ -255,16 +255,16 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
             quote! {
                 let old_val = {
                     #lock
-                    let old_val = cache.get_store().get(&key).cloned();
-                    if let Some(result) = cache.cache_get(&key) {
+                    let (result, has_expired) = cache.cache_get_expired(&key);
+                    if let (Some(result), false) = (result, has_expired) {
                         #return_cache_block
                     }
-                    old_val
+                    result
                 };
                 #function_call
                 #lock
                 let result = match (result.is_err(), old_val) {
-                    (true, Some((_, result))) => {
+                    (true, Some(result)) => {
                         Ok(result)
                     }
                     _ => result
@@ -315,6 +315,7 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
         #(#attributes)*
         #visibility #signature_no_muts {
             use cached::Cached;
+            use cached::CloneCached;
             let key = #key_convert_block;
             #do_set_return_block
         }

--- a/cached_proc_macro/src/cached.rs
+++ b/cached_proc_macro/src/cached.rs
@@ -264,8 +264,8 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
                 #function_call
                 #lock
                 let result = match (result.is_err(), old_val) {
-                    (true, Some(result)) => {
-                        Ok(result)
+                    (true, Some(old_val)) => {
+                        Ok(old_val)
                     }
                     _ => result
                 };

--- a/cached_proc_macro/src/lib.rs
+++ b/cached_proc_macro/src/lib.rs
@@ -29,6 +29,9 @@ use proc_macro::TokenStream;
 /// - `option`: (optional, bool) If your function returns an `Option`, only cache `Some` values returned by the function.
 /// - `with_cached_flag`: (optional, bool) If your function returns a `cached::Return` or `Result<cached::Return, E>`,
 ///   the `cached::Return.was_cached` flag will be updated when a cached value is returned.
+/// - `result_fallback`: (optional, bool) If your function returns a `Result` and it fails, the cache will instead refresh the recently expired `Ok` value.
+///   In other words, refreshes are best-effort - returning `Ok` refreshes as usual but `Err` falls back to the last `Ok`.
+///   This is useful, for example, for keeping the last successful result of a network operation even during network disconnects.
 ///
 /// ## Note
 /// The `type`, `create`, `key`, and `convert` attributes must be in a `String`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,6 +326,15 @@ pub trait Cached<K, V> {
     }
 }
 
+/// Extra cache operations for types that implement `Clone`
+pub trait CloneCached<K, V> {
+    /// Attempt to retrieve a cached value and indicate whether that value was evicted.
+    fn cache_get_expired<Q>(&mut self, _key: &Q) -> (Option<V>, bool)
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized;
+}
+
 #[cfg(feature = "async")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 #[async_trait]

--- a/src/stores/timed.rs
+++ b/src/stores/timed.rs
@@ -151,22 +151,7 @@ impl<K: Hash + Eq, V> Cached<K, V> for TimedCache<K, V> {
         K: std::borrow::Borrow<Q>,
         Q: std::hash::Hash + Eq + ?Sized,
     {
-        let status = {
-            let mut val = self.store.get_mut(key);
-            if let Some(&mut (instant, _)) = val.as_mut() {
-                if instant.elapsed().as_secs() < self.seconds {
-                    if self.refresh {
-                        *instant = Instant::now();
-                    }
-                    Status::Found
-                } else {
-                    Status::Expired
-                }
-            } else {
-                Status::NotFound
-            }
-        };
-        match status {
+        match self.status(key) {
             Status::NotFound => {
                 self.misses += 1;
                 None

--- a/src/stores/timed.rs
+++ b/src/stores/timed.rs
@@ -11,6 +11,8 @@ use std::collections::{hash_map::Entry, HashMap};
 #[cfg(feature = "async")]
 use {super::CachedAsync, async_trait::async_trait, futures::Future};
 
+use crate::CloneCached;
+
 use super::Cached;
 
 /// Enum used for defining the status of time-cached values
@@ -99,6 +101,26 @@ impl<K: Hash + Eq, V> TimedCache<K, V> {
         self.store
             .retain(|_, (instant, _)| instant.elapsed().as_secs() < seconds);
     }
+
+    fn status<Q>(&mut self, key: &Q) -> Status
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
+        let mut val = self.store.get_mut(key);
+        if let Some(&mut (instant, _)) = val.as_mut() {
+            if instant.elapsed().as_secs() < self.seconds {
+                if self.refresh {
+                    *instant = Instant::now();
+                }
+                Status::Found
+            } else {
+                Status::Expired
+            }
+        } else {
+            Status::NotFound
+        }
+    }
 }
 
 impl<K: Hash + Eq, V> Cached<K, V> for TimedCache<K, V> {
@@ -107,22 +129,7 @@ impl<K: Hash + Eq, V> Cached<K, V> for TimedCache<K, V> {
         K: std::borrow::Borrow<Q>,
         Q: std::hash::Hash + Eq + ?Sized,
     {
-        let status = {
-            let mut val = self.store.get_mut(key);
-            if let Some(&mut (instant, _)) = val.as_mut() {
-                if instant.elapsed().as_secs() < self.seconds {
-                    if self.refresh {
-                        *instant = Instant::now();
-                    }
-                    Status::Found
-                } else {
-                    Status::Expired
-                }
-            } else {
-                Status::NotFound
-            }
-        };
-        match status {
+        match self.status(key) {
             Status::NotFound => {
                 self.misses += 1;
                 None
@@ -249,6 +256,29 @@ impl<K: Hash + Eq, V> Cached<K, V> for TimedCache<K, V> {
         let old = self.seconds;
         self.seconds = seconds;
         Some(old)
+    }
+}
+
+impl<K: Hash + Eq + Clone, V: Clone> CloneCached<K, V> for TimedCache<K, V> {
+    fn cache_get_expired<Q>(&mut self, k: &Q) -> (Option<V>, bool)
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
+        match self.status(k) {
+            Status::NotFound => {
+                self.misses += 1;
+                (None, false)
+            }
+            Status::Found => {
+                self.hits += 1;
+                (self.store.get(k).map(|stamped| &stamped.1).cloned(), false)
+            }
+            Status::Expired => {
+                self.misses += 1;
+                (self.store.remove(k).map(|stamped| stamped.1), true)
+            }
+        }
     }
 }
 

--- a/src/stores/timed_sized.rs
+++ b/src/stores/timed_sized.rs
@@ -6,7 +6,7 @@ use instant::Instant;
 #[cfg(feature = "async")]
 use {super::CachedAsync, async_trait::async_trait, futures::Future};
 
-use crate::stores::timed::Status;
+use crate::{stores::timed::Status, CloneCached};
 
 use super::{Cached, SizedCache};
 
@@ -127,6 +127,26 @@ impl<K: Hash + Eq + Clone, V> TimedSizedCache<K, V> {
         self.store
             .retain(|_, (instant, _)| instant.elapsed().as_secs() < seconds);
     }
+
+    fn status<Q>(&mut self, key: &Q) -> Status
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
+        let mut val = self.store.get_mut_if(key, |_| true);
+        if let Some(&mut (instant, _)) = val.as_mut() {
+            if instant.elapsed().as_secs() < self.seconds {
+                if self.refresh {
+                    *instant = Instant::now();
+                }
+                Status::Found
+            } else {
+                Status::Expired
+            }
+        } else {
+            Status::NotFound
+        }
+    }
 }
 
 impl<K: Hash + Eq + Clone, V> Cached<K, V> for TimedSizedCache<K, V> {
@@ -135,22 +155,7 @@ impl<K: Hash + Eq + Clone, V> Cached<K, V> for TimedSizedCache<K, V> {
         K: std::borrow::Borrow<Q>,
         Q: std::hash::Hash + Eq + ?Sized,
     {
-        let status = {
-            let mut val = self.store.get_mut_if(key, |_| true);
-            if let Some(&mut (instant, _)) = val.as_mut() {
-                if instant.elapsed().as_secs() < self.seconds {
-                    if self.refresh {
-                        *instant = Instant::now();
-                    }
-                    Status::Found
-                } else {
-                    Status::Expired
-                }
-            } else {
-                Status::NotFound
-            }
-        };
-        match status {
+        match self.status(key) {
             Status::NotFound => {
                 self.misses += 1;
                 None
@@ -276,6 +281,32 @@ impl<K: Hash + Eq + Clone, V> Cached<K, V> for TimedSizedCache<K, V> {
         let old = self.seconds;
         self.seconds = seconds;
         Some(old)
+    }
+}
+
+impl<K: Hash + Eq + Clone, V: Clone> CloneCached<K, V> for TimedSizedCache<K, V> {
+    fn cache_get_expired<Q>(&mut self, k: &Q) -> (Option<V>, bool)
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
+        match self.status(k) {
+            Status::NotFound => {
+                self.misses += 1;
+                (None, false)
+            }
+            Status::Found => {
+                self.hits += 1;
+                (
+                    self.store.cache_get(k).map(|stamped| stamped.1.clone()),
+                    false,
+                )
+            }
+            Status::Expired => {
+                self.misses += 1;
+                (self.store.cache_remove(k).map(|stamped| stamped.1), true)
+            }
+        }
     }
 }
 

--- a/src/stores/timed_sized.rs
+++ b/src/stores/timed_sized.rs
@@ -177,22 +177,7 @@ impl<K: Hash + Eq + Clone, V> Cached<K, V> for TimedSizedCache<K, V> {
         K: std::borrow::Borrow<Q>,
         Q: std::hash::Hash + Eq + ?Sized,
     {
-        let status = {
-            let mut val = self.store.get_mut_if(key, |_| true);
-            if let Some(&mut (instant, _)) = val.as_mut() {
-                if instant.elapsed().as_secs() < self.seconds {
-                    if self.refresh {
-                        *instant = Instant::now();
-                    }
-                    Status::Found
-                } else {
-                    Status::Expired
-                }
-            } else {
-                Status::NotFound
-            }
-        };
-        match status {
+        match self.status(key) {
             Status::NotFound => {
                 self.misses += 1;
                 None

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -1479,7 +1479,7 @@ fn test_result_fallback() {
         assert_eq!(cache.cache_hits(), Some(0));
         assert_eq!(cache.cache_misses(), Some(1));
     }
-    
+
     // Pretend it succeeded once
     ALWAYS_FAILING.lock().unwrap().cache_set((), 1);
     assert_eq!(always_failing(), Ok(1));

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -1480,7 +1480,7 @@ fn test_result_fallback() {
         assert_eq!(cache.cache_misses(), Some(1));
     }
     
-    // Pretend it succeeded once and will now never return an error again
+    // Pretend it succeeded once
     ALWAYS_FAILING.lock().unwrap().cache_set((), 1);
     assert_eq!(always_failing(), Ok(1));
     {
@@ -1491,6 +1491,7 @@ fn test_result_fallback() {
 
     std::thread::sleep(std::time::Duration::from_millis(2000));
 
+    // Even though the cache should've expired, the `result_fallback` flag means it refreshes the cache with the last valid result
     assert_eq!(always_failing(), Ok(1));
     {
         let cache = ALWAYS_FAILING.lock().unwrap();


### PR DESCRIPTION
Allows for returning the last valid cache value in the case of a fallible function. Useful for example in network disconnections, where you might want to stay operating until everything returns to normal.