### PR TITLE
v3 API changes, security hardening, and macro guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,102 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+
+#### `capacity()` builder method renamed to `initial_capacity()` on allocation-hint builders
+- `UnboundCacheBuilder`, `TtlCacheBuilder`, `TtlSortedCacheBuilder`, and `ExpiringCacheBuilder`
+  had a `.capacity(n)` method that pre-allocates the backing `HashMap` without bounding entry
+  count. The name was ambiguous next to `.max_size(n)` (the eviction bound on the LRU builders).
+  It is now `.initial_capacity(n)`.
+- **Migration:** rename `.capacity(n)` to `.initial_capacity(n)` on those four builders.
+  `max_size` on the LRU builders is unchanged.
+
+#### `Return<T>` fields are now private (`cached_proc_macro_types`)
+- `Return<T>::value` and `Return<T>::was_cached` are now private fields. Code that accessed
+  them directly no longer compiles.
+- **Migration:** use `*r` / `r.into_inner()` to get the inner value and `r.was_cached()` for
+  the flag. Pattern-matching on the struct fields (`Return { value, was_cached }`) must switch
+  to the accessor methods.
+
+#### `set_max_size` returns `Option<usize>` on LRU stores
+- `LruCache::set_max_size`, `LruTtlCache::set_max_size`, and `ExpiringLruCache::set_max_size`
+  now return `Option<usize>` (the previous bound) instead of `usize`, matching
+  `TtlSortedCache::set_max_size` and unifying the return type across all four stores.
+- **Migration:** the returned value is now wrapped in `Some(..)`; update any pattern or type
+  annotation that expected a bare `usize`.
+
+#### ahash default hasher enables `runtime-rng` on non-wasm targets
+- The `ahash` feature now enables the `ahash/runtime-rng` sub-feature on non-wasm targets,
+  seeding hash maps from the OS RNG at startup. Previously ahash used a compile-time seed,
+  which left hash maps vulnerable to hash-flood denial-of-service attacks.
+- No source change is required. On wasm32 targets `runtime-rng` is not enabled (it would
+  require a `getrandom` backend); the compile-time seed is kept there.
+- **Migration:** transparent to code. No rename or API change. wasm targets using `ahash`
+  retain compile-time seeding; non-wasm targets get OS-seeded hashing automatically.
+
+### Security
+
+#### redb: cache directory and file permissions hardened (Unix)
+- The cache directory is now created with mode `0700` and the redb database file with mode
+  `0600` on Unix, preventing other local users from reading cached data.
+- The system-temp-dir fallback path is rejected if it resolves to a symlink or is
+  group/world-writable, closing a symlink-attack and shared-temp-dir interception vector.
+
+#### Redis: credential and error hardening
+- Connection-string parse errors no longer include the URL or embedded password in the error
+  message, preventing accidental credential leakage in logs.
+- The legacy-JSON backward-read fallback now requires the exact version field value; a JSON
+  object without the precise version marker is not treated as a cached entry.
+- Client-side caching (`redis_async_cache`) rejects a connection URL that pins RESP2 (via the
+  `?protocol=resp2` query parameter); RESP2 does not support client-side invalidation messages,
+  so accepting it would silently serve stale data.
+- `RedbCacheError::CacheDeserialization` and `RedisCacheError::CacheDeserialization` are
+  documented as potentially sensitive (the `cached_value` bytes field may contain raw
+  application data); callers should not log the full error in production.
+
+### Fixed
+
+#### `LruCache::cache_reset` no longer risks allocation panic after `set_max_size` grows the bound
+- After `set_max_size` increased the capacity, a subsequent `cache_reset` could request a
+  `HashMap` capacity larger than `isize::MAX / mem::size_of::<Entry>()`, causing an allocation
+  panic. `cache_reset` now uses a fallible allocation path.
+
+#### `lru_list::with_capacity` uses saturating arithmetic
+- Internal LRU list pre-allocation used unchecked arithmetic that could overflow on extreme
+  capacity values. The computation now saturates.
+
+### Changed
+
+#### `#[once]` emits a clear compile error when the value type names a function generic parameter
+- Previously using `#[once]` with a value type that referenced a generic parameter of the
+  annotated function produced a confusing downstream error. The macro now emits a clear
+  compile-time diagnostic explaining that `#[once]` requires a concrete value type (generics
+  are supported only when the value type itself does not reference a generic parameter).
+- The docs are corrected to state that generics are supported only with a concrete value type.
+
+#### Reserved name prefix `__cached` enforced across all three macros
+- `#[cached]`, `#[once]`, and `#[concurrent_cached]` now reject a `name` attribute that starts
+  with `__cached` (the prefix reserved for generated bindings).
+
+#### `#[once]` rejects `sync_writes_buckets`
+- `sync_writes_buckets` is inert on `#[once]` (which has no per-key lock). The macro now
+  emits a clear error instead of silently ignoring the attribute.
+
+#### Generated by-key lock bindings renamed to the `__cached_` hygiene convention
+- Internal generated bindings used by the per-key (`by_key`) lock path are renamed to follow
+  the `__cached_` prefix, consistent with the rest of the generated hygiene convention
+  introduced in the main rc.1 batch.
+
+#### Documentation corrections
+- `#[cached]` `sync_writes` default is documented as `"by_key"` (was incorrectly documented
+  as `false`).
+- `refresh = true` requiring a TTL is noted at the attribute documentation.
+- `ty` / `expires` interaction is documented.
+- Sharded store `len` / `metrics` are documented as approximate (may include expired entries).
+- Several method-doc and inline comment fixes.
+- `#[must_use]` added to `CacheEvict::evict`.
+- Macro error messages aligned for consistency.
+
 ## [3.0.0-rc.1] - 2026-06-21
 > First 3.0 release candidate. The 3.0 API is not final and may change before the 3.0.0 release. See the [migration guide](docs/migrations/2.0-to-unreleased.md).
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,18 @@ version = "0.8"
 default-features = false
 optional = true
 
+# On non-wasm targets, enable runtime-rng so RandomState seeds from the OS RNG
+# (closes a hash-flood DoS gap). On wasm32-unknown-unknown, getrandom has no
+# usable backend unless the caller wires up wasm_js, so we leave runtime-rng
+# out there. Cargo additively merges features across target-gated and
+# unconditional sections for the same dep, so non-wasm gets runtime-rng while
+# wasm falls back to compile-time seeding only.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.ahash]
+version = "0.8"
+default-features = false
+features = ["runtime-rng"]
+optional = true
+
 
 [dependencies.redis]
 version = "1.0"

--- a/cached_proc_macro/src/cached.rs
+++ b/cached_proc_macro/src/cached.rs
@@ -340,7 +340,7 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
     if args.time.is_some() {
         return syn::Error::new(
             fn_ident.span(),
-            "`time` (whole seconds) was renamed in cached 1.0; use `ttl_secs = ...` \
+            "`time` was renamed in a prior major release; use `ttl_secs = ...` \
              (or `ttl = \"Duration::from_secs(...)\"` / `ttl_millis = ...`)",
         )
         .to_compile_error()
@@ -350,7 +350,7 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
     if args.time_refresh.is_some() {
         return syn::Error::new(
             fn_ident.span(),
-            "`time_refresh` was renamed to `refresh` in cached 1.0; use `refresh = ...`",
+            "`time_refresh` was renamed in a prior major release; use `refresh = ...`",
         )
         .to_compile_error()
         .into();
@@ -565,6 +565,16 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
                     .to_compile_error()
                     .into();
             }
+            // G2: `__cached` prefix is reserved for macro-generated bindings.
+            if name.starts_with("__cached") {
+                return syn::Error::new(
+                    fn_ident.span(),
+                    "cache names beginning with `__cached` are reserved for macro-generated \
+                     bindings and cannot be used as a `name` value",
+                )
+                .to_compile_error()
+                .into();
+            }
             Ident::new(name, fn_ident.span())
         }
         None => Ident::new(&fn_ident.to_string().to_uppercase(), fn_ident.span()),
@@ -677,7 +687,7 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
             let set_cache_block =
                 quote! { __cached_cache.cache_set(__cached_key, __cached_result.clone()); };
             let return_cache_block = if args.with_cached_flag {
-                quote! { let mut __cached_r = __cached_result.to_owned(); __cached_r.was_cached = true; return __cached_r }
+                quote! { let mut __cached_r = __cached_result.to_owned(); __cached_r.set_was_cached(true); return __cached_r }
             } else {
                 quote! { return __cached_result.to_owned() }
             };
@@ -690,7 +700,7 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
                 }
             };
             let return_cache_block = if args.with_cached_flag {
-                quote! { let mut __cached_r = __cached_result.to_owned(); __cached_r.was_cached = true; return Ok(__cached_r) }
+                quote! { let mut __cached_r = __cached_result.to_owned(); __cached_r.set_was_cached(true); return Ok(__cached_r) }
             } else {
                 quote! { return Ok(__cached_result.to_owned()) }
             };
@@ -703,9 +713,9 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
                 }
             };
             let return_cache_block = if args.with_cached_flag {
-                quote! { let mut __cached_r = __cached_result.to_owned(); __cached_r.was_cached = true; return Some(__cached_r) }
+                quote! { let mut __cached_r = __cached_result.to_owned(); __cached_r.set_was_cached(true); return Some(__cached_r) }
             } else {
-                quote! { return Some(__cached_result.clone()) }
+                quote! { return Some(__cached_result.to_owned()) }
             };
             (set_cache_block, return_cache_block)
         }

--- a/cached_proc_macro/src/concurrent_cached.rs
+++ b/cached_proc_macro/src/concurrent_cached.rs
@@ -280,7 +280,7 @@ pub fn concurrent_cached(args: TokenStream, input: TokenStream) -> TokenStream {
     if args.time.is_some() {
         return syn::Error::new(
             fn_ident.span(),
-            "`time` (whole seconds) was renamed in cached 1.0; use `ttl_secs = ...` \
+            "`time` was renamed in a prior major release; use `ttl_secs = ...` \
              (or `ttl = \"Duration::from_secs(...)\"` / `ttl_millis = ...`)",
         )
         .to_compile_error()
@@ -290,7 +290,7 @@ pub fn concurrent_cached(args: TokenStream, input: TokenStream) -> TokenStream {
     if args.time_refresh.is_some() {
         return syn::Error::new(
             fn_ident.span(),
-            "`time_refresh` was renamed to `refresh` in cached 1.0; use `refresh = ...`",
+            "`time_refresh` was renamed in a prior major release; use `refresh = ...`",
         )
         .to_compile_error()
         .into();
@@ -686,6 +686,16 @@ pub fn concurrent_cached(args: TokenStream, input: TokenStream) -> TokenStream {
                     .to_compile_error()
                     .into();
             }
+            // G2: `__cached` prefix is reserved for macro-generated bindings.
+            if name.starts_with("__cached") {
+                return syn::Error::new(
+                    fn_ident.span(),
+                    "cache names beginning with `__cached` are reserved for macro-generated \
+                     bindings and cannot be used as a `name` value",
+                )
+                .to_compile_error()
+                .into();
+            }
             Ident::new(name, fn_ident.span())
         }
         None => Ident::new(&fn_ident.to_string().to_uppercase(), fn_ident.span()),
@@ -981,32 +991,32 @@ pub fn concurrent_cached(args: TokenStream, input: TokenStream) -> TokenStream {
     // make the set cache and return cache blocks
     let (set_cache_block, return_cache_block) = if with_cached_flag_result {
         // Result<Return<T>, E>: cache the inner T from Ok(Return<T>).
-        let set = set_call(quote! { &__cached_inner.value });
+        let set = set_call(quote! { &**__cached_inner });
         (
             quote! {
                 if let Ok(__cached_inner) = &__cached_result {
                     #set
                 }
             },
-            quote! { let mut __cached_r = #krate::Return::new(__cached_result); __cached_r.was_cached = true; return Ok(__cached_r) },
+            quote! { let mut __cached_r = #krate::Return::new(__cached_result); __cached_r.set_was_cached(true); return Ok(__cached_r) },
         )
     } else if with_cached_flag_option {
         // Option<Return<T>>: cache the inner T from Some(Return<T>), skip None.
-        let set = set_call(quote! { &__cached_inner.value });
+        let set = set_call(quote! { &**__cached_inner });
         (
             quote! {
                 if let Some(__cached_inner) = &__cached_result {
                     #set
                 }
             },
-            quote! { let mut __cached_r = #krate::Return::new(__cached_result); __cached_r.was_cached = true; return Some(__cached_r) },
+            quote! { let mut __cached_r = #krate::Return::new(__cached_result); __cached_r.set_was_cached(true); return Some(__cached_r) },
         )
     } else if args.with_cached_flag {
         // Plain Return<T>: cache the inner T directly.
-        let set = set_call(quote! { &__cached_result.value });
+        let set = set_call(quote! { &*__cached_result });
         (
             set,
-            quote! { let mut __cached_r = #krate::Return::new(__cached_result); __cached_r.was_cached = true; return __cached_r },
+            quote! { let mut __cached_r = #krate::Return::new(__cached_result); __cached_r.set_was_cached(true); return __cached_r },
         )
     } else if is_smart_result {
         // Result<T, E> return type: cache only Ok(T), skip Err
@@ -1698,7 +1708,7 @@ fn get_custom_cache_type_and_create(
         None => {
             return Err(syn::Error::new(
                 fn_ident.span(),
-                "#[concurrent_cached] cache `ty` must be specified",
+                "`create` requires `ty` to also be set",
             ));
         }
     };
@@ -1710,7 +1720,7 @@ fn get_custom_cache_type_and_create(
         None => {
             return Err(syn::Error::new(
                 fn_ident.span(),
-                "#[concurrent_cached] cache `create` block must be specified",
+                "`ty` requires `create` to also be set",
             ));
         }
     };

--- a/cached_proc_macro/src/helpers.rs
+++ b/cached_proc_macro/src/helpers.rs
@@ -260,7 +260,11 @@ pub(super) fn by_key_lock_block(
     await_if_async: TokenStream2,
 ) -> TokenStream2 {
     quote! {
-        let lock = {
+        // G3: renamed from `lock` / `_key_lock` to `__cached_bucket_lock` /
+        // `__cached_key_lock` to match the `__cached_` hygiene convention and
+        // eliminate the shadow window against user-defined `lock` / `_key_lock`
+        // bindings.
+        let __cached_bucket_lock = {
             use std::hash::{Hash, Hasher};
             // DefaultHasher is used for bucket selection only. It is not cryptographic and
             // has no cross-version stability guarantees, but only within-process consistency
@@ -269,7 +273,7 @@ pub(super) fn by_key_lock_block(
             #key.hash(&mut hasher);
             #locks[(hasher.finish() as usize) % #locks.len()].clone()
         };
-        let _key_lock = lock.#lock_method()#await_if_async;
+        let __cached_key_lock = __cached_bucket_lock.#lock_method()#await_if_async;
     }
 }
 

--- a/cached_proc_macro/src/lib.rs
+++ b/cached_proc_macro/src/lib.rs
@@ -23,6 +23,8 @@ use proc_macro::TokenStream;
 ///   in-memory store, so sub-second TTLs are honored exactly; a custom `ty`/`create` store honors them
 ///   only if that store itself supports sub-second granularity.
 /// - `refresh`: (optional, bool) specify whether to refresh the TTL on cache hits.
+///   Requires a TTL (`ttl`, `ttl_secs`, or `ttl_millis`); setting `refresh = true` without a TTL
+///   is a compile error.
 /// - `force_refresh`: (optional, expression block) a boolean expression over the function arguments,
 ///   written in curly braces like `convert` (it is evaluated, not a magic flag and not a required
 ///   bool parameter). When it evaluates to `true`, any cached value is bypassed and the function body
@@ -54,9 +56,12 @@ use proc_macro::TokenStream;
 ///   origin function) is still generated and inherits the method's visibility, so a `pub` cached
 ///   method exposes a `pub {fn}_no_cache` cache-bypass sibling on the same `impl`.
 /// - `sync_writes`: (optional, bool or string) specify whether to synchronize the execution and writing of uncached values.
-///   When not specified or set to `false`, uncached calls execute without write synchronization. When set to `true`
-///   or `"default"`, all keys synchronize by locking the whole cache during uncached execution. When set to
-///   `"by_key"`, a per-key lock synchronizes uncached execution of duplicate keys only.
+///   **Default: `"by_key"`** - when not specified, a per-key lock synchronizes concurrent uncached
+///   calls for the same key (duplicate first-call serialization). When set to `false` or
+///   `"disabled"`, synchronization is disabled entirely and concurrent uncached calls for the same key
+///   may all execute and overwrite each other. When set to `true` or `"default"`, all keys
+///   synchronize by locking the whole cache during uncached execution. When set to `"by_key"`,
+///   the same per-key behavior as the default is applied explicitly.
 /// - `sync_writes_buckets`: (optional, usize) number of per-key lock buckets used by
 ///   `sync_writes = "by_key"`; defaults to 64. Each bucket is one `Arc<RwLock<()>>`. Keys
 ///   hash into a bucket, so two different keys may share a bucket and serialize unnecessarily
@@ -73,6 +78,8 @@ use proc_macro::TokenStream;
 ///   When `ttl` is specified, defaults to `TtlCache`.
 ///   When `max_size` and `ttl` are specified, defaults to `LruTtlCache`. When `ty` is
 ///   specified, `create` must also be specified.
+///   Setting `expires = true` auto-selects `ExpiringCache` (unbounded) or `ExpiringLruCache`
+///   (when `max_size` is also set); `expires` is mutually exclusive with `ty`.
 /// - `create`: (optional, string expr) specify an expression used to create a new cache store, e.g. `create = r##"{ CacheType::new() }"##`.
 /// - `key`: (optional, string type) specify what type to use for the cache key, e.g. `key = "u32"`.
 ///   When `key` is specified, `convert` must also be specified.
@@ -89,13 +96,13 @@ use proc_macro::TokenStream;
 ///   `Option` is the cache hit/miss, the inner `Option` is the stored value.
 /// - `with_cached_flag`: (optional, bool) If your function returns a `cached::Return`,
 ///   `Result<cached::Return<T>, E>`, or `Option<cached::Return<T>>`,
-///   the `cached::Return.was_cached` flag will be updated when a cached value is returned.
+///   the `cached::Return.was_cached()` flag will be updated when a cached value is returned.
 ///   The wrapper type **must** be `cached::Return` - either written fully
 ///   qualified, or imported from `cached` (`use cached::Return;`). A proc macro
 ///   only sees tokens, not resolved types: an unrelated type that merely happens
 ///   to be named `Return<T>` passes the attribute check but then fails to
 ///   compile in the generated body (it calls `::cached::Return::new` /
-///   `.was_cached`). Use a different name for any non-`cached` `Return` type.
+///   `.set_was_cached`). Use a different name for any non-`cached` `Return` type.
 /// - `result_fallback`: (optional, bool) If your function returns a `Result` and it fails, the cache will instead refresh the recently expired `Ok` value.
 ///   In other words, refreshes are best-effort - returning `Ok` refreshes as usual but `Err` falls back to the last `Ok`.
 ///   This is useful, for example, for keeping the last successful result of a network operation even during network disconnects.
@@ -170,20 +177,22 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
 ///   (the uncached origin function) is still generated and inherits the method's visibility, so a
 ///   `pub` cached method exposes a `pub {fn}_no_cache` cache-bypass sibling on the same `impl`.
 /// - `sync_writes`: (optional, bool or string) specify whether to synchronize the execution of writing of uncached values.
-///   When set to `true` or `"default"`, uncached execution is synchronized with the whole cache.
-///   When omitted or set to `false`, uncached calls are not synchronized. `sync_writes = "by_key"`
-///   is not supported by `#[once]` because a `#[once]` cache stores a single value for all arguments.
+///   **Default: `"disabled"`** - when not specified, uncached calls are not synchronized.
+///   When set to `true` or `"default"`, uncached execution is synchronized by locking the whole
+///   cache. When set to `false` or `"disabled"`, uncached calls are explicitly unsynchronized.
+///   `sync_writes = "by_key"` is not supported by `#[once]` because a `#[once]` cache stores a
+///   single value for all arguments.
 /// - `cache_err`: (optional, bool) If your function returns a `Result`, also cache `Err` values (by default only `Ok` is cached).
 /// - `cache_none`: (optional, bool) If your function returns an `Option`, also cache `None` values (by default only `Some` is cached).
 /// - `with_cached_flag`: (optional, bool) If your function returns a `cached::Return`,
 ///   `Result<cached::Return<T>, E>`, or `Option<cached::Return<T>>`,
-///   the `cached::Return.was_cached` flag will be updated when a cached value is returned.
+///   the `cached::Return.was_cached()` flag will be updated when a cached value is returned.
 ///   The wrapper type **must** be `cached::Return` - either written fully
 ///   qualified, or imported from `cached` (`use cached::Return;`). A proc macro
 ///   only sees tokens, not resolved types: an unrelated type that merely happens
 ///   to be named `Return<T>` passes the attribute check but then fails to
 ///   compile in the generated body (it calls `::cached::Return::new` /
-///   `.was_cached`). Use a different name for any non-`cached` `Return` type.
+///   `.set_was_cached`). Use a different name for any non-`cached` `Return` type.
 /// - `expires`: (optional, bool) Delegate expiry to the cached value instead of a fixed TTL.
 ///   The return type must implement `Expires`; for `Result<T, E>` or `Option<T>` returns, the inner `T` must implement `Expires`.
 ///   When a lookup finds the cached value reports `is_expired() == true`, the cached value is
@@ -198,8 +207,11 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
 /// is treated as a plain return value and its `Err` / `None` will be cached. Return
 /// `Result<T, E>` / `Option<T>` directly when you need the default Ok-only / Some-only behavior.
 ///
-/// **Generic functions are supported** by `#[once]`: its static only holds the (concrete) value
-/// type, never the function's type parameters, so no `key`/`convert` is required.
+/// **Generic functions** are supported by `#[once]` only when the cached value type is concrete
+/// (does not name the function's type parameters). The static holds one value of a fixed type;
+/// if the inferred value type references a type parameter, the macro emits a compile error.
+/// In that case, annotate the return type concretely (e.g. via a trait object or newtype) or use
+/// a non-generic wrapper function. No `key`/`convert` is required.
 #[proc_macro_attribute]
 pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
     once::once(args, input)
@@ -332,7 +344,7 @@ pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
 ///   by default (implicit smart-option), and the inner `T` (not `Option<T>`)
 ///   must implement `Expires`. When a cached entry is found but `is_expired()` returns `true`,
 ///   the function re-executes and the result is treated as a fresh uncached value; the returned
-///   `Return<T>` will have `was_cached = false` in this case.
+///   `Return<T>` will have `was_cached()` returning `false` in this case.
 /// - `ty`: (optional, string type) explicitly specify the cache store type to use.
 /// - `cache_prefix_block`: (optional, string expr) specify an expression used to create the string used as a
 ///   prefix for all cache keys of this function, e.g. `cache_prefix_block = r##"{ "my_prefix" }"##`.
@@ -376,13 +388,13 @@ pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
 ///   default key already satisfies this, so it only matters with a custom non-`Clone` `key`/`convert`.
 /// - `with_cached_flag`: (optional, bool) If your function returns a `cached::Return`,
 ///   `Result<cached::Return<T>, E>`, or `Option<cached::Return<T>>`, the
-///   `cached::Return.was_cached` flag will be updated when a cached value is returned.
+///   `cached::Return.was_cached()` flag will be updated when a cached value is returned.
 ///   The wrapper type **must** be `cached::Return` - either written fully
 ///   qualified, or imported from `cached` (`use cached::Return;`). A proc macro
 ///   only sees tokens, not resolved types: an unrelated type that merely happens
 ///   to be named `Return<T>` passes the attribute check but then fails to
 ///   compile in the generated body (it calls `::cached::Return::new` /
-///   `.was_cached`). Use a different name for any non-`cached` `Return` type.
+///   `.set_was_cached`). Use a different name for any non-`cached` `Return` type.
 /// - `disk_dir`: (optional, string) in the case of `RedbCache` specify the directory in which the redb
 ///   database file is stored. Defaults to a system cache directory. Requires `disk = true`; mutually
 ///   exclusive with `create`. Using it on the in-memory or `redis` path is a compile error.

--- a/cached_proc_macro/src/once.rs
+++ b/cached_proc_macro/src/once.rs
@@ -29,8 +29,12 @@ struct OnceMacroArgs {
     /// `None` = not specified by user (defaults to `Disabled` for `#[once]`).
     #[darling(default)]
     sync_writes: Option<SyncWriteMode>,
-    #[darling(default = "default_sync_writes_buckets")]
-    sync_writes_buckets: usize,
+    /// D11: On `#[once]`, `sync_writes_buckets` is inert (buckets only apply to
+    /// `sync_writes = "by_key"`, which `#[once]` does not support). The field is
+    /// `Option<usize>` so the macro can detect whether the user explicitly supplied
+    /// it and emit a clear error, rather than silently ignoring the value.
+    #[darling(default)]
+    sync_writes_buckets: Option<usize>,
     #[darling(default)]
     cache_err: bool,
     #[darling(default)]
@@ -82,10 +86,6 @@ struct OnceMacroArgs {
     key: Option<String>,
     #[darling(default)]
     convert: Option<syn::Expr>,
-}
-
-fn default_sync_writes_buckets() -> usize {
-    64
 }
 
 pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
@@ -156,15 +156,14 @@ pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
         .into();
     }
 
-    // Note: `#[once]` supports generic functions. Its static only holds the
-    // (concrete) value type, never the function's type parameters, so no
-    // generic-rejection check is needed here (unlike `#[cached]` /
-    // `#[concurrent_cached]`, whose key/value types can leak generics) (#80).
+    // Note: `#[once]` supports generic functions, but only when the cache value
+    // type is concrete (does not name any of the function's own type or const
+    // params). The guard below (after `cache_value_ty` is resolved) enforces this.
 
     if args.time.is_some() {
         return syn::Error::new(
             fn_ident.span(),
-            "`time` (whole seconds) was renamed in cached 1.0; use `ttl_secs = ...` \
+            "`time` was renamed in a prior major release; use `ttl_secs = ...` \
              (or `ttl = \"Duration::from_secs(...)\"` / `ttl_millis = ...`)",
         )
         .to_compile_error()
@@ -421,6 +420,45 @@ pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
         Err(e) => return e.to_compile_error().into(),
     };
 
+    // G1: Reject a generic `#[once]` whose cache value type names one of the
+    // function's own type or const parameters. The cache static is
+    // monomorphic, so it cannot contain a bare type/const param in its type.
+    // A generic `#[once]` is fine as long as the value type is concrete
+    // (e.g. `fn foo<T>(x: T) -> usize` is allowed; `fn foo<T>() -> T` is not).
+    {
+        let generic_param_idents: Vec<String> = signature
+            .generics
+            .type_params()
+            .map(|tp| tp.ident.to_string())
+            .chain(
+                signature
+                    .generics
+                    .const_params()
+                    .map(|cp| cp.ident.to_string()),
+            )
+            .collect();
+        if !generic_param_idents.is_empty() {
+            let value_ty_str = cache_value_ty.to_string().replace(' ', "");
+            if let Some(param) = generic_param_idents
+                .iter()
+                .find(|p| value_ty_str.contains(p.as_str()))
+            {
+                return syn::Error::new(
+                    fn_ident.span(),
+                    format!(
+                        "#[once]'s cache value type cannot name the function's generic \
+                         parameter `{param}`: the generated cache static is monomorphic \
+                         and cannot hold a value of a type that names a function-level \
+                         type or const parameter. Make the return type concrete, or use \
+                         `#[cached]` with `key`/`convert` to handle generic functions.",
+                    ),
+                )
+                .to_compile_error()
+                .into();
+            }
+        }
+    }
+
     // make the cache identifier
     let cache_ident = match args.name {
         Some(ref name) => {
@@ -429,13 +467,32 @@ pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
                     .to_compile_error()
                     .into();
             }
+            // G2: `__cached` prefix is reserved for macro-generated bindings.
+            if name.starts_with("__cached") {
+                return syn::Error::new(
+                    fn_ident.span(),
+                    "cache names beginning with `__cached` are reserved for macro-generated \
+                     bindings and cannot be used as a `name` value",
+                )
+                .to_compile_error()
+                .into();
+            }
             Ident::new(name, fn_ident.span())
         }
         None => Ident::new(&fn_ident.to_string().to_uppercase(), fn_ident.span()),
     };
 
-    if let Err(error) = validate_sync_writes_buckets(args.sync_writes_buckets, fn_ident.span()) {
-        return error.to_compile_error().into();
+    // D11: `sync_writes_buckets` is inert on `#[once]` — buckets only apply to
+    // `sync_writes = "by_key"`, which `#[once]` does not support. Reject an
+    // explicitly supplied value with a clear error rather than silently ignoring it.
+    if args.sync_writes_buckets.is_some() {
+        return syn::Error::new(
+            fn_ident.span(),
+            "`sync_writes_buckets` is not supported on `#[once]`: buckets only apply \
+             to `sync_writes = \"by_key\"`, which `#[once]` does not support",
+        )
+        .to_compile_error()
+        .into();
     }
     if sync_writes == SyncWriteMode::ByKey {
         return syn::Error::new(
@@ -445,7 +502,10 @@ pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
         .to_compile_error()
         .into();
     }
-    let sync_writes_buckets = args.sync_writes_buckets;
+    // `sync_writes_buckets` is unused on `#[once]` (no `by_key` path), but the
+    // static generator still references the binding for the (rejected) `is_by_key`
+    // branch below; provide the default so the branches compile.
+    let sync_writes_buckets = 64_usize;
 
     // `has_ttl` / `ttl_duration` were resolved above (from `ttl` expr, `ttl_secs`,
     // or `ttl_millis`); `has_ttl` gates the timestamped storage shape (#149).
@@ -484,7 +544,7 @@ pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
             };
 
             let return_cache_block = if args.with_cached_flag {
-                quote! { let mut __cached_r = __cached_result.clone(); __cached_r.was_cached = true; return __cached_r }
+                quote! { let mut __cached_r = __cached_result.clone(); __cached_r.set_was_cached(true); return __cached_r }
             } else {
                 quote! { return __cached_result.clone() }
             };
@@ -512,7 +572,7 @@ pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
             };
 
             let return_cache_block = if args.with_cached_flag {
-                quote! { let mut __cached_r = __cached_result.clone(); __cached_r.was_cached = true; return Ok(__cached_r) }
+                quote! { let mut __cached_r = __cached_result.clone(); __cached_r.set_was_cached(true); return Ok(__cached_r) }
             } else {
                 quote! { return Ok(__cached_result.clone()) }
             };
@@ -540,7 +600,7 @@ pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
             };
 
             let return_cache_block = if args.with_cached_flag {
-                quote! { let mut __cached_r = __cached_result.clone(); __cached_r.was_cached = true; return Some(__cached_r) }
+                quote! { let mut __cached_r = __cached_result.clone(); __cached_r.set_was_cached(true); return Some(__cached_r) }
             } else {
                 quote! { return Some(__cached_result.clone()) }
             };

--- a/cached_proc_macro_types/src/lib.rs
+++ b/cached_proc_macro_types/src/lib.rs
@@ -1,8 +1,8 @@
 /// Used to wrap a function result so callers can see whether the result was cached.
 #[derive(Clone, Debug)]
 pub struct Return<T> {
-    pub was_cached: bool,
-    pub value: T,
+    was_cached: bool,
+    value: T,
 }
 
 impl<T> Return<T> {
@@ -11,6 +11,21 @@ impl<T> Return<T> {
             was_cached: false,
             value,
         }
+    }
+
+    /// Returns `true` if the value came from the cache.
+    pub fn was_cached(&self) -> bool {
+        self.was_cached
+    }
+
+    /// Sets the `was_cached` flag. Used by generated macro code.
+    pub fn set_was_cached(&mut self, was_cached: bool) {
+        self.was_cached = was_cached;
+    }
+
+    /// Consumes `self` and returns the inner value.
+    pub fn into_inner(self) -> T {
+        self.value
     }
 }
 
@@ -25,5 +40,44 @@ impl<T> std::ops::Deref for Return<T> {
 impl<T> std::ops::DerefMut for Return<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_sets_was_cached_false() {
+        let r = Return::new(42u32);
+        assert!(!r.was_cached());
+    }
+
+    #[test]
+    fn set_was_cached_updates_flag() {
+        let mut r = Return::new(42u32);
+        r.set_was_cached(true);
+        assert!(r.was_cached());
+    }
+
+    #[test]
+    fn into_inner_returns_owned_value() {
+        let r = Return::new(String::from("hello"));
+        let v = r.into_inner();
+        assert_eq!(v, "hello");
+    }
+
+    #[test]
+    fn deref_accesses_inner_value() {
+        let r = Return::new(String::from("world"));
+        assert_eq!(*r, "world");
+        assert_eq!(r.to_uppercase(), "WORLD");
+    }
+
+    #[test]
+    fn deref_mut_allows_mutation() {
+        let mut r = Return::new(vec![1u32, 2, 3]);
+        r.push(4);
+        assert_eq!(*r, vec![1, 2, 3, 4]);
     }
 }

--- a/docs/migrations/1.1-to-2.0-human.md
+++ b/docs/migrations/1.1-to-2.0-human.md
@@ -238,6 +238,19 @@ let c = LruCache::builder().max_size(100).build();
 let c = LruCache::builder().max_size(100).build()?;
 ```
 
+**Inside a `#[cached(create = ...)]` block, use `.unwrap()`, not `?`.** The `create` expression
+runs inside a `LazyLock` closure that returns the store directly, so `?` does not compile there:
+
+```rust
+// Wrong -- ? does not compile inside a create block:
+#[cached(ty = "LruCache<String, usize>", create = "{ LruCache::builder().max_size(100).build()? }")]
+fn f(a: String) -> usize { ... }
+
+// Correct:
+#[cached(ty = "LruCache<String, usize>", create = "{ LruCache::builder().max_size(100).build().unwrap() }")]
+fn f(a: String) -> usize { ... }
+```
+
 **The `.size(n)` builder setter is renamed to `.max_size(n)`** to make clear it sets the
 eviction bound, not a current count. This affects all LRU-family builders and `TtlSortedCache`.
 

--- a/docs/migrations/2.0-to-unreleased.md
+++ b/docs/migrations/2.0-to-unreleased.md
@@ -1001,6 +1001,97 @@ in a hot path), recreate the cache with the same builder settings instead of cal
 - `#[cached]` / `#[once]` now reject the concurrent-store-only attributes `disk`, `redis`, and `map_error` with a clear error pointing to `#[concurrent_cached]`, instead of darling's generic "Unknown field" message. No change to which attributes are accepted.
 - `len` / `cache_size` / `iter` / `evict` contract on lazy-eviction stores is now documented in one place: `len` / `cache_size` returns the stored count without scanning for expiry (so it may include expired entries), `iter` omits expired entries from the view without removing them, and `evict()` physically reclaims expired entries (and is how to obtain an accurate live count). Behavior is unchanged; see the `CachedIter` and `CacheEvict` docs.
 
+## Post-rc.1 breaking changes
+
+These four changes were made after the 3.0.0-rc.1 tag and will be in the 3.0.0 final release.
+
+### 50. `capacity()` renamed to `initial_capacity()` on allocation-hint builders
+
+The `.capacity(n)` builder method on `UnboundCacheBuilder`, `TtlCacheBuilder`,
+`TtlSortedCacheBuilder`, and `ExpiringCacheBuilder` is renamed to `.initial_capacity(n)`. The
+method sets a pre-allocation hint on the backing `HashMap` without bounding entry count (that is
+`max_size` on the LRU builders). The rename removes the ambiguity between a hint and an eviction
+bound.
+
+Detection: `no method named capacity found for struct UnboundCacheBuilder` (or the other three
+builders).
+
+Action: rename `.capacity(n)` to `.initial_capacity(n)`.
+```rust
+// Before
+let cache = UnboundCache::<String, u32>::builder()
+    .capacity(128)
+    .build()?;
+
+// After
+let cache = UnboundCache::<String, u32>::builder()
+    .initial_capacity(128)
+    .build()?;
+```
+`max_size` on `LruCacheBuilder`, `LruTtlCacheBuilder`, and `ExpiringLruCacheBuilder` is
+unchanged; it bounds entry count, not pre-allocation.
+
+### 51. `Return<T>` fields are now private (`cached_proc_macro_types`)
+
+`Return<T>::value` and `Return<T>::was_cached` are now private. They were public struct fields
+accessible with `.value` / `.was_cached` or pattern syntax (`Return { value, was_cached }`).
+
+Detection: `field value of struct Return is private` / `field was_cached of struct Return is
+private`.
+
+Action:
+```rust
+// Before
+let r: Return<String> = my_fn();
+println!("{}", r.value);
+if r.was_cached { ... }
+
+// After: use deref or into_inner() for the value, was_cached() for the flag
+let r: Return<String> = my_fn();
+println!("{}", *r);           // deref coerces to &T
+// or
+println!("{}", r.into_inner()); // consumes r, returns T
+if r.was_cached() { ... }
+```
+Struct-pattern matches must also switch to the accessor methods (there is no destructure form
+for private fields).
+
+### 52. `set_max_size` returns `Option<usize>` on LRU stores
+
+`LruCache::set_max_size`, `LruTtlCache::set_max_size`, and `ExpiringLruCache::set_max_size`
+now return `Option<usize>` (the previous bound), matching `TtlSortedCache::set_max_size`.
+
+Detection: a type mismatch where code expected `usize` from `set_max_size` on one of those three
+types.
+
+Action:
+```rust
+// Before
+let prev: usize = cache.set_max_size(200);
+
+// After
+let prev: Option<usize> = cache.set_max_size(200);
+// or just ignore it
+cache.set_max_size(200);
+```
+
+### 53. ahash `runtime-rng` enabled on non-wasm targets
+
+When the `ahash` feature is active, `cached` now enables `ahash/runtime-rng` on non-wasm
+targets. The ahash hasher seeds itself from the OS RNG at startup instead of using a fixed
+compile-time seed, closing a hash-flood denial-of-service vector.
+
+This is transparent to source code. No API or type change.
+
+On wasm32 targets `runtime-rng` is not enabled because it would require a `getrandom` wasm
+backend. The compile-time seed is kept on wasm. If your wasm target uses `getrandom` already
+(e.g. via `getrandom/js`), you can enable `ahash/runtime-rng` directly on your own `ahash`
+dependency to opt in.
+
+Detection: none -- no compile error and no source change required.
+
+Action: none for non-wasm targets. wasm targets are unaffected.
+
 ## Required Cargo.toml change
 
 ```toml

--- a/examples/kitchen_sink.rs
+++ b/examples/kitchen_sink.rs
@@ -29,7 +29,7 @@ fn fib(n: u32) -> u32 {
 // Note that the cache key type is a tuple of function argument types.
 #[cached(
     ty = "UnboundCache<u32, u32>",
-    create = UnboundCache::builder().capacity(50).build().unwrap()
+    create = UnboundCache::builder().initial_capacity(50).build().unwrap()
 )]
 fn fib_specific(n: u32) -> u32 {
     if n == 0 || n == 1 {

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -37,9 +37,9 @@ async fn main() {
 
     let a = cached_was_cached(4).await.unwrap();
     assert_eq!(a.to_uppercase(), "AAAA");
-    assert!(!a.was_cached);
+    assert!(!a.was_cached());
     let a = cached_was_cached(4).await.unwrap();
-    assert!(a.was_cached);
+    assert!(a.was_cached());
 
     println!("done!");
 }

--- a/src/lru_list.rs
+++ b/src/lru_list.rs
@@ -1,6 +1,5 @@
 /// Limited functionality doubly linked list using Vec as storage.
 #[derive(Clone, Debug)]
-
 pub struct LRUList<T> {
     values: Vec<ListEntry<T>>,
 }
@@ -20,7 +19,8 @@ impl<T> LRUList<T> {
     const OCCUPIED: usize = 1;
 
     pub(crate) fn with_capacity(capacity: usize) -> LRUList<T> {
-        let mut values = Vec::with_capacity(capacity + 2);
+        let cap = capacity.saturating_add(2);
+        let mut values = Vec::with_capacity(cap);
         values.push(ListEntry::<T> {
             value: None,
             next: 0,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -150,7 +150,7 @@ use cached::Return;
 
 /// Get a `cached::Return` value that indicates
 /// whether the value returned came from the cache:
-/// `cached::Return.was_cached`.
+/// `cached::Return.was_cached()`.
 /// Use an LRU cache and a `String` cache key.
 #[cached(max_size=1, with_cached_flag = true)]
 fn calculate(a: String) -> Return<String> {
@@ -158,9 +158,9 @@ fn calculate(a: String) -> Return<String> {
 }
 pub fn main() {
     let r = calculate("a".to_string());
-    assert!(!r.was_cached);
+    assert!(!r.was_cached());
     let r = calculate("a".to_string());
-    assert!(r.was_cached);
+    assert!(r.was_cached());
     // Return<String> derefs to String
     assert_eq!(r.to_uppercase(), "A");
 }
@@ -186,7 +186,7 @@ pub fn main() {
     match calculate("a".to_string()) {
         Err(e) => eprintln!("error: {:?}", e),
         Ok(r) => {
-            println!("value: {:?}, was cached: {}", *r, r.was_cached);
+            println!("value: {:?}, was cached: {}", *r, r.was_cached());
             // value: "a", was cached: true
         }
     }
@@ -210,7 +210,7 @@ fn calculate(a: String) -> Option<Return<usize>> {
 }
 pub fn main() {
     if let Some(a) = calculate("a".to_string()) {
-        println!("value: {:?}, was cached: {}", *a, a.was_cached);
+        println!("value: {:?}, was cached: {}", *a, a.was_cached());
         // value: "a", was cached: true
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -227,7 +227,7 @@ use cached::LruCache;
 /// Use an explicit cache-type with a custom creation block and custom cache-key generating block
 #[cached(
     ty = "LruCache<String, usize>",
-    create = "{ LruCache::builder().max_size(100).build().unwrap() }",
+    create = LruCache::builder().max_size(100).build().unwrap(),
     convert = r#"{ format!("{}{}", a, b) }"#
 )]
 fn keyed(a: &str, b: &str) -> usize {

--- a/src/stores/expiring.rs
+++ b/src/stores/expiring.rs
@@ -18,7 +18,7 @@ use {super::CachedAsync, std::collections::hash_map::Entry, std::future::Future}
 /// When using the `#[cached]` proc macro, `expires = true` automatically selects this store
 /// (or `ExpiringLruCache` when `size` is also specified).
 ///
-/// **`len` / `iter` / `evict` contract**: `len()` returns the raw stored entry count
+/// **`cache_size` / `iter` / `evict` contract**: `cache_size()` returns the raw stored entry count
 /// and may include expired-but-not-yet-swept entries. `iter()` omits expired entries
 /// from the view but does not remove them. Call `evict()` (via [`CacheEvict`](crate::CacheEvict))
 /// to physically remove expired entries, reclaim memory, and obtain an accurate live count.
@@ -135,7 +135,7 @@ impl<K, V: Expires> Default for ExpiringCacheBuilder<K, V, DefaultHashBuilder> {
 impl<K, V: Expires, S> ExpiringCacheBuilder<K, V, S> {
     /// Set the initial allocation capacity (optional).
     #[must_use]
-    pub fn capacity(mut self, capacity: usize) -> Self {
+    pub fn initial_capacity(mut self, capacity: usize) -> Self {
         self.capacity = Some(capacity);
         self
     }
@@ -204,7 +204,7 @@ impl<K, V: Expires, S> ExpiringCacheBuilder<K, V, S> {
     {
         let store = match self.capacity {
             Some(cap) => UnboundCache::builder()
-                .capacity(cap)
+                .initial_capacity(cap)
                 .hasher(self.hasher)
                 .build()
                 .expect("infallible"),
@@ -695,7 +695,7 @@ mod tests {
     #[test]
     fn expiring_cache_builder() {
         let mut c: ExpiringCache<u8, ExpiredU8> = ExpiringCache::builder()
-            .capacity(10)
+            .initial_capacity(10)
             .on_evict(|_k: &u8, v: &ExpiredU8| {
                 assert!(v.0 > 10);
             })
@@ -1022,7 +1022,7 @@ mod tests {
     #[test]
     fn expiring_cache_try_build() {
         let result: Result<ExpiringCache<u8, ExpiredU8>, _> =
-            ExpiringCache::builder().capacity(10).build();
+            ExpiringCache::builder().initial_capacity(10).build();
         assert!(result.is_ok());
         let c = result.unwrap();
         assert_eq!(c.cache_size(), 0);
@@ -1165,5 +1165,16 @@ mod tests {
         let empty2: ExpiringCache<u8, ExpiredU8> = ExpiringCache::builder().build().unwrap();
         assert_eq!(empty1, empty2);
         assert_ne!(empty1, a);
+    }
+
+    #[test]
+    fn builder_initial_capacity_method_exists_and_preallocates() {
+        // Verifies the renamed builder method: initial_capacity() sets a preallocation hint.
+        let c: ExpiringCache<u8, ExpiredU8> = ExpiringCache::builder()
+            .initial_capacity(32)
+            .build()
+            .unwrap();
+        // The backing store must have at least the requested capacity.
+        assert!(c.store.store.capacity() >= 32);
     }
 }

--- a/src/stores/expiring_lru.rs
+++ b/src/stores/expiring_lru.rs
@@ -70,7 +70,7 @@ pub trait Expires {
 ///
 /// Note: This cache is in-memory only.
 ///
-/// **`len` / `iter` / `evict` contract**: `len()` returns the raw stored entry count
+/// **`cache_size` / `iter` / `evict` contract**: `cache_size()` returns the raw stored entry count
 /// and may include expired-but-not-yet-swept entries. `iter()` omits expired entries
 /// from the view but does not remove them. Call `evict()` (via [`CacheEvict`](crate::CacheEvict))
 /// to physically remove expired entries and obtain an accurate live count.
@@ -303,18 +303,21 @@ impl<K: Clone + Hash + Eq, V: Expires, S: BuildHasher> ExpiringLruCache<K, V, S>
     ///
     /// Panics if `max_size` is 0. Use [`try_set_max_size`](ExpiringLruCache::try_set_max_size)
     /// to validate first and avoid the panic.
-    pub fn set_max_size(&mut self, max_size: usize) -> usize {
+    pub fn set_max_size(&mut self, max_size: usize) -> Option<usize> {
         self.store.set_max_size(max_size)
     }
 
     /// Fallible counterpart of [`set_max_size`](ExpiringLruCache::set_max_size): validates
     /// that `max_size` is non-zero and then delegates to `set_max_size`.
-    /// Returns the previous capacity on success.
+    /// Returns the previous capacity wrapped in `Some` on success.
     ///
     /// # Errors
     ///
     /// Returns [`SetMaxSizeError::ZeroSize`](super::SetMaxSizeError) if `max_size` is 0.
-    pub fn try_set_max_size(&mut self, max_size: usize) -> Result<usize, super::SetMaxSizeError> {
+    pub fn try_set_max_size(
+        &mut self,
+        max_size: usize,
+    ) -> Result<Option<usize>, super::SetMaxSizeError> {
         self.store.try_set_max_size(max_size)
     }
 
@@ -1184,7 +1187,7 @@ mod tests {
 
         // Shrink to 2: LRU entry (1) should be evicted.
         let prev = c.set_max_size(2);
-        assert_eq!(prev, 3);
+        assert_eq!(prev, Some(3));
         assert_eq!(c.capacity(), 2);
         assert_eq!(c.cache_size(), 2);
 
@@ -1217,7 +1220,7 @@ mod tests {
 
         let evictions_before = c.cache_evictions().expect("evictions tracked");
         let prev = c.set_max_size(2);
-        assert_eq!(prev, 4);
+        assert_eq!(prev, Some(4));
         assert_eq!(c.capacity(), 2);
         assert_eq!(c.cache_size(), 2);
 
@@ -1252,7 +1255,7 @@ mod tests {
             c.try_set_max_size(0),
             Err(super::super::SetMaxSizeError::ZeroSize)
         );
-        assert_eq!(c.try_set_max_size(5).unwrap(), 3);
+        assert_eq!(c.try_set_max_size(5).unwrap(), Some(3));
     }
 
     #[test]

--- a/src/stores/lru.rs
+++ b/src/stores/lru.rs
@@ -262,13 +262,17 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruCache<K, V, S> {
         self.capacity
     }
 
-    /// Change the maximum number of entries, returning the previous capacity;
-    /// shrinking below the current entry count immediately evicts least-recently-used
-    /// entries.
+    /// Change the maximum number of entries, returning the previous bound as
+    /// `Some(prev_capacity)`.
     ///
-    /// Eviction on shrink fires `on_evict` and counts evictions until the cache
-    /// fits. Growing the capacity does not pre-allocate; the backing stores grow
-    /// on demand as entries are inserted.
+    /// Because `LruCache` is always bounded, this always returns `Some`. The
+    /// `Option` wrapper aligns the return type with `TtlSortedCache::set_max_size`,
+    /// which may have no prior bound and returns `None` in that case.
+    ///
+    /// Shrinking below the current entry count immediately evicts least-recently-used
+    /// entries. Eviction fires `on_evict` and counts evictions until the cache fits.
+    /// Growing the capacity does not pre-allocate; the backing stores grow on demand
+    /// as entries are inserted.
     ///
     /// This is useful for sizing a `#[cached(create = "{ ... }")]` cache from a value
     /// loaded at startup (e.g. config), then adjusting it later as load changes.
@@ -283,10 +287,9 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruCache<K, V, S> {
     /// [`LruTtlCache::set_max_size`](super::LruTtlCache::set_max_size),
     /// [`ExpiringLruCache::set_max_size`](super::ExpiringLruCache::set_max_size), and
     /// [`TtlSortedCache::set_max_size`](super::TtlSortedCache::set_max_size) are
-    /// parallel methods on the other LRU-family stores. Note that `TtlSortedCache::set_max_size`
-    /// returns `Option<usize>` (the previous bound, which is optional) rather than `usize`.
+    /// parallel methods on the other LRU-family stores.
     /// All stores also provide a fallible `try_set_max_size` counterpart.
-    pub fn set_max_size(&mut self, max_size: usize) -> usize {
+    pub fn set_max_size(&mut self, max_size: usize) -> Option<usize> {
         assert!(max_size > 0, "max_size must be greater than zero");
         let prev = self.capacity;
         self.capacity = max_size;
@@ -295,17 +298,20 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruCache<K, V, S> {
         while self.store.len() > self.capacity {
             self.check_capacity();
         }
-        prev
+        Some(prev)
     }
 
     /// Fallible counterpart of [`set_max_size`](LruCache::set_max_size): validates
     /// that `max_size` is non-zero and then delegates to `set_max_size`.
-    /// Returns the previous capacity on success.
+    /// Returns the previous capacity wrapped in `Some` on success.
     ///
     /// # Errors
     ///
     /// Returns [`SetMaxSizeError::ZeroSize`](super::SetMaxSizeError) if `max_size` is 0.
-    pub fn try_set_max_size(&mut self, max_size: usize) -> Result<usize, super::SetMaxSizeError> {
+    pub fn try_set_max_size(
+        &mut self,
+        max_size: usize,
+    ) -> Result<Option<usize>, super::SetMaxSizeError> {
         if max_size == 0 {
             return Err(super::SetMaxSizeError::ZeroSize);
         }
@@ -321,7 +327,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruCache<K, V, S> {
         self.order.iter().cloned().collect()
     }
 
-    /// Return an iterator of keys in the current order from most
+    /// Return a `Vec` of keys in the current order from most
     /// to least recently used.
     pub fn key_order(&self) -> Vec<K>
     where
@@ -330,7 +336,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruCache<K, V, S> {
         self.order.iter().map(|(k, _v)| k.clone()).collect()
     }
 
-    /// Return an iterator of values in the current order from most
+    /// Return a `Vec` of values in the current order from most
     /// to least recently used.
     pub fn value_order(&self) -> Vec<V>
     where
@@ -728,6 +734,15 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruCache<K, V, S>
         self.get_mut_if(key, |_| true)
     }
 
+    /// Insert or replace a cache entry.
+    ///
+    /// Returns the previous value if the key already existed, or `None` for a
+    /// new insertion.
+    ///
+    /// **Note:** overwriting an existing key replaces the value in-place
+    /// **without** refreshing the key's LRU recency. The entry stays at its
+    /// current position in the eviction order. Use `cache_get` before
+    /// `cache_set` if you need to promote the entry to most-recently-used.
     fn cache_set(&mut self, key: K, val: V) -> Option<V> {
         let hash = self.hash(&key);
         let v = if let Some(index) = self.get_index(hash, &key) {
@@ -784,8 +799,18 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruCache<K, V, S>
     }
     fn cache_reset(&mut self) {
         // Entries are dropped in-place; `on_evict` is NOT called for cleared entries.
-        self.store = HashTable::with_capacity(self.capacity);
-        self.order = LRUList::<(K, V)>::with_capacity(self.capacity);
+        //
+        // Pre-allocate up to the live entry count to avoid a large allocation when
+        // `capacity` has been set to a very large value (e.g. `usize::MAX`). The
+        // live count is a safe ceiling: we cannot have more entries than that right
+        // now, and the backing stores grow on demand as new entries are inserted.
+        let live = self.store.len();
+        let mut new_store = HashTable::new();
+        let _ = new_store.try_reserve(live, |&index: &usize| self.hash_builder.hash_one(index));
+        let new_order = LRUList::<(K, V)>::try_with_capacity(live)
+            .unwrap_or_else(|_| LRUList::<(K, V)>::with_capacity(0));
+        self.store = new_store;
+        self.order = new_order;
         self.cache_reset_metrics();
     }
     fn cache_reset_metrics(&mut self) {
@@ -1469,7 +1494,7 @@ mod tests {
         c.cache_set(1u32, 10u32);
         c.cache_set(2u32, 20u32);
         let prev = c.set_max_size(4);
-        assert_eq!(prev, 2);
+        assert_eq!(prev, Some(2));
         assert_eq!(c.capacity(), 4);
         // Growing keeps existing entries.
         assert_eq!(c.cache_get(&1), Some(&10));
@@ -1502,7 +1527,7 @@ mod tests {
         assert_eq!(c.cache_get(&2), Some(&20));
 
         let prev = c.set_max_size(2);
-        assert_eq!(prev, 4);
+        assert_eq!(prev, Some(4));
         assert_eq!(c.capacity(), 2);
         assert_eq!(c.cache_size(), 2);
         // Shrinking fires on_evict for each evicted entry and counts evictions.
@@ -1529,8 +1554,22 @@ mod tests {
             c.try_set_max_size(0),
             Err(super::super::SetMaxSizeError::ZeroSize)
         );
-        assert_eq!(c.try_set_max_size(8).unwrap(), 2);
+        assert_eq!(c.try_set_max_size(8).unwrap(), Some(2));
         assert_eq!(c.capacity(), 8);
+    }
+
+    #[test]
+    fn cache_reset_after_usize_max_capacity_does_not_panic() {
+        // R1: after set_max_size(usize::MAX) the internal `capacity` field is huge,
+        // but cache_reset must not attempt to pre-allocate that many bytes.
+        // It should cap the pre-allocation to the live entry count and succeed.
+        let mut c: LruCache<u32, u32> = LruCache::builder().max_size(2).build().unwrap();
+        c.cache_set(1, 10);
+        c.cache_set(2, 20);
+        c.set_max_size(usize::MAX);
+        // Must not panic/abort even though self.capacity == usize::MAX.
+        c.cache_reset();
+        assert_eq!(c.cache_size(), 0);
     }
 
     // --- custom hasher tests ---

--- a/src/stores/lru_ttl.rs
+++ b/src/stores/lru_ttl.rs
@@ -380,7 +380,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruTtlCache<K, V, S> {
             .collect()
     }
 
-    /// Return an iterator of keys in the current order from most
+    /// Return a `Vec` of keys in the current order from most
     /// to least recently used.
     /// Items past their expiry will be excluded.
     pub fn key_order(&self) -> Vec<K>
@@ -400,7 +400,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruTtlCache<K, V, S> {
             .collect()
     }
 
-    /// Return an iterator of (expiry, value) pairs in the current order
+    /// Return a `Vec` of (expiry, value) pairs in the current order
     /// from most to least recently used.
     /// Items past their expiry will be excluded.
     pub fn value_order(&self) -> Vec<(Option<Instant>, V)>
@@ -454,7 +454,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruTtlCache<K, V, S> {
     /// [`TtlSortedCache::set_max_size`](super::TtlSortedCache::set_max_size) are
     /// parallel methods on the other LRU-family stores. All stores also provide a
     /// fallible `try_set_max_size` counterpart.
-    pub fn set_max_size(&mut self, max_size: usize) -> usize {
+    pub fn set_max_size(&mut self, max_size: usize) -> Option<usize> {
         assert!(max_size > 0, "max_size must be greater than zero");
         let prev = self.store.set_max_size(max_size);
         self.size = self.store.capacity;
@@ -463,12 +463,15 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruTtlCache<K, V, S> {
 
     /// Fallible counterpart of [`set_max_size`](LruTtlCache::set_max_size): validates
     /// that `max_size` is non-zero and then delegates to `set_max_size`.
-    /// Returns the previous capacity on success.
+    /// Returns the previous capacity wrapped in `Some` on success.
     ///
     /// # Errors
     ///
     /// Returns [`SetMaxSizeError::ZeroSize`](super::SetMaxSizeError) if `max_size` is 0.
-    pub fn try_set_max_size(&mut self, max_size: usize) -> Result<usize, super::SetMaxSizeError> {
+    pub fn try_set_max_size(
+        &mut self,
+        max_size: usize,
+    ) -> Result<Option<usize>, super::SetMaxSizeError> {
         if max_size == 0 {
             return Err(super::SetMaxSizeError::ZeroSize);
         }
@@ -1307,7 +1310,7 @@ mod tests {
 
         // Shrink to 2: LRU entry (1) should be evicted.
         let prev = cache.set_max_size(2);
-        assert_eq!(prev, 3);
+        assert_eq!(prev, Some(3));
         assert_eq!(cache.capacity(), 2);
         assert_eq!(cache.cache_size(), 2);
 
@@ -1340,7 +1343,7 @@ mod tests {
 
         let evictions_before = cache.cache_evictions().expect("evictions tracked");
         let prev = cache.set_max_size(2);
-        assert_eq!(prev, 4);
+        assert_eq!(prev, Some(4));
         assert_eq!(cache.capacity(), 2);
         assert_eq!(cache.cache_size(), 2);
 
@@ -1378,7 +1381,7 @@ mod tests {
             cache.try_set_max_size(0),
             Err(super::super::SetMaxSizeError::ZeroSize)
         );
-        assert_eq!(cache.try_set_max_size(5).unwrap(), 3);
+        assert_eq!(cache.try_set_max_size(5).unwrap(), Some(3));
     }
 
     #[test]

--- a/src/stores/redb.rs
+++ b/src/stores/redb.rs
@@ -135,6 +135,11 @@ where
 
     /// Specify the cache TTL as a `Duration`.
     ///
+    /// **TTL is optional.** When no TTL is set (the default), entries never
+    /// expire and are kept until explicitly removed or the cache is cleared.
+    /// This is the primary difference from [`RedisCache`](crate::stores::RedisCache),
+    /// where a TTL is required.
+    ///
     /// Overrides any previously set ttl/ttl_secs/ttl_millis on this builder.
     #[must_use]
     pub fn ttl(mut self, ttl: Duration) -> Self {
@@ -215,11 +220,27 @@ where
     /// Find (and create) a writable default directory in which to place the
     /// redb database file, returning the directory path.
     fn default_disk_path() -> Result<PathBuf, std::io::Error> {
+        let candidates = Self::default_disk_dir_candidates();
+        // The last candidate is always the temp_dir fallback. All earlier
+        // candidates use the user's XDG cache dir and are treated as preferred.
+        let last_idx = candidates.len().saturating_sub(1);
         let mut last_error = None;
 
-        for disk_dir in Self::default_disk_dir_candidates() {
-            match std::fs::create_dir_all(&disk_dir) {
-                Ok(()) => return Ok(disk_dir),
+        for (idx, disk_dir) in candidates.into_iter().enumerate() {
+            let is_temp_fallback = idx == last_idx;
+            match create_cache_dir(&disk_dir) {
+                Ok(()) => {
+                    // On unix, when using the temp_dir fallback, validate the
+                    // resolved path to guard against symlink-based TOCTOU
+                    // attacks: reject symlinks and world/group-writable dirs.
+                    #[cfg(unix)]
+                    if is_temp_fallback {
+                        validate_temp_cache_dir(&disk_dir)?;
+                    }
+                    #[cfg(not(unix))]
+                    let _ = is_temp_fallback;
+                    return Ok(disk_dir);
+                }
                 Err(error) if error.kind() == ErrorKind::PermissionDenied => {
                     last_error = Some(error);
                 }
@@ -282,12 +303,30 @@ where
         // as the database file.
         let disk_dir = match self.disk_dir {
             Some(disk_dir) => {
-                std::fs::create_dir_all(&disk_dir)?;
+                create_cache_dir(&disk_dir)?;
                 disk_dir
             }
             None => Self::default_disk_path()?,
         };
         let disk_path = disk_dir.join(format!("{}.redb", cache_dir_name));
+
+        // On unix, pre-create the redb file with mode 0600 so that the
+        // database bytes are never readable by group or other. We use
+        // OpenOptions to create (or open) the file with the correct mode
+        // before redb opens it; redb will then open the existing file.
+        // On non-unix platforms we skip this step and let redb create the file
+        // with default OS permissions.
+        #[cfg(unix)]
+        {
+            use std::fs::OpenOptions;
+            use std::os::unix::fs::OpenOptionsExt;
+            OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .mode(0o600)
+                .open(&disk_path)?;
+        }
 
         let db = Builder::new().create(&disk_path)?;
 
@@ -311,8 +350,67 @@ where
     }
 }
 
+/// Create a directory (and all parents) for storing the redb database file.
+///
+/// On unix the directory is created with mode 0700 (owner read/write/execute
+/// only) so that the database file is not visible to other users. On non-unix
+/// platforms `std::fs::create_dir_all` is used and the OS decides the mode.
+fn create_cache_dir(path: &Path) -> Result<(), std::io::Error> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(path)
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::create_dir_all(path)
+    }
+}
+
+/// On unix, validate that the resolved cache directory path is not a symlink
+/// and is not group- or world-writable. This guards the `temp_dir` fallback
+/// path against symlink-based TOCTOU attacks where an adversary replaces the
+/// target directory with a symlink pointing elsewhere.
+///
+/// Uid ownership is not checked here because obtaining the process uid without
+/// a dependency (e.g. `libc` or `rustix`) would require unsafe platform calls.
+/// The symlink + permission-bits check is sufficient to reject the most
+/// common attack vectors (world-writable directory, symlink redirection).
+#[cfg(unix)]
+fn validate_temp_cache_dir(path: &Path) -> Result<(), std::io::Error> {
+    use std::os::unix::fs::MetadataExt;
+
+    let meta = std::fs::symlink_metadata(path)?;
+    if meta.file_type().is_symlink() {
+        return Err(std::io::Error::new(
+            ErrorKind::PermissionDenied,
+            "temp cache directory is a symlink; refusing to use it",
+        ));
+    }
+    // Reject group-writable (0o020) or other-writable (0o002) directories.
+    let mode = meta.mode();
+    if mode & 0o022 != 0 {
+        return Err(std::io::Error::new(
+            ErrorKind::PermissionDenied,
+            "temp cache directory has insecure permissions (group- or world-writable)",
+        ));
+    }
+    Ok(())
+}
+
 /// Cache store backed by disk, using an embedded [`redb`](https://crates.io/crates/redb)
 /// database (one file per cache).
+///
+/// # TTL
+///
+/// TTL is **optional**. When no TTL is configured (the default), entries never expire and
+/// persist until explicitly removed or the cache is cleared. This differs from
+/// [`RedisCache`](crate::stores::RedisCache), where a TTL is required. Set a TTL via
+/// [`RedbCacheBuilder::ttl`] / [`RedbCacheBuilder::ttl_secs`] / [`RedbCacheBuilder::ttl_millis`]
+/// at build time, or update it at runtime with [`ConcurrentCacheTtl::set_ttl`].
 ///
 /// # Concurrency and performance
 ///
@@ -463,6 +561,12 @@ pub enum RedbCacheError {
         #[from]
         source: redb::Error,
     },
+    /// A stored value failed to deserialize.
+    ///
+    /// **Security note:** `cached_value` contains the raw bytes that were read
+    /// from disk and failed to decode. Those bytes may contain sensitive
+    /// application data. Do not log or display this error variant without
+    /// redacting or omitting the `cached_value` field.
     #[error("Error deserializing cached value")]
     CacheDeserialization {
         #[source]
@@ -2325,5 +2429,117 @@ mod tests {
             err.source().is_some(),
             "RedbCacheBuildError::Storage must expose its inner error via source()"
         );
+    }
+
+    // ── Unix permission / security tests ─────────────────────────────────────
+    //
+    // Verifies that the cache directory is created with mode 0700, that the
+    // redb database file is created with mode 0600, and that the temp_dir
+    // fallback path is rejected if it resolves to a symlink.
+
+    #[cfg(unix)]
+    mod unix_permissions {
+        use super::*;
+        use std::os::unix::fs::MetadataExt;
+
+        /// The cache directory created by `disk_directory(path)` must have
+        /// mode 0700 (owner rwx only).
+        #[test]
+        fn explicit_disk_dir_is_created_with_mode_0700() {
+            let parent = temp_dir!();
+            // Point to a non-existent subdirectory so create_cache_dir must create it.
+            let cache_dir = parent.path().join("sub").join("cache");
+            let cache: RedbCache<u32, u32> = RedbCache::builder()
+                .name("perm-dir-explicit")
+                .disk_directory(&cache_dir)
+                .build()
+                .expect("build must succeed");
+            let meta = std::fs::metadata(&cache_dir).expect("metadata");
+            // Lower 9 bits: 0700 = 0o700
+            assert_eq!(
+                meta.mode() & 0o777,
+                0o700,
+                "cache directory must be created with mode 0700; got {:o}",
+                meta.mode() & 0o777
+            );
+            drop(cache);
+        }
+
+        /// The redb database file must be created with mode 0600 (owner rw only).
+        #[test]
+        fn redb_file_is_created_with_mode_0600() {
+            let dir = temp_dir!();
+            let cache: RedbCache<u32, u32> = RedbCache::builder()
+                .name("perm-file")
+                .disk_directory(dir.path())
+                .build()
+                .expect("build must succeed");
+            let file_path = cache.disk_path().to_owned();
+            drop(cache); // release the redb exclusive lock before inspecting
+            let meta = std::fs::metadata(&file_path).expect("metadata");
+            assert_eq!(
+                meta.mode() & 0o777,
+                0o600,
+                "redb file must be created with mode 0600; got {:o}",
+                meta.mode() & 0o777
+            );
+        }
+
+        /// A symlinked temp fallback directory must be rejected by
+        /// `validate_temp_cache_dir` with a `PermissionDenied` error.
+        #[test]
+        fn symlinked_temp_fallback_dir_is_rejected() {
+            let real_dir = temp_dir!();
+            let link_dir = temp_dir!();
+            let link_path = link_dir.path().join("symlink_cache");
+            std::os::unix::fs::symlink(real_dir.path(), &link_path)
+                .expect("failed to create symlink");
+            // validate_temp_cache_dir must reject a symlink.
+            let result = super::super::validate_temp_cache_dir(&link_path);
+            assert!(
+                result.is_err(),
+                "validate_temp_cache_dir must reject a symlink"
+            );
+            let err = result.unwrap_err();
+            assert_eq!(
+                err.kind(),
+                std::io::ErrorKind::PermissionDenied,
+                "rejection must be PermissionDenied, got {err}"
+            );
+        }
+
+        /// A real (non-symlink) temp fallback directory must be accepted by
+        /// `validate_temp_cache_dir`.
+        #[test]
+        fn real_temp_fallback_dir_is_accepted() {
+            let dir = temp_dir!();
+            // Ensure the directory has mode 0700 (which create_cache_dir produces).
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
+                .expect("set_permissions");
+            let result = super::super::validate_temp_cache_dir(dir.path());
+            assert!(
+                result.is_ok(),
+                "validate_temp_cache_dir must accept a real 0700 dir: {result:?}"
+            );
+        }
+
+        /// A world-writable temp fallback directory must be rejected.
+        #[test]
+        fn world_writable_temp_fallback_dir_is_rejected() {
+            let dir = temp_dir!();
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o777))
+                .expect("set_permissions");
+            let result = super::super::validate_temp_cache_dir(dir.path());
+            assert!(
+                result.is_err(),
+                "validate_temp_cache_dir must reject a world-writable dir"
+            );
+            assert_eq!(
+                result.unwrap_err().kind(),
+                std::io::ErrorKind::PermissionDenied
+            );
+        }
     }
 }

--- a/src/stores/redis.rs
+++ b/src/stores/redis.rs
@@ -329,6 +329,107 @@ mod builder_empty_scope_tests {
     }
 }
 
+#[cfg(test)]
+mod credential_leak_tests {
+    // No Redis server needed -- verifies that a bad connection URL containing a
+    // password does not surface the password in the build error's Display/Debug.
+    // Guards against the S3 credential-leak finding: the `#[from] redis::RedisError`
+    // path used to propagate raw connection errors before we started sanitizing them.
+    use super::{RedisCacheBuildError, RedisCacheBuilder};
+    use crate::time::Duration;
+
+    /// Building with a URL that contains an embedded password but has an invalid
+    /// scheme (so `Client::open` fails immediately) must not include the password
+    /// in the resulting error's `Display` or `Debug`.
+    #[test]
+    fn bad_url_with_password_does_not_leak_password_in_build_error() {
+        // `not-redis` is not a valid redis scheme, so `Client::open` / `into_connection_info`
+        // will fail before any network connection is attempted. The URL contains a
+        // plaintext password that must not appear in the error message.
+        let secret = "super_secret_password_xyz";
+        let bad_url = format!("not-redis://:{secret}@nonexistent-host:9999");
+
+        let result = RedisCacheBuilder::<String, String>::new()
+            .prefix("test")
+            .ttl(Duration::from_secs(1))
+            .connection_string(&bad_url)
+            .build();
+
+        let err = result.expect_err("build must fail with a bad URL");
+        let display = err.to_string();
+        let debug = format!("{err:?}");
+
+        assert!(
+            !display.contains(secret),
+            "Display must not expose the password; got: {display}"
+        );
+        assert!(
+            !debug.contains(secret),
+            "Debug must not expose the password; got: {debug}"
+        );
+        // The error must be a Connection variant (the sanitized one).
+        assert!(
+            matches!(err, RedisCacheBuildError::Connection(_)),
+            "expected Connection error, got: {err:?}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod legacy_json_version_gate_tests {
+    // No Redis server needed -- verifies that the S4 backward-read gate requires
+    // the `version` key to equal the known version constant, not merely exist.
+    use super::{RedisCacheError, deserialize_cached_redis_value};
+
+    /// A JSON object whose `version` key exists but holds an unexpected value must
+    /// NOT be accepted as a legacy entry — it falls through to `CacheDeserialization`.
+    #[test]
+    fn json_with_wrong_version_value_is_rejected() {
+        // `version: 99` is not the known REDIS_VALUE_VERSION (Some(1)).
+        // Before the fix, `json.get("version").is_some()` would have accepted this.
+        let bytes = br#"{"value": "hello", "version": 99}"#.to_vec();
+        match deserialize_cached_redis_value::<String>(&bytes) {
+            Ok(_) => panic!(
+                "JSON with an unexpected `version` value must not be accepted as a legacy entry"
+            ),
+            Err(RedisCacheError::CacheDeserialization { cached_value, .. }) => {
+                assert_eq!(
+                    cached_value, bytes,
+                    "raw bytes must be preserved in the error"
+                );
+            }
+            Err(other) => panic!("expected CacheDeserialization, got: {other:?}"),
+        }
+    }
+
+    /// A JSON object with `version: null` (the JSON encoding of `None`) is also
+    /// not the expected version (`Some(1)`) and must be rejected.
+    #[test]
+    fn json_with_null_version_is_rejected() {
+        let bytes = br#"{"value": 42, "version": null}"#.to_vec();
+        match deserialize_cached_redis_value::<u64>(&bytes) {
+            Ok(_) => panic!("JSON with version=null must not be accepted as a legacy entry"),
+            Err(RedisCacheError::CacheDeserialization { .. }) => {}
+            Err(other) => panic!("expected CacheDeserialization, got: {other:?}"),
+        }
+    }
+
+    /// A JSON object with `version: 1` (the known version, matches `Some(1)`) IS
+    /// accepted as a valid legacy entry. This confirms the gate is a value-check,
+    /// not just a presence-check, and that the correct version still passes through.
+    #[test]
+    fn json_with_correct_version_one_is_accepted() {
+        // `{"value": "ok", "version": 1}` is the pre-3.0 JSON format with the known version.
+        let bytes = br#"{"value": "ok", "version": 1}"#.to_vec();
+        let result = deserialize_cached_redis_value::<String>(&bytes);
+        assert!(
+            result.is_ok(),
+            "JSON with version=1 must be accepted as a legacy entry"
+        );
+        assert_eq!(result.unwrap().value, "ok");
+    }
+}
+
 /// A Redis connection URL stored in memory with credentials redacted in `Debug`/`Display`.
 ///
 /// Both [`Debug`](std::fmt::Debug) and [`Display`](std::fmt::Display) render the placeholder
@@ -399,6 +500,15 @@ pub enum RedisCacheBuildError {
         Set a non-empty namespace or prefix."
     )]
     EmptyScope,
+    /// The connection URL explicitly pins the RESP2 protocol (`?protocol=resp2`)
+    /// while `client_side_caching` is enabled. Client-side caching requires
+    /// RESP3; the combination is rejected at build time to prevent the
+    /// invalidation listener from silently no-oping and serving stale data.
+    #[error(
+        "client_side_caching requires RESP3 but the connection URL explicitly pins \
+        protocol=resp2; remove the protocol parameter or set it to resp3"
+    )]
+    Resp2DowngradeWithClientSideCaching,
 }
 
 impl<K, V> Default for RedisCacheBuilder<K, V>
@@ -558,7 +668,17 @@ where
 
     fn create_pool(&self) -> Result<r2d2::Pool<redis::Client>, RedisCacheBuildError> {
         let s = self.resolve_connection_string()?;
-        let client: redis::Client = redis::Client::open(s)?;
+        // Open the client, catching any error before it can propagate through
+        // the `#[from] redis::RedisError` impl on `RedisCacheBuildError::Connection`.
+        // A malformed URL such as `redis://:password@host` would otherwise surface
+        // the raw connection string (including the password) in the error's
+        // `Display`/`Debug`. Replace any error payload with a sanitized message.
+        let client: redis::Client = redis::Client::open(s).map_err(|_| {
+            redis::RedisError::from((
+                redis::ErrorKind::InvalidClientConfig,
+                "failed to open redis client (connection string redacted)",
+            ))
+        })?;
         // some pool-builder defaults are set when the builder is initialized
         // so we can't overwrite any values with Nones...
         let pool_builder = r2d2::Pool::builder();
@@ -729,6 +849,9 @@ pub enum RedisCacheError {
     Redis(#[from] redis::RedisError),
     #[error("redis pool error")]
     Pool(#[from] r2d2::Error),
+    /// **Security note:** `cached_value` may contain sensitive application data
+    /// (it is the raw bytes retrieved from Redis). Do not log this variant or
+    /// expose `cached_value` in error messages or observability pipelines.
     #[error("Error deserializing cached value")]
     CacheDeserialization {
         #[source]
@@ -800,11 +923,14 @@ fn deserialize_cached_redis_value<V: serde::de::DeserializeOwned>(
         Ok(v) => Ok(v),
         Err(msgpack_err) => {
             // Fall back to the pre-3.0 JSON format. Only treat the bytes as the
-            // legacy format if they parse as JSON AND carry the `version` key the
-            // old store always wrote — otherwise this is genuinely corrupt data
-            // and we should surface the original MessagePack error.
+            // legacy format if they parse as JSON AND carry a `version` key whose
+            // value matches the known version constant — otherwise this is genuinely
+            // corrupt data and we should surface the original MessagePack error.
+            // Checking the exact version value (not merely `is_some`) prevents a
+            // JSON object with an unexpected `version` (e.g. a future incompatible
+            // schema) from being silently accepted as a legacy entry.
             if let Ok(json) = serde_json::from_slice::<serde_json::Value>(bytes)
-                && json.get("version").is_some()
+                && json.get("version") == Some(&serde_json::json!(REDIS_VALUE_VERSION))
                 && let Ok(v) = serde_json::from_value::<CachedRedisValue<V>>(json)
             {
                 return Ok(v);
@@ -1064,6 +1190,27 @@ mod async_redis {
     #[cfg(feature = "redis_async_cache")]
     use redis::IntoConnectionInfo;
 
+    /// Builder for [`AsyncRedisCache`].
+    ///
+    /// **Feature:** requires one of `redis_tokio`, `redis_tokio_native_tls`,
+    /// `redis_tokio_rustls`, `redis_smol`, `redis_smol_native_tls`,
+    /// `redis_smol_rustls`, `redis_async_cache`, or `redis_connection_manager`.
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            feature = "async",
+            any(
+                feature = "redis_smol",
+                feature = "redis_smol_native_tls",
+                feature = "redis_smol_rustls",
+                feature = "redis_tokio",
+                feature = "redis_tokio_native_tls",
+                feature = "redis_tokio_rustls",
+                feature = "redis_async_cache",
+                feature = "redis_connection_manager"
+            )
+        )))
+    )]
     pub struct AsyncRedisCacheBuilder<K, V> {
         ttl: Option<Duration>,
         refresh: bool,
@@ -1209,6 +1356,30 @@ mod async_redis {
             }
         }
 
+        /// Returns `true` when the connection string URL explicitly pins `protocol=resp2`
+        /// (or `protocol=2`) in the query string.
+        ///
+        /// The redis crate defaults to RESP2 when no `protocol=` param is present, so
+        /// checking the parsed `ProtocolVersion` would incorrectly reject plain URLs.
+        /// This helper inspects the raw query string instead and only rejects URLs that
+        /// actively opt in to RESP2 — the scenarios where the user has explicitly
+        /// signalled an intent incompatible with client-side caching.
+        #[cfg(feature = "redis_async_cache")]
+        fn url_pins_resp2(s: &str) -> bool {
+            // Extract the query string fragment after `?` (if any) and scan for
+            // `protocol=resp2` or `protocol=2` as a key=value pair.  A simple
+            // string scan is sufficient because the redis crate's own `parse_protocol`
+            // uses the same comparison logic.
+            if let Some(query) = s.split('?').nth(1) {
+                for pair in query.split('&') {
+                    if let Some(val) = pair.strip_prefix("protocol=") {
+                        return val == "resp2" || val == "2";
+                    }
+                }
+            }
+            false
+        }
+
         /// Create a multiplexed redis connection. This is a single connection that can
         /// be used asynchronously by multiple futures.
         #[cfg(not(feature = "redis_connection_manager"))]
@@ -1219,7 +1390,21 @@ mod async_redis {
 
             #[cfg(feature = "redis_async_cache")]
             if self.client_side_caching {
-                let mut connection_info = s.into_connection_info()?;
+                // Reject URLs that explicitly pin RESP2 before parsing — client-side
+                // caching requires RESP3 and silently downgrading would cause the
+                // invalidation listener to no-op, serving stale data.
+                if Self::url_pins_resp2(&s) {
+                    return Err(RedisCacheBuildError::Resp2DowngradeWithClientSideCaching);
+                }
+
+                // Sanitize any parse error so the raw URL (which may contain a
+                // password) is not surfaced in the error's Display/Debug.
+                let mut connection_info = s.into_connection_info().map_err(|_| {
+                    redis::RedisError::from((
+                        redis::ErrorKind::InvalidClientConfig,
+                        "failed to parse redis connection info (connection string redacted)",
+                    ))
+                })?;
 
                 let mut config = redis::AsyncConnectionConfig::default();
                 let redis_settings = connection_info
@@ -1228,14 +1413,25 @@ mod async_redis {
                     .set_protocol(redis::ProtocolVersion::RESP3);
                 connection_info = connection_info.set_redis_settings(redis_settings);
                 config = config.set_cache_config(redis::caching::CacheConfig::default());
-                let client = redis::Client::open(connection_info)?;
+                let client = redis::Client::open(connection_info).map_err(|_| {
+                    redis::RedisError::from((
+                        redis::ErrorKind::InvalidClientConfig,
+                        "failed to open redis client (connection string redacted)",
+                    ))
+                })?;
                 let conn = client
                     .get_multiplexed_async_connection_with_config(&config)
                     .await?;
                 return Ok(conn);
             }
 
-            let client = redis::Client::open(s)?;
+            // Non-client-side-caching path: sanitize the Client::open error too.
+            let client = redis::Client::open(s).map_err(|_| {
+                redis::RedisError::from((
+                    redis::ErrorKind::InvalidClientConfig,
+                    "failed to open redis client (connection string redacted)",
+                ))
+            })?;
             let conn = client.get_multiplexed_async_connection().await?;
             Ok(conn)
         }
@@ -1250,7 +1446,22 @@ mod async_redis {
             let s = self.resolve_connection_string()?;
             #[cfg(feature = "redis_async_cache")]
             if self.client_side_caching {
-                let mut connection_info = s.into_connection_info()?;
+                // Reject URLs that explicitly pin RESP2 before parsing — client-side
+                // caching requires RESP3 and silently downgrading would cause the
+                // invalidation listener to no-op, serving stale data.
+                if Self::url_pins_resp2(&s) {
+                    return Err(RedisCacheBuildError::Resp2DowngradeWithClientSideCaching);
+                }
+
+                // Sanitize any parse error so the raw URL (which may contain a
+                // password) is not surfaced in the error's Display/Debug.
+                let mut connection_info = s.into_connection_info().map_err(|_| {
+                    redis::RedisError::from((
+                        redis::ErrorKind::InvalidClientConfig,
+                        "failed to parse redis connection info (connection string redacted)",
+                    ))
+                })?;
+
                 let redis_settings = connection_info
                     .redis_settings()
                     .clone()
@@ -1258,12 +1469,23 @@ mod async_redis {
                 connection_info = connection_info.set_redis_settings(redis_settings);
                 let config = redis::aio::ConnectionManagerConfig::default()
                     .set_cache_config(redis::caching::CacheConfig::default());
-                let client = redis::Client::open(connection_info)?;
+                let client = redis::Client::open(connection_info).map_err(|_| {
+                    redis::RedisError::from((
+                        redis::ErrorKind::InvalidClientConfig,
+                        "failed to open redis client (connection string redacted)",
+                    ))
+                })?;
                 let conn = redis::aio::ConnectionManager::new_with_config(client, config).await?;
                 return Ok(conn);
             }
 
-            let client = redis::Client::open(s)?;
+            // Non-client-side-caching path: sanitize the Client::open error too.
+            let client = redis::Client::open(s).map_err(|_| {
+                redis::RedisError::from((
+                    redis::ErrorKind::InvalidClientConfig,
+                    "failed to open redis client (connection string redacted)",
+                ))
+            })?;
             let conn = redis::aio::ConnectionManager::new(client).await?;
             Ok(conn)
         }
@@ -1313,11 +1535,32 @@ mod async_redis {
         }
     }
 
-    /// Cache store backed by redis
+    /// Async cache store backed by redis.
     ///
-    /// Values have a ttl applied and enforced by redis.
+    /// Values have a TTL applied and enforced by Redis.
     /// Uses a `redis::aio::MultiplexedConnection` or `redis::aio::ConnectionManager`
-    /// under the hood depending if feature `redis_connection_manager` is used or not.
+    /// under the hood depending on whether the `redis_connection_manager` feature is
+    /// enabled.
+    ///
+    /// **Feature:** requires one of `redis_tokio`, `redis_tokio_native_tls`,
+    /// `redis_tokio_rustls`, `redis_smol`, `redis_smol_native_tls`,
+    /// `redis_smol_rustls`, `redis_async_cache`, or `redis_connection_manager`.
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            feature = "async",
+            any(
+                feature = "redis_smol",
+                feature = "redis_smol_native_tls",
+                feature = "redis_smol_rustls",
+                feature = "redis_tokio",
+                feature = "redis_tokio_native_tls",
+                feature = "redis_tokio_rustls",
+                feature = "redis_async_cache",
+                feature = "redis_connection_manager"
+            )
+        )))
+    )]
     pub struct AsyncRedisCache<K, V> {
         pub(super) ttl: Mutex<Duration>,
         pub(super) refresh: AtomicBool,
@@ -1681,6 +1924,113 @@ mod async_redis {
             assert!(
                 matches!(result, Err(RedisCacheBuildError::EmptyScope)),
                 "expected EmptyScope"
+            );
+        }
+
+        /// S3: bad async URL with embedded password must not leak the password in
+        /// the build error's Display or Debug. No Redis server needed.
+        #[tokio::test]
+        async fn async_bad_url_with_password_does_not_leak_password() {
+            let secret = "async_super_secret_xyz";
+            let bad_url = format!("not-redis://:{secret}@nonexistent-host:9999");
+
+            let result = AsyncRedisCacheBuilder::<String, String>::new()
+                .prefix("test")
+                .ttl(Duration::from_secs(1))
+                .connection_string(&bad_url)
+                .build()
+                .await;
+
+            let err = result.expect_err("build must fail with a bad async URL");
+            let display = err.to_string();
+            let debug = format!("{err:?}");
+
+            assert!(
+                !display.contains(secret),
+                "Display must not expose the password; got: {display}"
+            );
+            assert!(
+                !debug.contains(secret),
+                "Debug must not expose the password; got: {debug}"
+            );
+        }
+
+        /// S5: building an AsyncRedisCache with `client_side_caching` enabled and a
+        /// URL that pins `protocol=resp2` must be rejected with
+        /// `Resp2DowngradeWithClientSideCaching`. No Redis server needed.
+        #[cfg(feature = "redis_async_cache")]
+        #[tokio::test]
+        async fn client_side_caching_rejects_resp2_url() {
+            // A valid redis URL that explicitly pins RESP2 via the query parameter.
+            let url_with_resp2 = "redis://127.0.0.1:6399?protocol=resp2";
+
+            let result = AsyncRedisCacheBuilder::<String, String>::new()
+                .prefix("test")
+                .ttl(Duration::from_secs(1))
+                .connection_string(url_with_resp2)
+                .client_side_caching(true)
+                .build()
+                .await;
+
+            assert!(
+                matches!(
+                    result,
+                    Err(RedisCacheBuildError::Resp2DowngradeWithClientSideCaching)
+                ),
+                "expected Resp2DowngradeWithClientSideCaching, got: {result:?}"
+            );
+        }
+
+        /// S5: building an AsyncRedisCache with `client_side_caching` enabled and a
+        /// URL that does NOT pin RESP2 must NOT be rejected for protocol reasons.
+        /// (It may fail for other reasons like no server, but not for the RESP2 guard.)
+        #[cfg(feature = "redis_async_cache")]
+        #[tokio::test]
+        async fn client_side_caching_accepts_resp3_url() {
+            // A URL with `protocol=resp3` must pass the RESP2 guard.
+            let url_with_resp3 = "redis://127.0.0.1:6399?protocol=resp3";
+
+            let result = AsyncRedisCacheBuilder::<String, String>::new()
+                .prefix("test")
+                .ttl(Duration::from_secs(1))
+                .connection_string(url_with_resp3)
+                .client_side_caching(true)
+                .build()
+                .await;
+
+            // Must NOT be the RESP2 guard error. May fail for other reasons (no server).
+            assert!(
+                !matches!(
+                    result,
+                    Err(RedisCacheBuildError::Resp2DowngradeWithClientSideCaching)
+                ),
+                "resp3 URL must not trigger the RESP2 guard; got: {result:?}"
+            );
+        }
+
+        /// S5: a URL without an explicit protocol query param also passes the RESP2 guard
+        /// (the default is RESP2 inside the redis crate, but the guard only fires when
+        /// the URL EXPLICITLY pins resp2).
+        #[cfg(feature = "redis_async_cache")]
+        #[tokio::test]
+        async fn client_side_caching_accepts_url_without_protocol_param() {
+            // No `protocol=` query param — must not trigger the guard.
+            let url_plain = "redis://127.0.0.1:6399";
+
+            let result = AsyncRedisCacheBuilder::<String, String>::new()
+                .prefix("test")
+                .ttl(Duration::from_secs(1))
+                .connection_string(url_plain)
+                .client_side_caching(true)
+                .build()
+                .await;
+
+            assert!(
+                !matches!(
+                    result,
+                    Err(RedisCacheBuildError::Resp2DowngradeWithClientSideCaching)
+                ),
+                "plain URL must not trigger the RESP2 guard; got: {result:?}"
             );
         }
 

--- a/src/stores/sharded/lru.rs
+++ b/src/stores/sharded/lru.rs
@@ -219,6 +219,9 @@ where
     /// explicit removes via [`ConcurrentCached::cache_remove`].
     /// `capacity` reflects the effective total capacity — may exceed the requested
     /// `size` when the 16-per-shard minimum floor is applied; see [`capacity`](Self::capacity).
+    ///
+    /// Approximate under concurrent mutation: no global lock is held across shards; each shard is
+    /// locked and read one at a time.
     #[must_use]
     pub fn metrics(&self) -> CacheMetrics {
         let mut hits = 0u64;
@@ -261,6 +264,9 @@ where
     }
 
     /// Total number of live entries across all shards.
+    ///
+    /// Approximate under concurrent mutation: no global lock is held across shards; each shard is
+    /// locked and read one at a time.
     #[must_use]
     pub fn len(&self) -> usize {
         self.inner
@@ -271,6 +277,9 @@ where
     }
 
     /// `true` if no entries are present.
+    ///
+    /// Approximate under concurrent mutation: no global lock is held across shards; each shard is
+    /// locked and read one at a time.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.inner

--- a/src/stores/sharded/lru_ttl.rs
+++ b/src/stores/sharded/lru_ttl.rs
@@ -429,7 +429,7 @@ where
                     .collect();
                 let mut removed = Vec::new();
                 for k in expired {
-                    // Use cache_remove_entry (not cache_remove) to avoid double-counting:
+                    // Use pop_raw (not cache_remove) to avoid double-counting:
                     // the outer evict() handles on_evict and non_capacity_evictions itself.
                     if let Some((key, entry)) = guard.pop_raw(&k) {
                         removed.push((key, entry));

--- a/src/stores/sharded/unbound.rs
+++ b/src/stores/sharded/unbound.rs
@@ -226,6 +226,9 @@ where
     K: Hash + Eq,
 {
     /// Return aggregate metrics across all shards.
+    ///
+    /// Note: the returned value is approximate under concurrent mutation — no global lock is held
+    /// across shards; each shard is locked and read one at a time.
     #[must_use]
     pub fn metrics(&self) -> CacheMetrics {
         let mut hits = 0u64;
@@ -262,12 +265,18 @@ where
     }
 
     /// Total number of live entries across all shards.
+    ///
+    /// Note: the returned value is approximate under concurrent mutation — no global lock is held
+    /// across shards; each shard is locked and read one at a time.
     #[must_use]
     pub fn len(&self) -> usize {
         self.inner.shards.iter().map(|s| s.lock.read().len()).sum()
     }
 
     /// `true` if no entries are present.
+    ///
+    /// Note: the returned value is approximate under concurrent mutation — no global lock is held
+    /// across shards; each shard is locked and read one at a time.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.inner.shards.iter().all(|s| s.lock.read().is_empty())

--- a/src/stores/ttl.rs
+++ b/src/stores/ttl.rs
@@ -127,7 +127,7 @@ impl<K, V, S> TtlCacheBuilder<K, V, S> {
 
     /// Set the initial allocation capacity (optional).
     #[must_use]
-    pub fn capacity(mut self, capacity: usize) -> Self {
+    pub fn initial_capacity(mut self, capacity: usize) -> Self {
         self.capacity = Some(capacity);
         self
     }
@@ -1127,5 +1127,17 @@ mod tests {
         assert_eq!(c.cache_get(&1), Some(&10));
         std::thread::sleep(std::time::Duration::from_millis(100));
         assert_eq!(c.cache_get(&1), None, "entry must expire after ttl");
+    }
+
+    #[test]
+    fn builder_initial_capacity_method_exists_and_preallocates() {
+        // Verifies the renamed builder method: initial_capacity() sets a preallocation hint.
+        let c = TtlCache::<u32, u32>::builder()
+            .ttl_secs(60)
+            .initial_capacity(32)
+            .build()
+            .unwrap();
+        // The backing store must have at least the requested capacity.
+        assert!(c.store.capacity() >= 32);
     }
 }

--- a/src/stores/ttl_sorted.rs
+++ b/src/stores/ttl_sorted.rs
@@ -132,6 +132,10 @@ impl<K, V> Entry<K, V> {
         }
     }
 
+    /// Returns `true` if the entry's expiry instant has passed.
+    /// Expires strictly AFTER `expiry` (`now > expiry`, i.e. `expiry < now`),
+    /// in contrast to [`TtlCache`](super::TtlCache) / `LruTtlCache` which expire
+    /// at-or-after (`now >= expires_at`).
     fn is_expired(&self) -> bool {
         self.expiry.is_some_and(|e| e < Instant::now())
     }
@@ -294,9 +298,9 @@ impl<K, V, S> TtlSortedCacheBuilder<K, V, S> {
     /// count. Only the backing map is pre-allocated; the `BTreeSet` TTL index is not.
     ///
     /// Note that [`set_max_size`](TtlSortedCache::set_max_size) on a live cache may re-grow
-    /// the backing map to `max_size + 1`, overriding a smaller `capacity` set here.
+    /// the backing map to `max_size + 1`, overriding a smaller `initial_capacity` set here.
     #[must_use]
-    pub fn capacity(mut self, capacity: usize) -> Self {
+    pub fn initial_capacity(mut self, capacity: usize) -> Self {
         self.capacity = Some(capacity);
         self
     }
@@ -452,7 +456,7 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> TtlSortedCache<K, V, S> {
     /// Returns the previous value if one was set.
     ///
     /// This grows the backing map to hold at least `max_size + 1` entries, so calling it on a
-    /// cache built with a deliberately small [`capacity`](TtlSortedCacheBuilder::capacity) will
+    /// cache built with a deliberately small [`initial_capacity`](TtlSortedCacheBuilder::initial_capacity) will
     /// override that smaller allocation.
     ///
     /// # Panics
@@ -1306,7 +1310,7 @@ mod test {
     fn borrow_keys() {
         let mut cache = TtlSortedCache::builder()
             .ttl(Duration::from_millis(100))
-            .capacity(100)
+            .initial_capacity(100)
             .build()
             .unwrap();
         cache.insert(String::from("a"), "a").unwrap();
@@ -1314,7 +1318,7 @@ mod test {
 
         let mut cache = TtlSortedCache::builder()
             .ttl(Duration::from_millis(100))
-            .capacity(100)
+            .initial_capacity(100)
             .build()
             .unwrap();
         cache.insert(vec![0], "a").unwrap();
@@ -1326,7 +1330,7 @@ mod test {
         let key = CountingKey::new("live");
         let mut cache = TtlSortedCache::builder()
             .ttl(Duration::from_secs(60))
-            .capacity(1)
+            .initial_capacity(1)
             .build()
             .unwrap();
         cache.insert(key.clone(), 10).unwrap();
@@ -1343,7 +1347,7 @@ mod test {
         let key = CountingKey::new("live-mut");
         let mut cache = TtlSortedCache::builder()
             .ttl(Duration::from_secs(60))
-            .capacity(1)
+            .initial_capacity(1)
             .build()
             .unwrap();
         cache.insert(key.clone(), 10).unwrap();
@@ -1428,7 +1432,7 @@ mod test {
     fn kitchen_sink() {
         let mut cache = TtlSortedCache::builder()
             .ttl(Duration::from_millis(100))
-            .capacity(100)
+            .initial_capacity(100)
             .build()
             .unwrap();
         assert_eq!(0, cache.evict());
@@ -1522,7 +1526,7 @@ mod test {
     fn set_max_size() {
         let mut cache = TtlSortedCache::builder()
             .ttl(Duration::from_millis(100))
-            .capacity(100)
+            .initial_capacity(100)
             .build()
             .unwrap();
         cache.set_max_size(2);
@@ -1547,7 +1551,7 @@ mod test {
     fn updating_existing_key_at_size_limit_does_not_evict_another_key() {
         let mut cache = TtlSortedCache::builder()
             .ttl(Duration::from_millis(1_000))
-            .capacity(2)
+            .initial_capacity(2)
             .build()
             .unwrap();
         cache.set_max_size(2);
@@ -1612,14 +1616,14 @@ mod test {
         let cache = TtlSortedCache::<u32, u32>::builder()
             .ttl(Duration::from_secs(300))
             .max_size(65_536)
-            .capacity(16)
+            .initial_capacity(16)
             .build()
             .unwrap();
         // The backing map must not have taken the max_size path, which would reserve
         // for max_size + 1 (= 65_537) entries.
         assert!(
             cache.map.capacity() < 65_537,
-            "expected the explicit capacity(16) to take precedence, got {}",
+            "expected the explicit initial_capacity(16) to take precedence, got {}",
             cache.map.capacity()
         );
         assert!(cache.map.capacity() >= 16);
@@ -2407,5 +2411,17 @@ mod test {
         std::thread::sleep(std::time::Duration::from_millis(100));
         // After TTL, entry should expire (lazy removal on cache_get).
         assert_eq!(c.cache_get(&1), None, "entry must expire after ttl");
+    }
+
+    #[test]
+    fn builder_initial_capacity_method_exists_and_preallocates() {
+        // Verifies the renamed builder method: initial_capacity() sets a preallocation hint.
+        let cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl_secs(60)
+            .initial_capacity(32)
+            .build()
+            .unwrap();
+        // The backing map must have at least the requested capacity.
+        assert!(cache.map.capacity() >= 32);
     }
 }

--- a/src/stores/unbound.rs
+++ b/src/stores/unbound.rs
@@ -96,7 +96,7 @@ impl<K, V> Default for UnboundCacheBuilder<K, V, DefaultHashBuilder> {
 impl<K, V, S> UnboundCacheBuilder<K, V, S> {
     /// Set the initial allocation capacity (optional, purely a hint).
     #[must_use]
-    pub fn capacity(mut self, capacity: usize) -> Self {
+    pub fn initial_capacity(mut self, capacity: usize) -> Self {
         self.capacity = Some(capacity);
         self
     }
@@ -489,7 +489,10 @@ mod tests {
         assert!(3 <= c.store.capacity()); // Keeps the allocated memory for reuse.
 
         let capacity = 1;
-        let mut c = UnboundCache::builder().capacity(capacity).build().unwrap();
+        let mut c = UnboundCache::builder()
+            .initial_capacity(capacity)
+            .build()
+            .unwrap();
         assert!(capacity <= c.store.capacity());
 
         assert_eq!(c.cache_set(1, 100), None);
@@ -520,7 +523,7 @@ mod tests {
 
         let init_capacity = 1;
         let mut c = UnboundCache::builder()
-            .capacity(init_capacity)
+            .initial_capacity(init_capacity)
             .build()
             .unwrap();
         assert_eq!(c.cache_set(1, 100), None);
@@ -659,7 +662,10 @@ mod tests {
 
     #[test]
     fn test_diagnostics_and_traits() {
-        let mut cache = UnboundCache::builder().capacity(10).build().unwrap();
+        let mut cache = UnboundCache::builder()
+            .initial_capacity(10)
+            .build()
+            .unwrap();
         cache.cache_set(1, 100);
         cache.cache_set(2, 200);
 
@@ -817,7 +823,7 @@ mod tests {
     fn custom_hasher_with_capacity_builder() {
         use std::collections::hash_map::RandomState;
         let mut c = UnboundCache::<u32, u32>::builder()
-            .capacity(16)
+            .initial_capacity(16)
             .hasher(RandomState::new())
             .build()
             .unwrap();
@@ -828,5 +834,16 @@ mod tests {
             assert_eq!(c.cache_get(&i), Some(&(i * 2)));
         }
         assert_eq!(c.cache_size(), 10);
+    }
+
+    #[test]
+    fn builder_initial_capacity_method_exists_and_preallocates() {
+        // Verifies the renamed builder method: initial_capacity() sets a preallocation hint.
+        let c = UnboundCache::<u32, u32>::builder()
+            .initial_capacity(32)
+            .build()
+            .unwrap();
+        // The backing store must have at least the requested capacity.
+        assert!(c.store.capacity() >= 32);
     }
 }

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -337,10 +337,10 @@ fn cached_return_flag(n: i32) -> cached::Return<i32> {
 #[test]
 fn test_cached_return_flag() {
     let r = cached_return_flag(1);
-    assert!(!r.was_cached);
+    assert!(!r.was_cached());
     assert_eq!(*r, 1);
     let r = cached_return_flag(1);
-    assert!(r.was_cached);
+    assert!(r.was_cached());
     // derefs to inner
     assert_eq!(*r, 1);
     assert!(r.is_positive());
@@ -364,10 +364,10 @@ fn cached_return_flag_result(n: i32) -> Result<cached::Return<i32>, ()> {
 #[test]
 fn test_cached_return_flag_result() {
     let r = cached_return_flag_result(1).unwrap();
-    assert!(!r.was_cached);
+    assert!(!r.was_cached());
     assert_eq!(*r, 1);
     let r = cached_return_flag_result(1).unwrap();
-    assert!(r.was_cached);
+    assert!(r.was_cached());
     // derefs to inner
     assert_eq!(*r, 1);
     assert!(r.is_positive());
@@ -394,10 +394,10 @@ fn cached_return_flag_option(n: i32) -> Option<cached::Return<i32>> {
 #[test]
 fn test_cached_return_flag_option() {
     let r = cached_return_flag_option(1).unwrap();
-    assert!(!r.was_cached);
+    assert!(!r.was_cached());
     assert_eq!(*r, 1);
     let r = cached_return_flag_option(1).unwrap();
-    assert!(r.was_cached);
+    assert!(r.was_cached());
     // derefs to inner
     assert_eq!(*r, 1);
     assert!(r.is_positive());
@@ -2523,8 +2523,8 @@ mod disk_tests {
 
     #[test]
     fn test_cached_disk_cached_flag() {
-        assert!(!cached_disk_cached_flag(1).unwrap().was_cached);
-        assert!(cached_disk_cached_flag(1).unwrap().was_cached);
+        assert!(!cached_disk_cached_flag(1).unwrap().was_cached());
+        assert!(cached_disk_cached_flag(1).unwrap().was_cached());
         assert!(cached_disk_cached_flag(5).is_err());
         assert!(cached_disk_cached_flag(6).is_err());
     }
@@ -3564,10 +3564,10 @@ mod concurrent_cached_default_with_cached_flag {
         FLAG_CALLS.store(0, Ordering::Relaxed);
         let first = flagged_double(7).unwrap();
         assert_eq!(*first, 14);
-        assert!(!first.was_cached, "first call should not be cached");
+        assert!(!first.was_cached(), "first call should not be cached");
         let second = flagged_double(7).unwrap();
         assert_eq!(*second, 14);
-        assert!(second.was_cached, "second call should be cached");
+        assert!(second.was_cached(), "second call should be cached");
         assert_eq!(FLAG_CALLS.load(Ordering::Relaxed), 1);
     }
 
@@ -3576,10 +3576,10 @@ mod concurrent_cached_default_with_cached_flag {
         PLAIN_FLAG_CALLS.store(0, Ordering::Relaxed);
         let first = flagged_plain_double(8);
         assert_eq!(*first, 16);
-        assert!(!first.was_cached, "first call should not be cached");
+        assert!(!first.was_cached(), "first call should not be cached");
         let second = flagged_plain_double(8);
         assert_eq!(*second, 16);
-        assert!(second.was_cached, "second call should be cached");
+        assert!(second.was_cached(), "second call should be cached");
         assert_eq!(PLAIN_FLAG_CALLS.load(Ordering::Relaxed), 1);
     }
 }
@@ -3644,10 +3644,10 @@ mod concurrent_cached_option {
         // Some — first call not cached, second is.
         let first = flagged_maybe_double(5).expect("should return Some");
         assert_eq!(*first, 10);
-        assert!(!first.was_cached, "first Some call should not be cached");
+        assert!(!first.was_cached(), "first Some call should not be cached");
         let second = flagged_maybe_double(5).expect("should return Some");
         assert_eq!(*second, 10);
-        assert!(second.was_cached, "second Some call should be cached");
+        assert!(second.was_cached(), "second Some call should be cached");
         assert_eq!(OPT_FLAG_CALLS.load(Ordering::Relaxed), 3);
     }
 }
@@ -3710,12 +3710,12 @@ mod concurrent_cached_async_option {
             .await
             .expect("should return Some");
         assert_eq!(*first, 12);
-        assert!(!first.was_cached, "first Some call should not be cached");
+        assert!(!first.was_cached(), "first Some call should not be cached");
         let second = async_flagged_maybe_double(6)
             .await
             .expect("should return Some");
         assert_eq!(*second, 12);
-        assert!(second.was_cached, "second Some call should be cached");
+        assert!(second.was_cached(), "second Some call should be cached");
         assert_eq!(ASYNC_OPT_FLAG_CALLS.load(Ordering::Relaxed), 3);
     }
 }
@@ -3746,10 +3746,10 @@ mod concurrent_cached_default_async_with_cached_flag {
         ASYNC_FLAG_CALLS.store(0, Ordering::Relaxed);
         let first = async_flagged_double(7).await.unwrap();
         assert_eq!(*first, 14);
-        assert!(!first.was_cached, "first call should not be cached");
+        assert!(!first.was_cached(), "first call should not be cached");
         let second = async_flagged_double(7).await.unwrap();
         assert_eq!(*second, 14);
-        assert!(second.was_cached, "second call should be cached");
+        assert!(second.was_cached(), "second call should be cached");
         assert_eq!(ASYNC_FLAG_CALLS.load(Ordering::Relaxed), 1);
     }
 
@@ -3758,10 +3758,10 @@ mod concurrent_cached_default_async_with_cached_flag {
         ASYNC_PLAIN_FLAG_CALLS.store(0, Ordering::Relaxed);
         let first = async_flagged_plain_double(8).await;
         assert_eq!(*first, 16);
-        assert!(!first.was_cached, "first call should not be cached");
+        assert!(!first.was_cached(), "first call should not be cached");
         let second = async_flagged_plain_double(8).await;
         assert_eq!(*second, 16);
-        assert!(second.was_cached, "second call should be cached");
+        assert!(second.was_cached(), "second call should be cached");
         assert_eq!(ASYNC_PLAIN_FLAG_CALLS.load(Ordering::Relaxed), 1);
     }
 }
@@ -4318,18 +4318,18 @@ mod sharded_expiring_tests {
 
             // First call: not cached.
             let r1 = get_flagged_expiring(42, flag.clone()).unwrap();
-            assert!(!r1.was_cached, "first call should not be cached");
+            assert!(!r1.was_cached(), "first call should not be cached");
             assert_eq!(r1.val, 42);
 
             // Second call: cached hit.
             let r2 = get_flagged_expiring(42, flag.clone()).unwrap();
-            assert!(r2.was_cached, "second call should be a cache hit");
+            assert!(r2.was_cached(), "second call should be a cache hit");
             assert_eq!(EXPIRES_FLAG_CALLS.load(Ordering::Relaxed), 1);
 
             // After expiry: function re-executes, was_cached = false.
             flag.store(true, Ordering::Relaxed);
             let r3 = get_flagged_expiring(42, flag.clone()).unwrap();
-            assert!(!r3.was_cached, "call after expiry should not be cached");
+            assert!(!r3.was_cached(), "call after expiry should not be cached");
             assert_eq!(EXPIRES_FLAG_CALLS.load(Ordering::Relaxed), 2);
         }
     }
@@ -4474,8 +4474,8 @@ mod redis_tests {
 
     #[test]
     fn test_cached_redis_cached_flag() {
-        assert!(!cached_redis_cached_flag(1).unwrap().was_cached);
-        assert!(cached_redis_cached_flag(1).unwrap().was_cached);
+        assert!(!cached_redis_cached_flag(1).unwrap().was_cached());
+        assert!(cached_redis_cached_flag(1).unwrap().was_cached());
         assert!(cached_redis_cached_flag(5).is_err());
         assert!(cached_redis_cached_flag(6).is_err());
     }
@@ -4543,8 +4543,18 @@ mod redis_tests {
 
         #[tokio::test]
         async fn test_async_cached_redis_cached_flag() {
-            assert!(!async_cached_redis_cached_flag(1).await.unwrap().was_cached);
-            assert!(async_cached_redis_cached_flag(1).await.unwrap().was_cached,);
+            assert!(
+                !async_cached_redis_cached_flag(1)
+                    .await
+                    .unwrap()
+                    .was_cached()
+            );
+            assert!(
+                async_cached_redis_cached_flag(1)
+                    .await
+                    .unwrap()
+                    .was_cached(),
+            );
             assert!(async_cached_redis_cached_flag(5).await.is_err());
             assert!(async_cached_redis_cached_flag(6).await.is_err());
         }
@@ -7520,10 +7530,10 @@ mod macro_arg_pairwise {
     #[test]
     fn test_once_with_cached_flag() {
         let first = once_flag(10);
-        assert!(!first.was_cached);
+        assert!(!first.was_cached());
         assert_eq!(*first, 11);
         let second = once_flag(999);
-        assert!(second.was_cached);
+        assert!(second.was_cached());
         assert_eq!(*second, 11);
     }
 
@@ -7541,9 +7551,9 @@ mod macro_arg_pairwise {
     fn test_once_result_with_cached_flag() {
         assert!(once_result_flag(false).is_err());
         let ok = once_result_flag(true).unwrap();
-        assert!(!ok.was_cached);
+        assert!(!ok.was_cached());
         let cached_ok = once_result_flag(true).unwrap();
-        assert!(cached_ok.was_cached);
+        assert!(cached_ok.was_cached());
         assert_eq!(*cached_ok, 1);
     }
 
@@ -7561,9 +7571,9 @@ mod macro_arg_pairwise {
     fn test_once_option_with_cached_flag() {
         assert!(once_option_flag(false).is_none());
         let s = once_option_flag(true).unwrap();
-        assert!(!s.was_cached);
+        assert!(!s.was_cached());
         let c = once_option_flag(true).unwrap();
-        assert!(c.was_cached);
+        assert!(c.was_cached());
         assert_eq!(*c, 2);
     }
 

--- a/tests/ui/cached_name_reserved_prefix.rs
+++ b/tests/ui/cached_name_reserved_prefix.rs
@@ -1,0 +1,10 @@
+use cached::macros::cached;
+
+// A `name` beginning with `__cached` is reserved for macro-generated bindings
+// and must be rejected.
+#[cached(name = "__cached_foo")]
+fn f(x: i32) -> i32 {
+    x
+}
+
+fn main() {}

--- a/tests/ui/cached_name_reserved_prefix.stderr
+++ b/tests/ui/cached_name_reserved_prefix.stderr
@@ -1,0 +1,5 @@
+error: cache names beginning with `__cached` are reserved for macro-generated bindings and cannot be used as a `name` value
+ --> tests/ui/cached_name_reserved_prefix.rs:6:4
+  |
+6 | fn f(x: i32) -> i32 {
+  |    ^

--- a/tests/ui/cached_with_cached_flag_unqualified_return.stderr
+++ b/tests/ui/cached_with_cached_flag_unqualified_return.stderr
@@ -1,7 +1,10 @@
-error[E0609]: no field `was_cached` on type `Return<i32>`
+error[E0599]: no method named `set_was_cached` found for struct `Return<T>` in the current scope
   --> tests/ui/cached_with_cached_flag_unqualified_return.rs:13:1
    |
+ 9 | struct Return<T> {
+   | ---------------- method `set_was_cached` not found for this struct
+...
 13 | #[cached(with_cached_flag = true)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown field
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method not found in `Return<i32>`
    |
    = note: this error originates in the attribute macro `cached` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/concurrent_cached_custom_create_required.stderr
+++ b/tests/ui/concurrent_cached_custom_create_required.stderr
@@ -1,4 +1,4 @@
-error: #[concurrent_cached] cache `create` block must be specified
+error: `ty` requires `create` to also be set
  --> tests/ui/concurrent_cached_custom_create_required.rs:4:4
   |
 4 | fn my_fn(k: i32) -> Result<i32, String> {

--- a/tests/ui/concurrent_cached_name_reserved_prefix.rs
+++ b/tests/ui/concurrent_cached_name_reserved_prefix.rs
@@ -1,0 +1,10 @@
+use cached::macros::concurrent_cached;
+
+// A `name` beginning with `__cached` is reserved for macro-generated bindings
+// and must be rejected.
+#[concurrent_cached(name = "__cached_foo")]
+fn f(x: i32) -> i32 {
+    x
+}
+
+fn main() {}

--- a/tests/ui/concurrent_cached_name_reserved_prefix.stderr
+++ b/tests/ui/concurrent_cached_name_reserved_prefix.stderr
@@ -1,0 +1,5 @@
+error: cache names beginning with `__cached` are reserved for macro-generated bindings and cannot be used as a `name` value
+ --> tests/ui/concurrent_cached_name_reserved_prefix.rs:6:4
+  |
+6 | fn f(x: i32) -> i32 {
+  |    ^

--- a/tests/ui/concurrent_cached_time_attr_renamed.stderr
+++ b/tests/ui/concurrent_cached_time_attr_renamed.stderr
@@ -1,4 +1,4 @@
-error: `time` (whole seconds) was renamed in cached 1.0; use `ttl_secs = ...` (or `ttl = "Duration::from_secs(...)"` / `ttl_millis = ...`)
+error: `time` was renamed in a prior major release; use `ttl_secs = ...` (or `ttl = "Duration::from_secs(...)"` / `ttl_millis = ...`)
  --> tests/ui/concurrent_cached_time_attr_renamed.rs:4:4
   |
 4 | fn my_fn(k: i32) -> Result<i32, String> {

--- a/tests/ui/concurrent_cached_time_refresh_attr_renamed.stderr
+++ b/tests/ui/concurrent_cached_time_refresh_attr_renamed.stderr
@@ -1,4 +1,4 @@
-error: `time_refresh` was renamed to `refresh` in cached 1.0; use `refresh = ...`
+error: `time_refresh` was renamed in a prior major release; use `refresh = ...`
  --> tests/ui/concurrent_cached_time_refresh_attr_renamed.rs:8:4
   |
 8 | fn my_fn(k: i32) -> Result<i32, String> {

--- a/tests/ui/once_generic_value_type_rejected.rs
+++ b/tests/ui/once_generic_value_type_rejected.rs
@@ -1,0 +1,12 @@
+use cached::macros::once;
+
+// A generic `#[once]` whose return type names a function type parameter is
+// rejected: the cache static is monomorphic and cannot hold a value of type `T`.
+// A non-generic `#[once]` and a generic `#[once]` with a concrete return type
+// (`fn foo<T>(_: T) -> usize`) must still compile.
+#[once]
+fn generic_once<T: Clone>(x: T) -> T {
+    x
+}
+
+fn main() {}

--- a/tests/ui/once_generic_value_type_rejected.stderr
+++ b/tests/ui/once_generic_value_type_rejected.stderr
@@ -1,0 +1,5 @@
+error: #[once]'s cache value type cannot name the function's generic parameter `T`: the generated cache static is monomorphic and cannot hold a value of a type that names a function-level type or const parameter. Make the return type concrete, or use `#[cached]` with `key`/`convert` to handle generic functions.
+ --> tests/ui/once_generic_value_type_rejected.rs:8:4
+  |
+8 | fn generic_once<T: Clone>(x: T) -> T {
+  |    ^^^^^^^^^^^^

--- a/tests/ui/once_name_reserved_prefix.rs
+++ b/tests/ui/once_name_reserved_prefix.rs
@@ -1,0 +1,10 @@
+use cached::macros::once;
+
+// A `name` beginning with `__cached` is reserved for macro-generated bindings
+// and must be rejected.
+#[once(name = "__cached_foo")]
+fn f() -> i32 {
+    42
+}
+
+fn main() {}

--- a/tests/ui/once_name_reserved_prefix.stderr
+++ b/tests/ui/once_name_reserved_prefix.stderr
@@ -1,0 +1,5 @@
+error: cache names beginning with `__cached` are reserved for macro-generated bindings and cannot be used as a `name` value
+ --> tests/ui/once_name_reserved_prefix.rs:6:4
+  |
+6 | fn f() -> i32 {
+  |    ^

--- a/tests/ui/once_sync_writes_buckets_inert.rs
+++ b/tests/ui/once_sync_writes_buckets_inert.rs
@@ -1,0 +1,11 @@
+use cached::macros::once;
+
+// `sync_writes_buckets` is inert on `#[once]` (buckets only apply to
+// `sync_writes = "by_key"`, which `#[once]` does not support).
+// Explicitly supplying it must be rejected with a clear error.
+#[once(sync_writes_buckets = 4)]
+fn my_fn() -> i32 {
+    42
+}
+
+fn main() {}

--- a/tests/ui/once_sync_writes_buckets_inert.stderr
+++ b/tests/ui/once_sync_writes_buckets_inert.stderr
@@ -1,5 +1,5 @@
 error: `sync_writes_buckets` is not supported on `#[once]`: buckets only apply to `sync_writes = "by_key"`, which `#[once]` does not support
- --> tests/ui/once_sync_writes_buckets_zero.rs:4:4
+ --> tests/ui/once_sync_writes_buckets_inert.rs:7:4
   |
-4 | fn my_fn(k: i32) -> i32 {
+7 | fn my_fn() -> i32 {
   |    ^^^^^

--- a/tests/ui/once_time_attr_renamed.stderr
+++ b/tests/ui/once_time_attr_renamed.stderr
@@ -1,4 +1,4 @@
-error: `time` (whole seconds) was renamed in cached 1.0; use `ttl_secs = ...` (or `ttl = "Duration::from_secs(...)"` / `ttl_millis = ...`)
+error: `time` was renamed in a prior major release; use `ttl_secs = ...` (or `ttl = "Duration::from_secs(...)"` / `ttl_millis = ...`)
  --> tests/ui/once_time_attr_renamed.rs:4:4
   |
 4 | fn my_fn(k: i32) -> i32 {

--- a/tests/ui/time_attr_renamed.stderr
+++ b/tests/ui/time_attr_renamed.stderr
@@ -1,4 +1,4 @@
-error: `time` (whole seconds) was renamed in cached 1.0; use `ttl_secs = ...` (or `ttl = "Duration::from_secs(...)"` / `ttl_millis = ...`)
+error: `time` was renamed in a prior major release; use `ttl_secs = ...` (or `ttl = "Duration::from_secs(...)"` / `ttl_millis = ...`)
  --> tests/ui/time_attr_renamed.rs:4:4
   |
 4 | fn my_fn(k: i32) -> i32 {

--- a/tests/ui/time_refresh_attr_renamed.stderr
+++ b/tests/ui/time_refresh_attr_renamed.stderr
@@ -1,4 +1,4 @@
-error: `time_refresh` was renamed to `refresh` in cached 1.0; use `refresh = ...`
+error: `time_refresh` was renamed in a prior major release; use `refresh = ...`
  --> tests/ui/time_refresh_attr_renamed.rs:4:4
   |
 4 | fn my_fn(k: i32) -> i32 {

--- a/tests/v3_macros.rs
+++ b/tests/v3_macros.rs
@@ -2425,3 +2425,60 @@ mod companions_vis_tests {
         );
     }
 }
+
+// ── G1 positive: generic `#[once]` with a concrete value type ────────────────
+// A generic `#[once]` function is valid as long as the return type does not name
+// any of the function's own type or const parameters. The guard added in G1
+// must not affect this case.
+
+static CONCRETE_ONCE_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+// `T` is used only as an input parameter; the return type `usize` is concrete.
+#[once]
+fn generic_once_concrete_return<T: std::fmt::Debug>(_x: T) -> usize {
+    CONCRETE_ONCE_CALLS.fetch_add(1, Ordering::SeqCst);
+    42
+}
+
+#[test]
+fn generic_once_concrete_value_type_compiles_and_caches() {
+    CONCRETE_ONCE_CALLS.store(0, Ordering::SeqCst);
+    // First call: body runs.
+    assert_eq!(generic_once_concrete_return::<i32>(1), 42);
+    assert_eq!(CONCRETE_ONCE_CALLS.load(Ordering::SeqCst), 1);
+    // Second call with different type/arg: cached hit, body does not re-run.
+    assert_eq!(
+        generic_once_concrete_return::<String>("hello".to_string()),
+        42
+    );
+    assert_eq!(
+        CONCRETE_ONCE_CALLS.load(Ordering::SeqCst),
+        1,
+        "#[once] with concrete return type: subsequent calls must be cache hits"
+    );
+}
+
+// ── G2 positive: valid custom `name` on `#[once]` still works ────────────────
+// A `name` that does NOT begin with `__cached` must compile and be usable as
+// the cache static identifier on `#[once]` (the G2 guard must not over-reject).
+
+static NAMED_ONCE_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+#[once(name = "MY_CUSTOM_ONCE_CACHE")]
+fn named_once_fn() -> usize {
+    NAMED_ONCE_CALLS.fetch_add(1, Ordering::SeqCst);
+    99
+}
+
+#[test]
+fn once_valid_name_compiles_and_caches() {
+    NAMED_ONCE_CALLS.store(0, Ordering::SeqCst);
+    assert_eq!(named_once_fn(), 99);
+    assert_eq!(NAMED_ONCE_CALLS.load(Ordering::SeqCst), 1);
+    assert_eq!(named_once_fn(), 99);
+    assert_eq!(
+        NAMED_ONCE_CALLS.load(Ordering::SeqCst),
+        1,
+        "valid custom name on #[once]: second call must be a cache hit"
+    );
+}

--- a/tests/v3_macros_ui.rs
+++ b/tests/v3_macros_ui.rs
@@ -93,4 +93,12 @@ fn compile_fail_v3_macros() {
     t.compile_fail("tests/ui/cached_convert_malformed_unquoted.rs");
     // Item #2: map_error = 5 (non-closure expression) rejected.
     t.compile_fail("tests/ui/concurrent_cached_map_error_non_closure.rs");
+    // G1: generic `#[once]` whose value type names a function type parameter.
+    t.compile_fail("tests/ui/once_generic_value_type_rejected.rs");
+    // G2: `name` beginning with `__cached` is reserved on all three macros.
+    t.compile_fail("tests/ui/cached_name_reserved_prefix.rs");
+    t.compile_fail("tests/ui/once_name_reserved_prefix.rs");
+    t.compile_fail("tests/ui/concurrent_cached_name_reserved_prefix.rs");
+    // D11: `sync_writes_buckets` is inert on `#[once]` (no `by_key` support).
+    t.compile_fail("tests/ui/once_sync_writes_buckets_inert.rs");
 }

--- a/tests/v3_serialize_set.rs
+++ b/tests/v3_serialize_set.rs
@@ -66,10 +66,10 @@ fn disk_with_cached_flag_round_trips_via_cache_set_ref() {
     FLAG_CALLS.store(0, std::sync::atomic::Ordering::SeqCst);
     let first = disk_flag(100).unwrap();
     assert_eq!(*first, 101);
-    assert!(!first.was_cached);
+    assert!(!first.was_cached());
     let second = disk_flag(100).unwrap();
     assert_eq!(*second, 101);
-    assert!(second.was_cached);
+    assert!(second.was_cached());
     // Body must have run exactly once: the second call is a cache hit.
     assert_eq!(FLAG_CALLS.load(std::sync::atomic::Ordering::SeqCst), 1);
 }


### PR DESCRIPTION
Security, soundness, and API changes for the 3.0.0 final release, made while the public API can still break.

## Breaking
- Rename builder `capacity()` to `initial_capacity()` on `UnboundCacheBuilder`, `TtlCacheBuilder`, `TtlSortedCacheBuilder`, and `ExpiringCacheBuilder` (pre-allocation hint, distinct from the `max_size` eviction bound).
- Make `Return<T>` fields private; add `into_inner()`, `was_cached()`, and `set_was_cached()`.
- Return `Option<usize>` from `set_max_size` on `LruCache`, `LruTtlCache`, and `ExpiringLruCache`, matching `TtlSortedCache`.
- Enable ahash `runtime-rng` on non-wasm targets so the default hasher seeds from the OS RNG; wasm32 keeps compile-time seeding.

See `docs/migrations/2.0-to-unreleased.md` for before/after snippets.

## Security
- `RedbCache`: create the directory `0700` and database file `0600` on unix, and reject a system-temp fallback that is a symlink or group/world-writable.
- Redis: scrub credentials from connection-string errors, require the exact version on the legacy JSON backward-read, and reject a RESP2 connection when client-side caching is enabled (it would silently serve stale data). Document `CacheDeserialization` as possibly-sensitive.
- Use fallible allocation in `LruCache::cache_reset` (avoids an abort after `set_max_size` grows the bound); saturating arithmetic in `lru_list`.

## Macros
- Reject a generic value type in `#[once]`, a `name` beginning with `__cached`, and `sync_writes_buckets` on `#[once]`, each with a clear compile error.
- Rename generated by-key lock bindings to the `__cached_` hygiene convention.

## Docs
- Correct the `#[cached]` `sync_writes` default (`by_key`), document `refresh` requiring a TTL and the `ty`/`expires` interaction, note sharded `len`/`metrics` are approximate, fix assorted store method docs, and add `#[must_use]` to `CacheEvict::evict`.

## Tests
- New unit tests, doctests, and trybuild compile-fail fixtures for the guards and hardening.

`make check` (fmt, readme, clippy, help) and the non-redis test suites pass. The Redis tests that need a live server (`tests/redis-store`, `tests/redis-tokio`, `tests/all-features`) were not run here; run `make ci` with the Docker Redis container before tagging.
