### PR TITLE
fix: TtlSortedCache capacity/max_size preallocation; release 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+## [2.0.1]
+- Fix `TtlSortedCacheBuilder`: an explicit `.capacity(n)` is now honored even when `.max_size(m)` is also set. Previously the `max_size`-derived `m + 1` preallocation ran first, and because `HashMap::reserve` never shrinks, a smaller `.capacity(n)` had no effect. The explicit capacity now takes precedence as the preallocation hint while `max_size` continues to bound entry count ([#266](https://github.com/jaemk/cached/issues/266)).
+
 ## [2.0.0 / cached_proc_macro 2.0.0]
 > **Upgrading from 1.1?** See the [2.0 migration guide](docs/migrations/1.1-to-2.0-human.md).
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cached"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["James Kominick <james@kominick.com>"]
 description = "Generic cache implementations and simplified function memoization"
 repository = "https://github.com/jaemk/cached"

--- a/docs/migrations/2.0-to-2.0.1.md
+++ b/docs/migrations/2.0-to-2.0.1.md
@@ -1,0 +1,64 @@
+# cached 2.0 → 2.0.1 Migration (Agent Instructions)
+
+Versions: `cached 2.0` → `cached 2.0.1`
+
+`cached_proc_macro` and `cached_proc_macro_types` did not change; leave them pinned
+at their existing versions if pinned directly.
+
+## Breaking changes
+
+None. This release is purely additive / a bug fix.
+
+## Behavior fix (no source change required)
+
+### `TtlSortedCacheBuilder` now honors `.capacity()` alongside `.max_size()`
+
+Previously, when both `.max_size(m)` and `.capacity(n)` were set on
+`TtlSortedCache::builder()`, the builder reserved `m + 1` slots first and then
+`n`. Because `HashMap::reserve` never reduces an existing allocation, a smaller
+`.capacity(n)` had no effect — the backing map was always pre-allocated for the
+larger `max_size`.
+
+As of 2.0.1, an explicit `.capacity(n)` takes precedence as the preallocation
+hint while `.max_size(m)` continues to bound the entry count:
+
+```rust
+use cached::stores::TtlSortedCache;
+use std::time::Duration;
+
+let cache = TtlSortedCache::<u32, u32>::builder()
+    .ttl(Duration::from_secs(300))
+    .max_size(65_536) // still caps entry count at 65_536
+    .capacity(16)     // now respected: backing map starts small and grows on demand
+    .build()
+    .unwrap();
+```
+
+**Detection:** search for `TtlSortedCache::builder()` (or `.builder()` on a
+`TtlSortedCache`) call sites that set both `.max_size(` and `.capacity(`.
+
+**Action:** none required. The fix only changes initial allocation sizing, never
+correctness or eviction behavior. Callers that relied on `.capacity()` being
+ignored will see a smaller initial allocation; those that want the larger
+allocation can set `.capacity(max_size + 1)` explicitly.
+
+Note: `TtlSortedCache::set_max_size` / `try_set_max_size` on a live cache still
+re-grow the backing map to `max_size + 1`, overriding a smaller build-time
+`capacity`.
+
+## Required Cargo.toml change
+
+```toml
+# Before
+cached = "2.0"
+
+# After
+cached = "2.0.1"
+```
+
+## VERIFY
+
+`cargo build` — no new compile errors expected from the version bump.
+
+`cargo test --features time_stores` — exercises the `TtlSortedCache` builder,
+including the new regression tests for the `capacity` / `max_size` interaction.

--- a/src/stores/ttl_sorted.rs
+++ b/src/stores/ttl_sorted.rs
@@ -247,7 +247,6 @@ impl<K, V> TtlSortedCacheBuilder<K, V> {
     /// [`capacity`](Self::capacity), this is a hard cap on entry count, not a preallocation
     /// hint.
     #[doc(alias = "size")]
-    #[doc(alias = "capacity")]
     #[must_use]
     pub fn max_size(mut self, max_size: usize) -> Self {
         self.size = Some(max_size);
@@ -256,8 +255,19 @@ impl<K, V> TtlSortedCacheBuilder<K, V> {
 
     /// Pre-allocate capacity for the backing store. This is a *preallocation hint* only —
     /// it does **not** bound the cache. Use [`max_size`](Self::max_size) to set the eviction
-    /// bound. Mirrors the old `TtlSortedCache::with_ttl_and_capacity` behavior, reserving
-    /// exactly `capacity` entries in the backing map.
+    /// bound. Reserves room for at least `capacity` entries in the backing map (the exact
+    /// amount may be rounded up by the allocator), matching the preallocation semantics of
+    /// the pre-2.0 `with_ttl_and_capacity` constructor.
+    ///
+    /// When set, this takes precedence over the preallocation implied by
+    /// [`max_size`](Self::max_size): the backing map reserves for `capacity` entries rather
+    /// than `max_size + 1`. This lets you cap entries at a large `max_size` while starting
+    /// with a small allocation that grows on demand. Passing `capacity` larger than
+    /// `max_size` is valid — the map simply starts larger; `max_size` still bounds the entry
+    /// count. Only the backing map is pre-allocated; the `BTreeSet` TTL index is not.
+    ///
+    /// Note that [`set_max_size`](TtlSortedCache::set_max_size) on a live cache may re-grow
+    /// the backing map to `max_size + 1`, overriding a smaller `capacity` set here.
     #[must_use]
     pub fn capacity(mut self, capacity: usize) -> Self {
         self.capacity = Some(capacity);
@@ -315,15 +325,18 @@ impl<K, V> TtlSortedCacheBuilder<K, V> {
             evictions: AtomicU64::new(0),
             on_evict: self.on_evict,
         };
-        // Preserve the previous internal behavior: a size limit pre-reserved
-        // `size + 1` entries in the backing map.
-        if let Some(size) = self.size {
-            cache.map.reserve(size.saturating_add(1));
-        }
-        // Apply the explicit preallocation hint, mirroring the old
-        // `with_ttl_and_capacity` which reserved exactly `capacity`.
-        if let Some(capacity) = self.capacity {
-            cache.map.reserve(capacity);
+        // Decide the single preallocation amount once all options are known.
+        // An explicit `capacity` is the preallocation hint and takes precedence,
+        // reserving for `capacity` and matching the old `with_ttl_and_capacity`.
+        // Otherwise fall back to the previous internal behavior where a size limit
+        // pre-reserved `size + 1` entries. We reserve only once: issuing the
+        // `size + 1` reservation first would defeat a smaller explicit `capacity`,
+        // since `HashMap::reserve` does not reduce an existing allocation.
+        let preallocate = self
+            .capacity
+            .or_else(|| self.size.map(|size| size.saturating_add(1)));
+        if let Some(amount) = preallocate {
+            cache.map.reserve(amount);
         }
         Ok(cache)
     }
@@ -343,6 +356,10 @@ impl<K: Hash + Eq + Ord + Clone, V> TtlSortedCache<K, V> {
 
     /// Set the maximum number of entries. When reached, the next entries to expire are evicted.
     /// Returns the previous value if one was set.
+    ///
+    /// This grows the backing map to hold at least `max_size + 1` entries, so calling it on a
+    /// cache built with a deliberately small [`capacity`](TtlSortedCacheBuilder::capacity) will
+    /// override that smaller allocation.
     ///
     /// # Panics
     ///
@@ -1303,6 +1320,40 @@ mod test {
                 "expected InvalidValue, got {error:?}"
             ),
         }
+    }
+
+    #[test]
+    fn explicit_capacity_takes_precedence_over_max_size_preallocation() {
+        // Regression for #266: an explicit, smaller `capacity` must not be defeated
+        // by `max_size`'s `size + 1` preallocation (HashMap::reserve does not reduce
+        // an existing allocation).
+        let cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(300))
+            .max_size(65_536)
+            .capacity(16)
+            .build()
+            .unwrap();
+        // The backing map must not have taken the max_size path, which would reserve
+        // for max_size + 1 (= 65_537) entries.
+        assert!(
+            cache.map.capacity() < 65_537,
+            "expected the explicit capacity(16) to take precedence, got {}",
+            cache.map.capacity()
+        );
+        assert!(cache.map.capacity() >= 16);
+        // The eviction bound still reflects max_size.
+        assert_eq!(cache.size_limit, Some(65_536));
+    }
+
+    #[test]
+    fn max_size_alone_preallocates() {
+        // Without an explicit capacity, max_size still drives preallocation.
+        let cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(300))
+            .max_size(64)
+            .build()
+            .unwrap();
+        assert!(cache.map.capacity() >= 65);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #266 and releases 2.0.1.

`TtlSortedCacheBuilder` now honors an explicit `.capacity()` even when `.max_size()` is also set (previously the larger `max_size` preallocation defeated a smaller capacity, since `HashMap::reserve` never shrinks). Bumps `cached` to 2.0.1.