### PR TITLE
Feature/disk cache sync on change and sled connection config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 ## Added
+- Add `DiskCacheBuilder::set_sync_to_disk_on_cache_change` to specify that the cache changes should be written to disk on every cache change.
+- Add `sync_to_disk_on_cache_change` to `#[io_cached]` to allow setting `DiskCacheBuilder::set_sync_to_disk_on_cache_change` from the proc macro.
+- Add `DiskCacheBuilder::set_connection_config` to give more control over the sled connection.
+- Add `connection_config` to `#[io_cached]` to allow setting `DiskCacheBuilder::set_connection_config` from the proc macro.
+- Add `DiskCache::connection()` and `DiskCache::connection_mut()` to give access to the underlying sled connection.
 ## Changed
 - [Breaking] `type` attribute is now `ty`
 - Upgrade to syn2 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Changed
 - [Breaking] `type` attribute is now `ty`
 - Upgrade to syn2 
+- Signature or `DiskCache::remove_expired_entries`: this now returns `Result<(), DiskCacheError>` instead of `()`, returning an `Err(sled::Error)` on removing and flushing from the connection.
 ## Removed
 
 ## [0.49.3]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ optional = true
 version = "0.1"
 
 [dev-dependencies]
+copy_dir = "0.1.3"
 googletest = "0.11.0"
 tempfile = "3.10.1"
 

--- a/cached_proc_macro/src/io_cached.rs
+++ b/cached_proc_macro/src/io_cached.rs
@@ -37,7 +37,7 @@ struct IOMacroArgs {
     #[darling(default)]
     create: Option<String>,
     #[darling(default)]
-    sync_to_disk_on_cache_set: Option<bool>,
+    sync_to_disk_on_cache_change: Option<bool>,
 }
 
 pub fn io_cached(args: TokenStream, input: TokenStream) -> TokenStream {
@@ -175,7 +175,7 @@ pub fn io_cached(args: TokenStream, input: TokenStream) -> TokenStream {
         &args.cache_prefix_block,
         &args.ty,
         &args.create,
-        &args.sync_to_disk_on_cache_set,
+        &args.sync_to_disk_on_cache_change,
     ) {
         // redis
         (true, false, time, time_refresh, cache_prefix, ty, cache_create, _) => {
@@ -245,7 +245,7 @@ pub fn io_cached(args: TokenStream, input: TokenStream) -> TokenStream {
             (cache_ty, cache_create)
         }
         // disk
-        (false, true, time, time_refresh, _, ty, cache_create, sync_to_disk_on_cache_set) => {
+        (false, true, time, time_refresh, _, ty, cache_create, sync_to_disk_on_cache_change) => {
             let cache_ty = match ty {
                 Some(ty) => {
                     let ty = parse_str::<Type>(ty).expect("unable to parse cache type");
@@ -288,11 +288,11 @@ pub fn io_cached(args: TokenStream, input: TokenStream) -> TokenStream {
                             }
                         }
                     };
-                    let create = match sync_to_disk_on_cache_set {
+                    let create = match sync_to_disk_on_cache_change {
                         None => create,
-                        Some(sync_to_disk_on_cache_set) => {
+                        Some(sync_to_disk_on_cache_change) => {
                             quote! {
-                                (#create).set_sync_on_cache_set(#sync_to_disk_on_cache_set)
+                                (#create).set_sync_to_disk_on_cache_change(#sync_to_disk_on_cache_change)
                             }
                         }
                     };

--- a/cached_proc_macro/src/io_cached.rs
+++ b/cached_proc_macro/src/io_cached.rs
@@ -36,6 +36,8 @@ struct IOMacroArgs {
     ty: Option<String>,
     #[darling(default)]
     create: Option<String>,
+    #[darling(default)]
+    sync_to_disk_on_cache_set: Option<bool>,
 }
 
 pub fn io_cached(args: TokenStream, input: TokenStream) -> TokenStream {
@@ -173,9 +175,10 @@ pub fn io_cached(args: TokenStream, input: TokenStream) -> TokenStream {
         &args.cache_prefix_block,
         &args.ty,
         &args.create,
+        &args.sync_to_disk_on_cache_set,
     ) {
         // redis
-        (true, false, time, time_refresh, cache_prefix, ty, cache_create) => {
+        (true, false, time, time_refresh, cache_prefix, ty, cache_create, _) => {
             let cache_ty = match ty {
                 Some(ty) => {
                     let ty = parse_str::<Type>(ty).expect("unable to parse cache type");
@@ -242,7 +245,7 @@ pub fn io_cached(args: TokenStream, input: TokenStream) -> TokenStream {
             (cache_ty, cache_create)
         }
         // disk
-        (false, true, time, time_refresh, _, ty, cache_create) => {
+        (false, true, time, time_refresh, _, ty, cache_create, sync_to_disk_on_cache_set) => {
             let cache_ty = match ty {
                 Some(ty) => {
                     let ty = parse_str::<Type>(ty).expect("unable to parse cache type");
@@ -285,6 +288,14 @@ pub fn io_cached(args: TokenStream, input: TokenStream) -> TokenStream {
                             }
                         }
                     };
+                    let create = match sync_to_disk_on_cache_set {
+                        None => create,
+                        Some(sync_to_disk_on_cache_set) => {
+                            quote! {
+                                (#create).set_sync_on_cache_set(#sync_to_disk_on_cache_set)
+                            }
+                        }
+                    };
                     let create = match args.disk_dir {
                         None => create,
                         Some(disk_dir) => {
@@ -296,7 +307,7 @@ pub fn io_cached(args: TokenStream, input: TokenStream) -> TokenStream {
             };
             (cache_ty, cache_create)
         }
-        (_, _, time, time_refresh, cache_prefix, ty, cache_create) => {
+        (_, _, time, time_refresh, cache_prefix, ty, cache_create, _) => {
             let cache_ty = match ty {
                 Some(ty) => {
                     let ty = parse_str::<Type>(ty).expect("unable to parse cache type");

--- a/cached_proc_macro/src/io_cached.rs
+++ b/cached_proc_macro/src/io_cached.rs
@@ -5,7 +5,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::spanned::Spanned;
 use syn::{
-    parse_macro_input, parse_str, Block, ExprClosure, GenericArgument, Ident, ItemFn,
+    parse_macro_input, parse_str, Block, Expr, ExprClosure, GenericArgument, Ident, ItemFn,
     PathArguments, ReturnType, Type,
 };
 
@@ -38,6 +38,8 @@ struct IOMacroArgs {
     create: Option<String>,
     #[darling(default)]
     sync_to_disk_on_cache_change: Option<bool>,
+    #[darling(default)]
+    connection_config: Option<String>,
 }
 
 pub fn io_cached(args: TokenStream, input: TokenStream) -> TokenStream {
@@ -176,9 +178,10 @@ pub fn io_cached(args: TokenStream, input: TokenStream) -> TokenStream {
         &args.ty,
         &args.create,
         &args.sync_to_disk_on_cache_change,
+        &args.connection_config,
     ) {
         // redis
-        (true, false, time, time_refresh, cache_prefix, ty, cache_create, _) => {
+        (true, false, time, time_refresh, cache_prefix, ty, cache_create, _, _) => {
             let cache_ty = match ty {
                 Some(ty) => {
                     let ty = parse_str::<Type>(ty).expect("unable to parse cache type");
@@ -245,7 +248,17 @@ pub fn io_cached(args: TokenStream, input: TokenStream) -> TokenStream {
             (cache_ty, cache_create)
         }
         // disk
-        (false, true, time, time_refresh, _, ty, cache_create, sync_to_disk_on_cache_change) => {
+        (
+            false,
+            true,
+            time,
+            time_refresh,
+            _,
+            ty,
+            cache_create,
+            sync_to_disk_on_cache_change,
+            connection_config,
+        ) => {
             let cache_ty = match ty {
                 Some(ty) => {
                     let ty = parse_str::<Type>(ty).expect("unable to parse cache type");
@@ -255,6 +268,14 @@ pub fn io_cached(args: TokenStream, input: TokenStream) -> TokenStream {
                     // https://github.com/spacejam/sled?tab=readme-ov-file#interaction-with-async
                     quote! { cached::DiskCache<#cache_key_ty, #cache_value_ty> }
                 }
+            };
+            let connection_config = match connection_config {
+                Some(connection_config) => {
+                    let connection_config = parse_str::<Expr>(connection_config)
+                        .expect("unable to parse connection_config block");
+                    Some(quote! { #connection_config })
+                }
+                None => None,
             };
             let cache_create = match cache_create {
                 Some(cache_create) => {
@@ -296,6 +317,14 @@ pub fn io_cached(args: TokenStream, input: TokenStream) -> TokenStream {
                             }
                         }
                     };
+                    let create = match connection_config {
+                        None => create,
+                        Some(connection_config) => {
+                            quote! {
+                                (#create).set_connection_config(#connection_config)
+                            }
+                        }
+                    };
                     let create = match args.disk_dir {
                         None => create,
                         Some(disk_dir) => {
@@ -307,7 +336,7 @@ pub fn io_cached(args: TokenStream, input: TokenStream) -> TokenStream {
             };
             (cache_ty, cache_create)
         }
-        (_, _, time, time_refresh, cache_prefix, ty, cache_create, _) => {
+        (_, _, time, time_refresh, cache_prefix, ty, cache_create, _, _) => {
             let cache_ty = match ty {
                 Some(ty) => {
                     let ty = parse_str::<Type>(ty).expect("unable to parse cache type");

--- a/cached_proc_macro/src/lib.rs
+++ b/cached_proc_macro/src/lib.rs
@@ -85,6 +85,11 @@ pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
 ///   `key` or `ty` must also be set.
 /// - `with_cached_flag`: (optional, bool) If your function returns a `cached::Return` or `Result<cached::Return, E>`,
 ///   the `cached::Return.was_cached` flag will be updated when a cached value is returned.
+/// - `sync_to_disk_on_cache_change`: (optional, bool) in the case of `DiskCache` specify whether to synchronize the cache to disk each
+///   time the cache changes.
+/// - connection_config: (optional, string expr) specify an expression which returns a `sled::Config`
+///   to give more control over the connection to the disk cache, i.e. useful for controlling the rate at which the cache syncs to disk.
+///   See the docs of `cached::stores::DiskCacheBuilder::connection_config` for more info.
 ///
 /// ## Note
 /// The `ty`, `create`, `key`, and `convert` attributes must be in a `String`

--- a/src/stores/disk.rs
+++ b/src/stores/disk.rs
@@ -167,7 +167,7 @@ where
         DiskCacheBuilder::new(cache_name)
     }
 
-    pub fn remove_expired_entries(&self) {
+    pub fn remove_expired_entries(&self) -> Result<(), DiskCacheError> {
         let now = SystemTime::now();
 
         for (key, value) in self.connection.iter().flatten() {
@@ -185,11 +185,9 @@ where
         }
 
         if self.sync_to_disk_on_cache_change {
-            // NOTE: we are not returning any error here so as not to change the function signature,
-            // and break backwards compatibility
-            // TODO: Review changing the function signature to return a Result<(), DiskCacheError> - this would be a breaking change
-            let _ = self.connection.flush();
+            self.connection.flush()?;
         }
+        Ok(())
     }
 
     /// Provide access to the underlying [sled::Db] connection

--- a/src/stores/disk.rs
+++ b/src/stores/disk.rs
@@ -409,7 +409,7 @@ mod test_DiskCache {
     const LIFE_SPAN_2_SECS: u64 = 2;
     const LIFE_SPAN_1_SEC: u64 = 1;
 
-    #[test]
+    #[googletest::test]
     fn cache_get_after_cache_remove_returns_none() {
         let tmp_dir = temp_dir!();
         let cache: DiskCache<u32, u32> = DiskCache::new("test-cache")
@@ -454,7 +454,7 @@ mod test_DiskCache {
         drop(cache);
     }
 
-    #[test]
+    #[googletest::test]
     fn values_expire_when_lifespan_elapses_returning_none() {
         let tmp_dir = temp_dir!();
         let cache: DiskCache<u32, u32> = DiskCache::new("test-cache")
@@ -490,7 +490,7 @@ mod test_DiskCache {
         );
     }
 
-    #[test]
+    #[googletest::test]
     fn set_lifespan_to_a_different_lifespan_is_respected() {
         // COPY PASTE of [values_expire_when_lifespan_elapses_returning_none]
         let tmp_dir = temp_dir!();
@@ -577,7 +577,7 @@ mod test_DiskCache {
         );
     }
 
-    #[test]
+    #[googletest::test]
     fn refreshing_on_cache_get_delays_cache_expiry() {
         // NOTE: Here we're relying on the fact that setting then sleeping for 2 secs and getting takes longer than 2 secs.
         const LIFE_SPAN: u64 = 2;
@@ -619,7 +619,7 @@ mod test_DiskCache {
         drop(cache);
     }
 
-    #[test]
+    #[googletest::test]
     // TODO: Consider removing this test, as it's not really testing anything.
     // If we want to check that setting a different disk directory to the default doesn't change anything,
     // we should design the tests to run all the same tests but paramaterized with different conditions.
@@ -698,7 +698,7 @@ mod test_DiskCache {
             mod changes_persist_after_recovery_when_set_to_true {
                 use super::*;
 
-                #[test]
+                #[googletest::test]
                 fn for_cache_set() {
                     check_on_recovered_cache(
                         false,
@@ -718,7 +718,7 @@ mod test_DiskCache {
                     )
                 }
 
-                #[test]
+                #[googletest::test]
                 fn for_cache_remove() {
                     check_on_recovered_cache(
                         false,
@@ -746,7 +746,7 @@ mod test_DiskCache {
                 }
 
                 #[ignore = "Not implemented"]
-                #[test]
+                #[googletest::test]
                 fn for_cache_get_when_refreshing() {
                     todo!("Test not implemented.")
                 }
@@ -756,7 +756,7 @@ mod test_DiskCache {
             mod changes_do_not_persist_after_recovery_when_set_to_false {
                 use super::*;
 
-                #[test]
+                #[googletest::test]
                 fn for_cache_set() {
                     check_on_recovered_cache(
                         true,
@@ -776,7 +776,7 @@ mod test_DiskCache {
                     )
                 }
 
-                #[test]
+                #[googletest::test]
                 fn for_cache_remove() {
                     check_on_recovered_cache(
                         true,
@@ -801,7 +801,7 @@ mod test_DiskCache {
                 }
 
                 #[ignore = "Not implemented"]
-                #[test]
+                #[googletest::test]
                 fn for_cache_get_when_refreshing() {
                     todo!("Test not implemented.")
                 }

--- a/src/stores/disk.rs
+++ b/src/stores/disk.rs
@@ -178,7 +178,7 @@ where
                         .unwrap_or(Duration::from_secs(0))
                         >= Duration::from_secs(lifetime_seconds)
                     {
-                        let _ = self.connection.remove(key);
+                        self.connection.remove(key)?;
                     }
                 }
             }

--- a/src/stores/disk.rs
+++ b/src/stores/disk.rs
@@ -70,10 +70,11 @@ where
         self
     }
 
-    /// Specify whether the cache should sync to disk on each call to [DiskCache::cache_set].
-    /// [sled] flushes every [sled::Config::flush_every_ms] which has a default value of 500ms.
-    /// In some use cases, this may not be quick enough, or a user may want to provide their own [sled::Db]
-    /// used for cache creation which may have a low flush frequency geared towards a manual flush strategy.
+    /// Specify whether the cache should sync to disk on each cache change.
+    /// [sled] flushes every [sled::Config::flush_every_ms] which has a default value.
+    /// In some use cases, the default value may not be quick enough,
+    /// or a user may want to reduce the flush rate / turn off auto-flushing to reduce IO (and only flush on cache changes).
+    /// (see [DiskCacheBuilder::set_connection_config] for more control over the sled connection)
     pub fn set_sync_to_disk_on_cache_change(mut self, sync_to_disk_on_cache_change: bool) -> Self {
         self.sync_to_disk_on_cache_change = sync_to_disk_on_cache_change;
         self

--- a/src/stores/disk.rs
+++ b/src/stores/disk.rs
@@ -190,6 +190,17 @@ where
             let _ = self.connection.flush();
         }
     }
+
+    /// Provide access to the underlying [sled::Db] connection
+    /// This is useful for i.e. manually flushing the cache to disk.
+    pub fn connection(&self) -> &Db {
+        &self.connection
+    }
+
+    /// Provide mutable access to the underlying [sled::Db] connection
+    pub fn connection_mut(&mut self) -> &mut Db {
+        &mut self.connection
+    }
 }
 
 #[derive(Error, Debug)]

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -1287,6 +1287,37 @@ mod disk_tests {
         assert_eq!(cached_disk_cache_create(6), Err(TestError::Count(6)));
     }
 
+    /// Just calling the macro with connection_config to test it doesn't break with an expected string
+    /// for connection_config.
+    /// There are no simple tests to test this here
+    #[io_cached(
+        disk = true,
+        map_error = r##"|e| TestError::DiskError(format!("{:?}", e))"##,
+        connection_config = r##"sled::Config::new().flush_every_ms(None)"##
+    )]
+    fn cached_disk_connection_config(n: u32) -> Result<u32, TestError> {
+        if n < 5 {
+            Ok(n)
+        } else {
+            Err(TestError::Count(n))
+        }
+    }
+
+    /// Just calling the macro with sync_to_disk_on_cache_change to test it doesn't break with an expected value
+    /// There are no simple tests to test this here
+    #[io_cached(
+        disk = true,
+        map_error = r##"|e| TestError::DiskError(format!("{:?}", e))"##,
+        sync_to_disk_on_cache_change = true
+    )]
+    fn cached_disk_sync_to_disk_on_cache_change(n: u32) -> Result<u32, TestError> {
+        if n < 5 {
+            Ok(n)
+        } else {
+            Err(TestError::Count(n))
+        }
+    }
+
     #[cfg(feature = "async")]
     mod async_test {
         use super::*;


### PR DESCRIPTION
This PR concerns only the `DiskCache`

Closes https://github.com/jaemk/cached/issues/190

#### The main features of this PR are
- test improvements in disk.rs: PR for this is https://github.com/jaemk/cached/pull/193 (or just within my clone for the sake of isolating changes: https://github.com/BaxHugh/cached/pull/4)
- feature to write changes to disk every time a cache is changed (value set, removed or refreshed) - PR within my clone to give isolated diffs: https://github.com/BaxHugh/cached/pull/2
- feature to provide a sled::Config to create the connection from + connection() and connection_mut() functions to give users more control over the sled backend. - PR within my clone to give isolated diffs: https://github.com/BaxHugh/cached/pull/3

This replaces https://github.com/jaemk/cached/pull/192

(the PRs in my clone are all stacked, but I don't think I can do that within this repo, so it is in one big PR to master here)