### PR TITLE
bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ version = "0.1"
 optional = true
 
 [dependencies.redis]
-version = "0.24"
+version = "0.25"
 features = ["r2d2"]
 optional = true
 
@@ -78,7 +78,7 @@ version = "1.1"
 optional = true
 
 [dependencies.directories]
-version = "4.0"
+version = "5.0"
 optional = true
 
 [dependencies.r2d2]
@@ -110,7 +110,7 @@ features = ["attributes"]
 version = "1"
 
 [dev-dependencies.serial_test]
-version = "2"
+version = "3"
 
 [workspace]
 members = ["cached_proc_macro", "examples/wasm"]


### PR DESCRIPTION
bump redis from 0.24 to 0.25; directories from 4.0 to 5.0;serial_test from 2 to 3