### PR TITLE
Fix `DiskCache::remove_expired_entries`

### DIFF
--- a/src/stores/disk.rs
+++ b/src/stores/disk.rs
@@ -132,7 +132,7 @@ where
                     if now
                         .duration_since(cached.created_at)
                         .unwrap_or(Duration::from_secs(0))
-                        < Duration::from_secs(lifetime_seconds)
+                        >= Duration::from_secs(lifetime_seconds)
                     {
                         let _ = self.connection.remove(key);
                     }


### PR DESCRIPTION
Previously, the `remove_expired_entries` would only remove _unexpired_ entries.