### PR TITLE
Make `cache_set_lifespan` the inverse of `cache_get_lifespan`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -357,6 +357,14 @@ pub trait Cached<K, V> {
     fn cache_set_lifespan(&mut self, _seconds: u64) -> Option<u64> {
         None
     }
+
+    /// Remove the lifespan for cached values, returns the old value.
+    ///
+    /// For cache implementations that don't support retaining values indefinitely, this method is
+    /// a no-op.
+    fn cache_unset_lifespan(&mut self) -> Option<u64> {
+        None
+    }
 }
 
 /// Extra cache operations for types that implement `Clone`
@@ -418,8 +426,16 @@ pub trait IOCached<K, V> {
         None
     }
 
-    /// Set the lifespan of cached values, returns the old value
+    /// Set the lifespan of cached values, returns the old value.
     fn cache_set_lifespan(&mut self, _seconds: u64) -> Option<u64> {
+        None
+    }
+
+    /// Remove the lifespan for cached values, returns the old value.
+    ///
+    /// For cache implementations that don't support retaining values indefinitely, this method is
+    /// a no-op.
+    fn cache_unset_lifespan(&mut self) -> Option<u64> {
         None
     }
 }
@@ -446,6 +462,14 @@ pub trait IOCachedAsync<K, V> {
 
     /// Set the lifespan of cached values, returns the old value
     fn cache_set_lifespan(&mut self, _seconds: u64) -> Option<u64> {
+        None
+    }
+
+    /// Remove the lifespan for cached values, returns the old value.
+    ///
+    /// For cache implementations that don't support retaining values indefinitely, this method is
+    /// a no-op.
+    fn cache_unset_lifespan(&mut self) -> Option<u64> {
         None
     }
 }

--- a/src/stores/disk.rs
+++ b/src/stores/disk.rs
@@ -284,6 +284,10 @@ where
         self.refresh = refresh;
         old
     }
+
+    fn cache_unset_lifespan(&mut self) -> Option<u64> {
+        self.seconds.take()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This makes it possible to temporarily change a cache lifespan, or to remove a cache lifespan once it's set. See #197 for context.