### PR TITLE
release: 2.0.2 (document dynamic per-entry TTL via Expires; test #246)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+## [2.0.2]
+- Docs/tests only (no API change): document the `Expires` trait / `expires = true` as the idiomatic way to set a dynamic, per-entry TTL (a lifetime computed at call time rather than the uniform `ttl = N`), with a runnable example reference, and add a regression test for the runtime-argument-driven TTL case ([#246](https://github.com/jaemk/cached/issues/246)).
+
 ## [2.0.1]
 - Fix `TtlSortedCacheBuilder`: an explicit `.capacity(n)` is now honored even when `.max_size(m)` is also set. Previously the `max_size`-derived `m + 1` preallocation ran first, and because `HashMap::reserve` never shrinks, a smaller `.capacity(n)` had no effect. The explicit capacity now takes precedence as the preallocation hint while `max_size` continues to bound entry count ([#266](https://github.com/jaemk/cached/issues/266)).
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cached"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["James Kominick <james@kominick.com>"]
 description = "Generic cache implementations and simplified function memoization"
 repository = "https://github.com/jaemk/cached"

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Any custom cache that implements `cached::ConcurrentCached`/`cached::ConcurrentC
 | Force-cache `None` returns | `#[cached(cache_none = true)] fn find(id: u64) -> Option<User>` |
 | Force-cache `Err` returns | `#[cached(cache_err = true)] fn load(id: u64) -> Result<Data, E>` |
 | Serve stale value when function returns `Err` | `#[cached(result_fallback = true, ttl = 60)] fn fetch(id: u64) -> Result<Data, E>` |
-| Per-value expiry (value carries its own TTL) | `#[cached(expires = true)] fn token(scope: String) -> Token` |
+| Per-value / dynamic per-entry TTL (value carries its own expiry) | `#[cached(expires = true)] fn token(scope: String) -> Token` |
 | Deduplicate concurrent first calls for same key | `#[cached(ttl = 30, sync_writes = "by_key")] fn expensive(id: u64) -> Payload` |
 | Async | `#[cached(max_size = 100)] async fn remote(id: u64) -> Data` |
 | **`#[once]`** | |
@@ -199,7 +199,33 @@ While standard timed stores (`TtlCache`, `LruTtlCache`, `TtlSortedCache`) enforc
 
 This approach is highly useful when caching payloads like OAuth tokens, HTTP responses with varying `Cache-Control` headers, or database records that contain their own absolute expiration timestamps.
 
+It is also the idiomatic way to give entries a **dynamic, per-entry TTL** — a lifetime computed at call time rather than the single uniform duration that `ttl = N` applies to every entry. Because the value carries its own expiry, each entry can be given a different lifetime derived from a function argument, runtime configuration, or a response header. (`expires = true` is mutually exclusive with `ttl`.) See the [`expires_per_key`](https://github.com/jaemk/cached/blob/master/examples/expires_per_key.rs) example for a runnable demonstration.
+
 When using the `#[cached]` or `#[once]` proc macros, add `expires = true` to opt into per-value expiry automatically. For `#[cached]`, this selects `ExpiringCache` (unbounded) by default or `ExpiringLruCache` when `max_size` is also specified. For `#[once]`, this stores a single value whose expiry is polled on each call.
+
+The macro form below derives each entry's TTL from a function argument — `key`/`convert` keep the TTL out of the cache key so it influences only the entry's lifetime, not which slot it occupies:
+
+```rust
+use cached::macros::cached;
+use cached::Expires;
+use cached::time::{Duration, Instant};
+
+#[derive(Clone)]
+struct Token { value: String, expires_at: Instant }
+
+impl Expires for Token {
+    fn is_expired(&self) -> bool { Instant::now() >= self.expires_at }
+}
+
+// `ttl_secs` is a runtime argument — each user's token expires on its own schedule.
+#[cached(expires = true, key = "u64", convert = "{ user_id }")]
+fn fetch_token(user_id: u64, ttl_secs: u64) -> Token {
+    Token {
+        value: format!("token-{user_id}"),
+        expires_at: Instant::now() + Duration::from_secs(ttl_secs),
+    }
+}
+```
 
 For concurrent (multi-thread, no external lock) use, the sharded equivalents [`ShardedExpiringCache`] and [`ShardedExpiringLruCache`] provide the same per-value expiry with internally-synchronized sharded storage. Use `#[concurrent_cached(expires = true)]` to select them automatically.
 

--- a/docs/migrations/2.0.1-to-2.0.2.md
+++ b/docs/migrations/2.0.1-to-2.0.2.md
@@ -1,0 +1,34 @@
+# cached 2.0.1 → 2.0.2 Migration (Agent Instructions)
+
+Versions: `cached 2.0.1` → `cached 2.0.2`
+
+`cached_proc_macro` and `cached_proc_macro_types` did not change; leave them pinned
+at their existing versions if pinned directly.
+
+## Breaking changes
+
+None. This release is documentation and tests only — there is no API or behavior change.
+
+## What changed
+
+- Documentation: the `Expires` trait / `#[cached(expires = true)]` / `#[once(expires = true)]`
+  feature is now documented as the idiomatic way to set a dynamic, per-entry TTL (a
+  lifetime computed at call time, rather than the uniform `ttl = N`). See the
+  `expires_per_key` example.
+- Tests: added a regression test for runtime-argument-driven per-entry TTL ([#246]).
+
+[#246]: https://github.com/jaemk/cached/issues/246
+
+## Required Cargo.toml change
+
+```toml
+# Before
+cached = "2.0.1"
+
+# After
+cached = "2.0.2"
+```
+
+## VERIFY
+
+`cargo build` — no new compile errors expected from the version bump.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ Any custom cache that implements `cached::ConcurrentCached`/`cached::ConcurrentC
 | Force-cache `None` returns | `#[cached(cache_none = true)] fn find(id: u64) -> Option<User>` |
 | Force-cache `Err` returns | `#[cached(cache_err = true)] fn load(id: u64) -> Result<Data, E>` |
 | Serve stale value when function returns `Err` | `#[cached(result_fallback = true, ttl = 60)] fn fetch(id: u64) -> Result<Data, E>` |
-| Per-value expiry (value carries its own TTL) | `#[cached(expires = true)] fn token(scope: String) -> Token` |
+| Per-value / dynamic per-entry TTL (value carries its own expiry) | `#[cached(expires = true)] fn token(scope: String) -> Token` |
 | Deduplicate concurrent first calls for same key | `#[cached(ttl = 30, sync_writes = "by_key")] fn expensive(id: u64) -> Payload` |
 | Async | `#[cached(max_size = 100)] async fn remote(id: u64) -> Data` |
 | **`#[once]`** | |
@@ -198,7 +198,34 @@ While standard timed stores (`TtlCache`, `LruTtlCache`, `TtlSortedCache`) enforc
 
 This approach is highly useful when caching payloads like OAuth tokens, HTTP responses with varying `Cache-Control` headers, or database records that contain their own absolute expiration timestamps.
 
+It is also the idiomatic way to give entries a **dynamic, per-entry TTL** — a lifetime computed at call time rather than the single uniform duration that `ttl = N` applies to every entry. Because the value carries its own expiry, each entry can be given a different lifetime derived from a function argument, runtime configuration, or a response header. (`expires = true` is mutually exclusive with `ttl`.) See the [`expires_per_key`](https://github.com/jaemk/cached/blob/master/examples/expires_per_key.rs) example for a runnable demonstration.
+
 When using the `#[cached]` or `#[once]` proc macros, add `expires = true` to opt into per-value expiry automatically. For `#[cached]`, this selects `ExpiringCache` (unbounded) by default or `ExpiringLruCache` when `max_size` is also specified. For `#[once]`, this stores a single value whose expiry is polled on each call.
+
+The macro form below derives each entry's TTL from a function argument — `key`/`convert` keep the TTL out of the cache key so it influences only the entry's lifetime, not which slot it occupies:
+
+```rust
+use cached::macros::cached;
+use cached::Expires;
+use cached::time::{Duration, Instant};
+
+#[derive(Clone)]
+struct Token { value: String, expires_at: Instant }
+
+impl Expires for Token {
+    fn is_expired(&self) -> bool { Instant::now() >= self.expires_at }
+}
+
+// `ttl_secs` is a runtime argument — each user's token expires on its own schedule.
+#[cached(expires = true, key = "u64", convert = "{ user_id }")]
+fn fetch_token(user_id: u64, ttl_secs: u64) -> Token {
+    Token {
+        value: format!("token-{user_id}"),
+        expires_at: Instant::now() + Duration::from_secs(ttl_secs),
+    }
+}
+# fn main() {}
+```
 
 For concurrent (multi-thread, no external lock) use, the sharded equivalents [`ShardedExpiringCache`] and [`ShardedExpiringLruCache`] provide the same per-value expiry with internally-synchronized sharded storage. Use `#[concurrent_cached(expires = true)]` to select them automatically.
 

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -708,6 +708,7 @@ fn test_mutable_args_once() {
 #[cfg(feature = "proc_macro")]
 mod expires_macro_tests {
     use cached::macros::{cached, once};
+    use cached::time::{Duration, Instant};
     use cached::{Cached, Expires};
 
     #[derive(Clone, Debug)]
@@ -718,6 +719,29 @@ mod expires_macro_tests {
     impl Expires for Val {
         fn is_expired(&self) -> bool {
             self.expired
+        }
+    }
+
+    // A value whose expiry is computed from a runtime `Duration` argument — the
+    // `#[cached]` way to get a dynamic, per-entry TTL (issue #246).
+    #[derive(Clone, Debug)]
+    struct TtlVal {
+        v: u32,
+        expires_at: Instant,
+    }
+    impl Expires for TtlVal {
+        fn is_expired(&self) -> bool {
+            Instant::now() >= self.expires_at
+        }
+    }
+
+    // `key`/`convert` keep `ttl_ms` out of the cache key so it only affects the
+    // entry's lifetime, not which slot it occupies.
+    #[cached(expires = true, key = "u32", convert = "{ k }")]
+    fn dyn_ttl(k: u32, ttl_ms: u64) -> TtlVal {
+        TtlVal {
+            v: k,
+            expires_at: Instant::now() + Duration::from_millis(ttl_ms),
         }
     }
 
@@ -817,6 +841,31 @@ mod expires_macro_tests {
         // expired entry — re-executes
         let v4 = sm_once_expires(false);
         assert!(!v4.expired);
+    }
+
+    // Regression for issue #246: a dynamic, per-entry TTL derived from a runtime
+    // argument. Two keys are inserted with different lifetimes — a 0ms TTL (already
+    // expired on the next read) and a long TTL (stays live) — so the assertions are
+    // deterministic without sleeping (time only ever moves forward).
+    #[test]
+    fn test_expires_macro_dynamic_ttl_from_arg() {
+        {
+            let mut c = DYN_TTL.write();
+            c.cache_clear();
+            c.cache_reset_metrics();
+        }
+
+        // key 1: 0ms lifetime → expires immediately. key 2: long lifetime → stays live.
+        assert_eq!(dyn_ttl(1, 0).v, 1); // miss
+        assert_eq!(dyn_ttl(2, 60_000).v, 2); // miss
+
+        // key 1's entry has expired → re-executes (no hit); key 2 is still live → hit.
+        assert_eq!(dyn_ttl(1, 0).v, 1);
+        assert_eq!(dyn_ttl(2, 60_000).v, 2);
+
+        let c = DYN_TTL.read();
+        // Only the long-TTL key produced a live hit; the 0ms key never hits.
+        assert_eq!(c.cache_hits(), Some(1));
     }
 }
 


### PR DESCRIPTION
Cuts **2.0.2** (docs and tests only, no API change).

The per-value expiry feature (`expires = true` + the `Expires` trait) already satisfies #246's dynamic / per-entry TTL request, but it wasn't framed that way in the docs and the runtime-duration-driven case was only shown in an example, never asserted.

- **`src/lib.rs`**: frame `expires = true` as the idiomatic way to get a dynamic per-entry TTL (vs. the uniform `ttl = N`), with a compiled macro doctest deriving each entry's TTL from an argument; link the `expires_per_key` example; broaden the quick-reference table row.
- **`tests/cached.rs`**: add `test_expires_macro_dynamic_ttl_from_arg`, a deterministic (no-sleep) regression for runtime-derived per-entry TTL.
- **Release**: bump `cached` to 2.0.2 (`cached_proc_macro`/`_types` unchanged), CHANGELOG entry, `docs/migrations/2.0.1-to-2.0.2.md`, regenerated README.

Refs #246