### PR TITLE
chore: update hashbrown to 0.17, criterion to 0.8, googletest to 0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Update `hashbrown` to 0.17 (internal only; not part of the public API). Dev-only: bump `criterion` to 0.8 and `googletest` to 0.14. No API or behavior change.
 
 ## [2.0.2]
 - Docs/tests only (no API change): document the `Expires` trait / `expires = true` as the idiomatic way to set a dynamic, per-entry TTL (a lifetime computed at call time rather than the uniform `ttl = N`), with a runnable example reference, and add a regression test for the runtime-argument-driven TTL case ([#246](https://github.com/jaemk/cached/issues/246)).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ path = "cached_proc_macro_types"
 optional = true
 
 [dependencies.hashbrown]
-version = "0.16"
+version = "0.17"
 default-features = false
 features = ["inline-more"]
 
@@ -108,10 +108,10 @@ version = "^1.1.0"
 
 [dev-dependencies]
 copy_dir = "0.1.3"
-googletest = "0.11.0"
+googletest = "0.14"
 tempfile = "3.10.1"
 trybuild = "1"
-criterion = "0.5"
+criterion = "0.8"
 
 [dev-dependencies.async-std]
 version = "1.6"

--- a/benches/cache_benches.rs
+++ b/benches/cache_benches.rs
@@ -4,9 +4,10 @@ use cached::{
     LruTtlCache, ShardedCache, ShardedLruCache, ShardedLruTtlCache, TtlCache, TtlSortedCache,
     UnboundCache,
 };
-use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use parking_lot::{Mutex, RwLock};
 use std::collections::HashMap;
+use std::hint::black_box;
 use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::Instant;

--- a/src/stores/disk.rs
+++ b/src/stores/disk.rs
@@ -653,7 +653,7 @@ impl<K, V> CacheTtl for DiskCache<K, V> {
 mod test_DiskCache {
     use crate::time::Duration;
     use googletest::{
-        GoogleTestSupport as _, assert_that,
+        assert_that,
         matchers::{anything, eq, none, ok, some},
     };
     use std::thread::sleep;
@@ -929,7 +929,7 @@ mod test_DiskCache {
         );
         assert_that!(
             cache.cache_get(&TEST_KEY),
-            ok(some(eq(TEST_VAL))),
+            ok(some(eq(&TEST_VAL))),
             "Getting a newly set (previously expired) key-value should return the value"
         );
 
@@ -951,12 +951,12 @@ mod test_DiskCache {
 
         assert_that!(
             cache.cache_get(&TEST_KEY),
-            ok(some(eq(TEST_VAL))),
+            ok(some(eq(&TEST_VAL))),
             "Getting a newly set (previously expired) key-value should return the value"
         );
         assert_that!(
             cache.cache_get(&TEST_KEY),
-            ok(some(eq(TEST_VAL))),
+            ok(some(eq(&TEST_VAL))),
             "Getting the same value again should return the value"
         );
     }
@@ -980,7 +980,7 @@ mod test_DiskCache {
         sleep(HALF_LIFE_SPAN);
         assert_that!(
             cache.cache_get(&TEST_KEY),
-            ok(some(eq(TEST_VAL))),
+            ok(some(eq(&TEST_VAL))),
             "Getting a value before expiry should return the value"
         );
 
@@ -988,7 +988,7 @@ mod test_DiskCache {
         sleep(HALF_LIFE_SPAN);
         assert_that!(
             cache.cache_get(&TEST_KEY),
-            ok(some(eq(TEST_VAL))),
+            ok(some(eq(&TEST_VAL))),
             "Getting a value after the initial expiry should return the value as we have refreshed"
         );
 
@@ -1121,7 +1121,7 @@ mod test_DiskCache {
                         |recovered_cache| {
                             assert_that!(
                                 recovered_cache.cache_get(&TEST_KEY),
-                                ok(some(eq(TEST_VAL))),
+                                ok(some(eq(&TEST_VAL))),
                                 "set_sync_to_disk_on_cache_change is false, and there is no auto-flushing, so the cache_remove should not have persisted"
                             );
                         },
@@ -1146,7 +1146,7 @@ mod test_DiskCache {
                         |recovered_cache| {
                             assert_that!(
                                 recovered_cache.cache_get(&TEST_KEY),
-                                ok(some(eq(TEST_VAL))),
+                                ok(some(eq(&TEST_VAL))),
                                 "Getting a set key should return the value"
                             );
                         },


### PR DESCRIPTION
Updates the dependencies that lagged a newer major/minor.

- **`hashbrown` 0.16 -> 0.17** (runtime). Used only internally (`HashTable` in `LruCache`), not part of the public API, so this is not consumer-visible or breaking.
- **`criterion` 0.5 -> 0.8** (dev/bench only). Switched the benches off the now-deprecated `criterion::black_box` to `std::hint::black_box`.
- **`googletest` 0.11 -> 0.14** (dev/test only). No test changes needed.

All tests pass (256 + 184 + 30 doctests, 0 failures), clippy is clean across all targets, and the benches compile without warnings.

Note: `criterion 0.8` requires Rust 1.86 to build, but as a dev-dependency it does not affect the published MSRV (1.85). CI runs on 1.96.

No API or behavior change.