### PR TITLE
test: widen the async redb eviction race ttl to match the sync test

### DIFF
--- a/tests/v3_redb_races_async.rs
+++ b/tests/v3_redb_races_async.rs
@@ -96,9 +96,14 @@ async fn async_refresh_does_not_clobber_concurrent_write() {
 async fn async_cache_get_eviction_does_not_delete_fresh_rewrite() {
     // See the sync counterpart: TTL must comfortably exceed the gap between the
     // writer committing value=1 and the final read, so value=1 cannot legitimately
-    // expire before that read (which would be a false failure).
-    const TTL: Duration = Duration::from_millis(30);
-    const ROUNDS: usize = 200;
+    // expire before that read (which would be a false failure). 150 ms matches the
+    // sync test's margin against scheduler stalls on a saturated CI runner; the
+    // async path needs it even more since every op also hops through the
+    // `blocking::unblock` thread pool. 40 rounds gives the same ~0.5^ROUNDS
+    // race-miss probability as the sync test while keeping the runtime down
+    // (each round sleeps TTL+6 ms to expire the pre-set value).
+    const TTL: Duration = Duration::from_millis(150);
+    const ROUNDS: usize = 40;
 
     let dir = TempDir::new().unwrap();
     let cache = build("async-race-evict-get", &dir, Some(TTL), false);


### PR DESCRIPTION
- Raise the async `cache_get` eviction race test's ttl from 30 ms to 150 ms, matching the sync counterpart's margin against scheduler stalls
- Drop rounds from 200 to 40 (same ~0.5^rounds race-miss probability as the sync test, keeps the runtime ~6 s)

The 30 ms ttl let the fresh value legitimately expire between the writer's commit and the final read on a loaded CI runner, failing the round with `None` (post-merge master run 29133850694, round 175). The async path is more exposed than the sync one since every op also hops through the `blocking::unblock` thread pool. Not a store bug: the write-txn re-check behaves correctly; the test's expiry margin was just too thin.