### PR TITLE
cached: Add sync_writes_by_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ function-cache wrapped in a mutex/rwlock, or externally synchronized in the case
 By default, the function-cache is **not** locked for the duration of the function's execution, so initial (on an empty cache)
 concurrent calls of long-running functions with the same arguments will each execute fully and each overwrite
 the memoized value as they complete. This mirrors the behavior of Python's `functools.lru_cache`. To synchronize the execution and caching
-of un-cached arguments, specify `#[cached(sync_writes = true)]` / `#[once(sync_writes = true)]` (not supported by `#[io_cached]`.
+of un-cached arguments, specify `#[cached(sync_writes = "default")]` / `#[once(sync_writes = "default")]` (not supported by `#[io_cached]`.
 
 - See [`cached::stores` docs](https://docs.rs/cached/latest/cached/stores/index.html) cache stores available.
 - See [`proc_macro`](https://docs.rs/cached/latest/cached/proc_macro/index.html) for more procedural macro examples.
@@ -93,7 +93,7 @@ use cached::proc_macro::once;
 /// When no (or expired) cache, concurrent calls
 /// will synchronize (`sync_writes`) so the function
 /// is only executed once.
-#[once(time=10, option = true, sync_writes = true)]
+#[once(time=10, option = true, sync_writes = "default")]
 fn keyed(a: String) -> Option<usize> {
     if a == "a" {
         Some(a.len())
@@ -112,7 +112,7 @@ use cached::proc_macro::cached;
 #[cached(
     result = true,
     time = 1,
-    sync_writes = true,
+    sync_writes = "default",
     result_fallback = true
 )]
 fn doesnt_compile() -> Result<String, ()> {

--- a/cached_proc_macro/src/lib.rs
+++ b/cached_proc_macro/src/lib.rs
@@ -14,6 +14,7 @@ use proc_macro::TokenStream;
 /// - `time`: (optional, u64) specify a cache TTL in seconds, implies the cache type is a `TimedCache` or `TimedSizedCache`.
 /// - `time_refresh`: (optional, bool) specify whether to refresh the TTL on cache hits.
 /// - `sync_writes`: (optional, bool) specify whether to synchronize the execution of writing of uncached values.
+/// - `sync_writes_by_key`: (optional, bool) specify whether to synchronize the execution of writing of uncached values by key.
 /// - `ty`: (optional, string type) The cache store type to use. Defaults to `UnboundCache`. When `unbound` is
 ///   specified, defaults to `UnboundCache`. When `size` is specified, defaults to `SizedCache`.
 ///   When `time` is specified, defaults to `TimedCached`.

--- a/cached_proc_macro/src/once.rs
+++ b/cached_proc_macro/src/once.rs
@@ -9,7 +9,6 @@ use syn::{parse_macro_input, Ident, ItemFn, ReturnType};
 #[derive(Debug, Default, FromMeta)]
 enum SyncWriteMode {
     #[default]
-    Disabled,
     Default,
 }
 
@@ -20,7 +19,7 @@ struct OnceMacroArgs {
     #[darling(default)]
     time: Option<u64>,
     #[darling(default)]
-    sync_writes: SyncWriteMode,
+    sync_writes: Option<SyncWriteMode>,
     #[darling(default)]
     result: bool,
     #[darling(default)]
@@ -228,7 +227,7 @@ pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
     };
 
     let do_set_return_block = match args.sync_writes {
-        SyncWriteMode::Default => quote! {
+        Some(SyncWriteMode::Default) => quote! {
             #r_lock_return_cache_block
             #w_lock
             if let Some(result) = &*cached {
@@ -237,7 +236,7 @@ pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
             #function_call
             #set_cache_and_return
         },
-        SyncWriteMode::Disabled => quote! {
+        None => quote! {
             #r_lock_return_cache_block
             #function_call
             #w_lock

--- a/examples/async_std.rs
+++ b/examples/async_std.rs
@@ -86,7 +86,7 @@ async fn only_cached_once_per_second(s: String) -> Vec<String> {
 /// _one_ call will be "executed" and all others will be synchronized
 /// to return the cached result of the one call instead of all
 /// concurrently un-cached tasks executing and writing concurrently.
-#[once(time = 2, sync_writes = true)]
+#[once(time = 2, sync_writes = "default")]
 async fn only_cached_once_per_second_sync_writes(s: String) -> Vec<String> {
     vec![s]
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ function-cache wrapped in a mutex/rwlock, or externally synchronized in the case
 By default, the function-cache is **not** locked for the duration of the function's execution, so initial (on an empty cache)
 concurrent calls of long-running functions with the same arguments will each execute fully and each overwrite
 the memoized value as they complete. This mirrors the behavior of Python's `functools.lru_cache`. To synchronize the execution and caching
-of un-cached arguments, specify `#[cached(sync_writes = true)]` / `#[once(sync_writes = true)]` (not supported by `#[io_cached]`.
+of un-cached arguments, specify `#[cached(sync_writes = "default")]` / `#[once(sync_writes = "default")]` (not supported by `#[io_cached]`.
 
 - See [`cached::stores` docs](https://docs.rs/cached/latest/cached/stores/index.html) cache stores available.
 - See [`proc_macro`](https://docs.rs/cached/latest/cached/proc_macro/index.html) for more procedural macro examples.
@@ -94,7 +94,7 @@ use cached::proc_macro::once;
 /// When no (or expired) cache, concurrent calls
 /// will synchronize (`sync_writes`) so the function
 /// is only executed once.
-#[once(time=10, option = true, sync_writes = true)]
+#[once(time=10, option = true, sync_writes = "default")]
 fn keyed(a: String) -> Option<usize> {
     if a == "a" {
         Some(a.len())
@@ -114,7 +114,7 @@ use cached::proc_macro::cached;
 #[cached(
     result = true,
     time = 1,
-    sync_writes = true,
+    sync_writes = "default",
     result_fallback = true
 )]
 fn doesnt_compile() -> Result<String, ()> {

--- a/src/proc_macro.rs
+++ b/src/proc_macro.rs
@@ -115,7 +115,7 @@ use cached::proc_macro::cached;
 /// When called concurrently, duplicate argument-calls will be
 /// synchronized so as to only run once - the remaining concurrent
 /// calls return a cached value.
-#[cached(size=1, option = true, sync_writes = true)]
+#[cached(size=1, option = true, sync_writes = "default")]
 fn keyed(a: String) -> Option<usize> {
     if a == "a" {
         Some(a.len())
@@ -233,7 +233,7 @@ use cached::proc_macro::once;
 /// When no (or expired) cache, concurrent calls
 /// will synchronize (`sync_writes`) so the function
 /// is only executed once.
-#[once(time=10, option = true, sync_writes = true)]
+#[once(time=10, option = true, sync_writes = "default")]
 fn keyed(a: String) -> Option<usize> {
     if a == "a" {
         Some(a.len())

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -848,7 +848,7 @@ async fn test_only_cached_option_once_per_second_a() {
 /// to return the cached result of the one call instead of all
 /// concurrently un-cached tasks executing and writing concurrently.
 #[cfg(feature = "async")]
-#[once(time = 2, sync_writes = true)]
+#[once(time = 2, sync_writes = "default")]
 async fn only_cached_once_per_second_sync_writes(s: String) -> Vec<String> {
     vec![s]
 }
@@ -862,7 +862,7 @@ async fn test_only_cached_once_per_second_sync_writes() {
     assert_eq!(a.await.unwrap(), b.await.unwrap());
 }
 
-#[cached(time = 2, sync_writes = true, key = "u32", convert = "{ 1 }")]
+#[cached(time = 2, sync_writes = "default", key = "u32", convert = "{ 1 }")]
 fn cached_sync_writes(s: String) -> Vec<String> {
     vec![s]
 }
@@ -881,7 +881,7 @@ fn test_cached_sync_writes() {
 }
 
 #[cfg(feature = "async")]
-#[cached(time = 2, sync_writes = true, key = "u32", convert = "{ 1 }")]
+#[cached(time = 2, sync_writes = "default", key = "u32", convert = "{ 1 }")]
 async fn cached_sync_writes_a(s: String) -> Vec<String> {
     vec![s]
 }
@@ -898,7 +898,7 @@ async fn test_cached_sync_writes_a() {
     assert_eq!(a, c.await.unwrap());
 }
 
-#[cached(time = 2, sync_writes_by_key = true, key = "u32", convert = "{ 1 }")]
+#[cached(time = 2, sync_writes = "by_key", key = "u32", convert = "{ 1 }")]
 fn cached_sync_writes_by_key(s: String) -> Vec<String> {
     sleep(Duration::new(1, 0));
     vec![s]
@@ -919,7 +919,7 @@ fn test_cached_sync_writes_by_key() {
 #[cfg(feature = "async")]
 #[cached(
     time = 5,
-    sync_writes_by_key = true,
+    sync_writes = "by_key",
     key = "String",
     convert = r#"{ format!("{}", s) }"#
 )]
@@ -942,7 +942,7 @@ async fn test_cached_sync_writes_by_key_a() {
 }
 
 #[cfg(feature = "async")]
-#[once(sync_writes = true)]
+#[once(sync_writes = "default")]
 async fn once_sync_writes_a(s: &tokio::sync::Mutex<String>) -> String {
     let mut guard = s.lock().await;
     let results: String = (*guard).clone().to_string();


### PR DESCRIPTION
# Sync Writes by Key
 
This PR implements the `sync_writes_by_key` attribute, which works like `sync_writes`, but uses an individual lock per key.

This way you can call a method concurrently with different cache keys without locking the method (globally).

**Related Issues:**
- https://github.com/jaemk/cached/issues/158
- https://github.com/jaemk/cached/issues/62
- https://github.com/jaemk/cached/issues/81

