### PR TITLE
add Cached::cache_try_get_or_set_with

### DIFF
--- a/examples/kitchen_sink.rs
+++ b/examples/kitchen_sink.rs
@@ -2,7 +2,7 @@
 extern crate cached;
 
 use std::cmp::Eq;
-use std::collections::HashMap;
+use std::collections::{hash_map::Entry, HashMap};
 use std::hash::Hash;
 
 use std::thread::sleep;
@@ -82,6 +82,18 @@ impl<K: Hash + Eq, V> Cached<K, V> for MyCache<K, V> {
     }
     fn cache_get_or_set_with<F: FnOnce() -> V>(&mut self, k: K, f: F) -> &mut V {
         self.store.entry(k).or_insert_with(f)
+    }
+    fn cache_try_get_or_set_with<F: FnOnce() -> Result<V, E>, E>(
+        &mut self,
+        k: K,
+        f: F,
+    ) -> Result<&mut V, E> {
+        let v = match self.store.entry(k) {
+            Entry::Occupied(occupied) => occupied.into_mut(),
+            Entry::Vacant(vacant) => vacant.insert(f()?),
+        };
+
+        Ok(v)
     }
     fn cache_set(&mut self, k: K, v: V) -> Option<V> {
         self.store.insert(k, v)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,6 +318,13 @@ pub trait Cached<K, V> {
     /// Get or insert a key, value pair
     fn cache_get_or_set_with<F: FnOnce() -> V>(&mut self, k: K, f: F) -> &mut V;
 
+    /// Get or insert a key, value pair with error handling
+    fn cache_try_get_or_set_with<F: FnOnce() -> Result<V, E>, E>(
+        &mut self,
+        k: K,
+        f: F,
+    ) -> Result<&mut V, E>;
+
     /// Remove a cached value
     ///
     /// ```rust


### PR DESCRIPTION
This commit adds a new trait method `Cached::cache_try_get_or_set_with` and implements it for all cache variants in the code.

This method was already available for `async`, but there was no way how to do the same in the sync code.

Each module follows slightly different coding styles, so I tried to match a coding style for each particular module.

Tests were extended for every implementation (mostly inspired by their already existing async counterparts).