### PR TITLE
release: 3.0.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## [Unreleased]
-> Staged for the next major release (not yet cut). See the [unreleased migration guide](docs/migrations/2.0-to-unreleased.md).
+
+## [3.0.0-rc.1] - 2026-06-21
+> First 3.0 release candidate. The 3.0 API is not final and may change before the 3.0.0 release. See the [migration guide](docs/migrations/2.0-to-unreleased.md).
 
 ### Breaking Changes
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cached"
-version = "2.0.2"
+version = "3.0.0-rc.1"
 authors = ["James Kominick <james@kominick.com>"]
 description = "Generic cache implementations and simplified function memoization"
 repository = "https://github.com/jaemk/cached"
@@ -48,12 +48,12 @@ redb_store = ["redb", "serde", "rmp-serde", "directories"]
 time_stores = []
 
 [dependencies.cached_proc_macro]
-version = "2.0.0"
+version = "3.0.0-rc.1"
 path = "cached_proc_macro"
 optional = true
 
 [dependencies.cached_proc_macro_types]
-version = "1.0.0"
+version = "3.0.0-rc.1"
 path = "cached_proc_macro_types"
 optional = true
 

--- a/cached_proc_macro/Cargo.toml
+++ b/cached_proc_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cached_proc_macro"
-version = "2.0.0"
+version = "3.0.0-rc.1"
 authors = ["csos95 <csoscss@gmail.com>", "James Kominick <james@kominick.com>"]
 description = "Generic cache implementations and simplified function memoization"
 repository = "https://github.com/jaemk/cached"

--- a/cached_proc_macro_types/Cargo.toml
+++ b/cached_proc_macro_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cached_proc_macro_types"
-version = "1.0.0"
+version = "3.0.0-rc.1"
 authors = ["James Kominick <james@kominick.com>"]
 description = "Types used by the cached proc-macro crate"
 repository = "https://github.com/jaemk/cached"


### PR DESCRIPTION
Cuts the first 3.0 release candidate.

- bump `cached`, `cached_proc_macro`, and `cached_proc_macro_types` to `3.0.0-rc.1` (lockstep), and update the root's internal version requirements.
- add a `3.0.0-rc.1` CHANGELOG section; the entries are the staged 3.0 changes from #272.

The 3.0 API is not final and may change before `3.0.0`. This rc is for downstream testing.

Note: merging to `master` triggers `bin/publish.sh`, which publishes all three crates to crates.io (types -> proc_macro -> root) and tags the release. `cargo publish --dry-run` passes for both subcrates.
