### PR TITLE
Fix deprecated default_features

### DIFF
--- a/examples/wasm/Cargo.toml
+++ b/examples/wasm/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies.cached]
-path ="../.."
-default_features = false
+path = "../.."
+default-features = false
 features = ["proc_macro", "wasm", "async"]
 
 [dependencies.chrono]


### PR DESCRIPTION
`default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition