### PR TITLE
Support clone types and sync writes result fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,22 @@ fn keyed(a: String) -> Option<usize> {
 
 ----
 
+```compile_fail
+use cached::proc_macro::cached;
+
+/// Cannot use sync_writes and result_fallback together
+#[cached(
+    result = true,
+    time = 1,
+    sync_writes = true,
+    result_fallback = true
+)]
+fn doesnt_compile() -> Result<String, ()> {
+    Ok("a".to_string())
+}
+```
+----
+
 ```rust,no_run,ignore
 use cached::proc_macro::io_cached;
 use cached::AsyncRedisCache;

--- a/cached_proc_macro/src/cached.rs
+++ b/cached_proc_macro/src/cached.rs
@@ -188,6 +188,10 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
         _ => panic!("the result and option attributes are mutually exclusive"),
     };
 
+    if args.result_fallback && args.sync_writes {
+        panic!("the result_fallback and sync_writes attributes are mutually exclusive");
+    }
+
     let set_cache_and_return = quote! {
         #set_cache_block
         result
@@ -255,7 +259,7 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
             let old_val = {
                 #lock
                 let (result, has_expired) = cache.cache_get_expired(&key);
-                if let (Some(result), false) = (result, has_expired) {
+                if let (Some(result), false) = (result.clone(), has_expired) {
                     #return_cache_block
                 }
                 result

--- a/cached_proc_macro/src/cached.rs
+++ b/cached_proc_macro/src/cached.rs
@@ -259,7 +259,7 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
             let old_val = {
                 #lock
                 let (result, has_expired) = cache.cache_get_expired(&key);
-                if let (Some(result), false) = (result.clone(), has_expired) {
+                if let (Some(result), false) = (&result, has_expired) {
                     #return_cache_block
                 }
                 result

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,22 @@ fn keyed(a: String) -> Option<usize> {
 
 ----
 
+```compile_fail
+use cached::proc_macro::cached;
+
+/// Cannot use sync_writes and result_fallback together
+#[cached(
+    result = true,
+    time = 1,
+    sync_writes = true,
+    result_fallback = true
+)]
+fn doesnt_compile() -> Result<String, ()> {
+    Ok("a".to_string())
+}
+```
+----
+
 ```rust,no_run,ignore
 use cached::proc_macro::io_cached;
 use cached::AsyncRedisCache;

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -1571,11 +1571,7 @@ fn test_expiring_value_unexpired_article_returned_with_hit() {
     }
 }
 
-#[cached::proc_macro::cached(
-    result = true,
-    time = 1,
-    result_fallback = true
-)]
+#[cached::proc_macro::cached(result = true, time = 1, result_fallback = true)]
 fn always_failing() -> Result<String, ()> {
     Err(())
 }
@@ -1590,7 +1586,10 @@ fn test_result_fallback() {
     }
 
     // Pretend it succeeded once
-    ALWAYS_FAILING.lock().unwrap().cache_set((), "abc".to_string());
+    ALWAYS_FAILING
+        .lock()
+        .unwrap()
+        .cache_set((), "abc".to_string());
     assert_eq!(always_failing(), Ok("abc".to_string()));
     {
         let cache = ALWAYS_FAILING.lock().unwrap();

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -1571,8 +1571,12 @@ fn test_expiring_value_unexpired_article_returned_with_hit() {
     }
 }
 
-#[cached::proc_macro::cached(result = true, time = 1, result_fallback = true)]
-fn always_failing() -> Result<i64, ()> {
+#[cached::proc_macro::cached(
+    result = true,
+    time = 1,
+    result_fallback = true
+)]
+fn always_failing() -> Result<String, ()> {
     Err(())
 }
 
@@ -1586,8 +1590,8 @@ fn test_result_fallback() {
     }
 
     // Pretend it succeeded once
-    ALWAYS_FAILING.lock().unwrap().cache_set((), 1);
-    assert_eq!(always_failing(), Ok(1));
+    ALWAYS_FAILING.lock().unwrap().cache_set((), "abc".to_string());
+    assert_eq!(always_failing(), Ok("abc".to_string()));
     {
         let cache = ALWAYS_FAILING.lock().unwrap();
         assert_eq!(cache.cache_hits(), Some(1));
@@ -1597,14 +1601,14 @@ fn test_result_fallback() {
     std::thread::sleep(std::time::Duration::from_millis(2000));
 
     // Even though the cache should've expired, the `result_fallback` flag means it refreshes the cache with the last valid result
-    assert_eq!(always_failing(), Ok(1));
+    assert_eq!(always_failing(), Ok("abc".to_string()));
     {
         let cache = ALWAYS_FAILING.lock().unwrap();
         assert_eq!(cache.cache_hits(), Some(1));
         assert_eq!(cache.cache_misses(), Some(2));
     }
 
-    assert_eq!(always_failing(), Ok(1));
+    assert_eq!(always_failing(), Ok("abc".to_string()));
     {
         let cache = ALWAYS_FAILING.lock().unwrap();
         assert_eq!(cache.cache_hits(), Some(2));


### PR DESCRIPTION
As a followup to https://github.com/jaemk/cached/pull/177, i changed the code a bit in my fork to work for types that are `Clone` but not necessarily `Copy`, and explicitly fail to compile when using `result_fallback` with the incompatible `sync_writes` flag.

Would be cool to merge this whenever :) 