### PR TITLE
ci: replace archived actions-rs/toolchain with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,11 +17,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@1.96.0
       with:
-        toolchain: "1.96.0"
-        target: wasm32-unknown-unknown
         components: rustfmt, clippy
+        targets: wasm32-unknown-unknown
 
     - name: Cache cargo dir
       uses: actions/cache@v4


### PR DESCRIPTION
Replace the archived `actions-rs/toolchain@v1` action in the `build` workflow with the maintained [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain).
