### PR TITLE
Cargo.toml: `disk` example requires `disk_store` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,3 +139,7 @@ required-features = ["async", "proc_macro"]
 [[example]]
 name = "expiring_sized_cache"
 required-features = ["async_tokio_rt_multi_thread"]
+
+[[example]]
+name = "disk"
+required-features = ["disk_store"]


### PR DESCRIPTION
Fixes errors while running (e.g.) `cargo fix`:

```
error[E0433]: failed to resolve: could not find `DiskCache` in `cached`
   --> examples/disk.rs:20:1
    |
20  | / #[io_cached(
21  | |     disk = true,
22  | |     time = 30,
23  | |     map_error = r##"|e| ExampleError::DiskError(format!("{:?}", e))"##
24  | | )]
    | |__^ could not find `DiskCache` in `cached`
    |
note: found an item that was configured out
   --> cached/src/lib.rs:241:18
    |
241 | pub use stores::{DiskCache, DiskCacheError};
    |                  ^^^^^^^^^
note: the item is gated behind the `disk_store` feature
   --> cached/src/lib.rs:239:7
    |
239 | #[cfg(feature = "disk_store")]
    |       ^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the attribute macro `io_cached` (in Nightly builds, run with -Z macro-backtrace for more info)
```