### PR TITLE
Improvements to DiskCache tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,9 @@ optional = true
 [dependencies.instant]
 version = "0.1"
 
+[dev-dependencies]
+tempfile = "3.10.1"
+
 [dev-dependencies.async-std]
 version = "1.6"
 features = ["attributes"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ optional = true
 version = "0.1"
 
 [dev-dependencies]
+googletest = "0.11.0"
 tempfile = "3.10.1"
 
 [dev-dependencies.async-std]

--- a/src/stores/disk.rs
+++ b/src/stores/disk.rs
@@ -368,7 +368,7 @@ mod test_DiskCache {
     #[test]
     fn values_expire_when_lifespan_elapses_returning_none() {
         let tmp_dir = temp_dir!();
-        let mut cache: DiskCache<u32, u32> = DiskCache::new("test-cache")
+        let cache: DiskCache<u32, u32> = DiskCache::new("test-cache")
             .set_disk_directory(tmp_dir.path())
             .set_lifespan(LIFE_SPAN_2_SECS)
             .build()

--- a/src/stores/disk.rs
+++ b/src/stores/disk.rs
@@ -291,8 +291,15 @@ where
 mod tests {
     use std::thread::sleep;
     use std::time::Duration;
+    use tempfile::TempDir;
 
     use super::*;
+
+    macro_rules! temp_dir {
+        () => {
+            TempDir::new().expect("Error creating temp dir")
+        };
+    }
 
     fn now_millis() -> u128 {
         std::time::SystemTime::now()
@@ -303,11 +310,11 @@ mod tests {
 
     #[test]
     fn disk_set_get_remove() {
-        let cache: DiskCache<u32, u32> =
-            DiskCache::new(&format!("{}:disk-cache-test-sgr", now_millis()))
-                .set_disk_directory(std::env::temp_dir().join("cachedtest-sgr"))
-                .build()
-                .unwrap();
+        let tmp_dir = temp_dir!();
+        let cache: DiskCache<u32, u32> = DiskCache::new("test-cache")
+            .set_disk_directory(tmp_dir.path())
+            .build()
+            .unwrap();
 
         let cached = cache.cache_get(&6).unwrap();
         assert!(cached.is_none());
@@ -332,11 +339,12 @@ mod tests {
 
     #[test]
     fn disk_expire() {
-        let mut c: DiskCache<u32, u32> =
-            DiskCache::new(&format!("{}:disk-cache-test", now_millis()))
-                .set_lifespan(2)
-                .build()
-                .unwrap();
+        let tmp_dir = temp_dir!();
+        let mut c: DiskCache<u32, u32> = DiskCache::new("test-cache")
+            .set_disk_directory(tmp_dir.path())
+            .set_lifespan(2)
+            .build()
+            .unwrap();
 
         assert!(c.cache_get(&1).unwrap().is_none());
 
@@ -363,11 +371,11 @@ mod tests {
 
     #[test]
     fn disk_remove() {
-        let cache: DiskCache<u32, u32> =
-            DiskCache::new(&format!("{}:disk-cache-test-remove", now_millis()))
-                .set_disk_directory(std::env::temp_dir().join("cachedtest-remove"))
-                .build()
-                .unwrap();
+        let tmp_dir = temp_dir!();
+        let cache: DiskCache<u32, u32> = DiskCache::new("test-cache")
+            .set_disk_directory(tmp_dir.path())
+            .build()
+            .unwrap();
 
         assert!(cache.cache_set(1, 100).unwrap().is_none());
         assert!(cache.cache_set(2, 200).unwrap().is_none());
@@ -380,8 +388,10 @@ mod tests {
 
     #[test]
     fn disk_default_cache_dir() {
+        let tmp_dir = temp_dir!();
         let cache: DiskCache<u32, u32> =
             DiskCache::new(&format!("{}:disk-cache-test-default-dir", now_millis()))
+                // use the default disk directory
                 .build()
                 .unwrap();
 


### PR DESCRIPTION
Since I've been doing some work on the disk.rs module, I've noticed the tests could be improced, both in what's being tested and the descriptiveness of the tests.

In this PR, I haven't changed the functionality of the existing tests, but I've made improvements:
- Use googletest assertions + matchers: These have very nice, descriptive failure messages rather than `'left != right"` from std.
- Added descriptive messages in the assertions
- Use tempfile::TempDir - the proper way to use the file system in tests (when the TempDir object goes out of scope, the directory gets deleted).
- Change the test structure / names to be more descriptive.

Also, I've added a test for the refreshing functionality.

Just as a note, another way in which the tests can be improved would be to be more specific in what the tests are actually testing, i.e. currently all the tests check that getting a non existent key returns none, but ideally we should have one test for that, and then not tests that behaviour in other tests, i.e. each test should test one thing, and its name should explain what that thing is.

What I'd like to do, if / when I get some time would be to look into having a generic test suite for any cache, and then just plug any specific caching implementation (disk, memory, redis, etc...) into those tests.

Just as a reference: Luca Palmieri has a really nice set of exercises in his [testing workshop](https://github.com/mainmatter/rust-advanced-testing-workshop), which is where I learned about googletest.