### PR TITLE
3.0.0-rc.7: pre-release review fixes (redis prefix guard, redb dir self-heal, docs, example CI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## [Unreleased]
 
+## [3.0.0-rc.7 / cached_proc_macro 3.0.0-rc.7] - 2026-07-12
+
+### Breaking Changes
+
+- `RedisCacheBuilder::build()` / `AsyncRedisCacheBuilder::build()` reject an empty prefix with `Build(BuildError::InvalidValue { field: "prefix", .. })`. The prefix is what scopes `cache_clear` to one logical cache; with an empty prefix, `cache_clear` matches `<namespace>:*` and deletes the entries of every cache sharing the namespace (all of them, under the shared default namespace). The `RedisCacheBuildError::EmptyScope` variant from rc.3 (which fired only when namespace and prefix were both empty) is removed; the empty-prefix rejection subsumes it. See the [migration guide](docs/migrations/2.0-to-3.0.md#9-rediscachebuilderbuild--asyncrediscachebuilderbuild-reject-an-empty-prefix).
+- `#[concurrent_cached]` rejects an `async` closure for `map_error` at the macro with a pointed message. It previously passed macro validation and failed downstream at the `Result::map_err` `FnOnce` bound with an opaque type error.
+
+### Fixed
+
+- `RedbCache` default-directory resolution self-heals a pre-existing cache directory with legacy permissions. A directory created by an earlier `cached` version was created with the process umask (0775 under the umask-002 user-private-group default of Debian/Ubuntu) and permanently failed the security validation with "I/O error preparing the disk cache directory"; the app-derived candidate is now tightened to 0700 and re-validated (the chmod only succeeds for the owner, so an attacker-owned or symlinked directory still falls through to the next candidate instead of aborting).
+- `ShardedExpiringLruCache::cache_set` evaluates the displaced entry's `is_expired()` exactly once, under the shard write lock. It previously evaluated twice (once inside the lock for the eviction counter, once outside for `on_evict` and the return value), so a value crossing the expiry threshold between the two calls fired `on_evict` without counting the eviction. The other sharded expiring stores already evaluated once.
+- `RedisCacheBuildError::MissingConnectionString` redacts the env-var value carried by `std::env::VarError::NotUnicode`. The raw value is the connection string itself (credentials included) and was printed by both `Display` and `Debug`.
+- `RedisCacheBuildError` uses a manual `Debug` impl, matching `RedisCacheError` / `RedbCacheError` / `RedbCacheBuildError`.
+- `make examples` actually runs the registered examples again: the per-example targets are `.PHONY`, and make skips implicit-rule search for phony targets, so the `examples/basic/%` / `examples/redis/%` pattern rules silently expanded to nothing and only the two explicitly-ruled examples (`wasm`, `redis-async-async-std`) ran. The rules are now static pattern rules, `expires_per_key` and `struct_method` are registered, and the expansion guard checks every registered example expands to its own run command.
+
+### Documentation
+
+- `Cached`'s trait-object recipe is now the compiling form `dyn ConcurrentCached<K, V, Error = E>` (the previous `dyn ConcurrentCached<K, V> + ConcurrentCacheBase<Error = E>` spelling fails E0225: only one non-auto trait is allowed in `dyn`).
+- The sharded stores' inherent `get` docs name `ConcurrentCachedExt::get` as the trait-qualified call; the documented `ConcurrentCached::get(&store, k)` does not compile (the `get` alias lives on the extension trait).
+- The evictions-counter exception in the store comparison covers both unbounded non-expiring stores (`UnboundCache` and `ShardedUnboundCache` return `None` from `metrics().evictions`), not just the sharded one.
+- The migration guide's feature-name section no longer claims `serde` is a private `dep:` name: `serde` is a public feature (since rc.5) enabling `SerializeCached` support for custom stores; the feature table and error-message index now list it.
+- `RedisCache` / `AsyncRedisCache` struct docs describe the TTL as optional (entries built without one persist until removed) instead of always applied.
+- `strict_deserialization` docs (redis and redb) state that the previous value displaced by `cache_set` is discarded in both modes when it cannot be decoded, and that a strict-mode `remove_expired_entries` sweep aborts atomically (evictions from earlier in the pass are rolled back; covered by a new test).
+- `RedbCache::remove_expired_entries` no longer links `CacheEvict::evict` (a trait `RedbCache` does not implement); it explains the naming and `Result` return instead.
+- `ShardedLruCache`'s `on_evict` builder doc enumerates `cache_clear_with_on_evict` as a firing site, matching the other sharded stores; `cache_prefix_block` docs show the unquoted expression form.
+
 ## [3.0.0-rc.6 / cached_proc_macro 3.0.0-rc.6] - 2026-07-09
 
 > Fixes from the 3.0.0 pre-release review. The 2.x -> 3.0 upgrade is documented in the [migration guide](docs/migrations/2.0-to-3.0.md).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cached"
-version = "3.0.0-rc.6"
+version = "3.0.0-rc.7"
 authors = ["James Kominick <james@kominick.com>"]
 description = "Generic cache implementations and simplified function memoization"
 repository = "https://github.com/jaemk/cached"
@@ -76,7 +76,7 @@ redb_store = ["serde", "dep:redb", "dep:directories", "dep:blocking"]
 time_stores = []
 
 [dependencies.cached_proc_macro]
-version = "3.0.0-rc.6"
+version = "3.0.0-rc.7"
 path = "cached_proc_macro"
 optional = true
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,9 @@
 # **enabled**
 CACHED_BASIC_EXAMPLES = async_std \
                         basic \
+                        expires_per_key \
                         kitchen_sink \
+                        struct_method \
                         tokio \
                         sharded \
                         sharded_expiring \
@@ -167,9 +169,17 @@ help: ## List all supported Make targets
 	done
 
 ################################################################################
+# Guard against the example targets silently expanding to nothing (e.g. the
+# .PHONY/implicit-rule interaction fixed below): every registered example must
+# expand to its own `run --example <name>` (or the wasm `build --target`) in a
+# dry run, not just "at least one command somewhere".
 .check-examples-expanded:
 	@output="$$( $(MAKE) -n --no-print-directory examples/basic examples/cargo examples/redis )"; \
-	echo "$$output" | grep -Eq 'run --example|build --target' || (>&2 echo 'Example targets did not expand to runnable commands'; exit 1)
+	for example in $(CACHED_BASIC_EXAMPLES) $(CACHED_REDIS_EXAMPLES); do \
+		echo "$$output" | grep -q -- "run --example $$example" \
+			|| (>&2 echo "Example target '$$example' did not expand to a runnable command"; exit 1) || exit 1; \
+	done; \
+	echo "$$output" | grep -q 'build --target' || (>&2 echo 'wasm example did not expand to a build command'; exit 1)
 
 # Runs all examples
 examples: .check-examples-expanded examples/basic examples/cargo examples/redis
@@ -180,7 +190,12 @@ examples/cargo: $(CACHED_CARGO_EXAMPLE_TARGETS)
 # Runs `redis` related examples. NOTE: depends on `docker/redis`
 examples/redis: $(CACHED_REDIS_EXAMPLE_TARGETS)
 
-examples/basic/%:
+# Static pattern rule (not an implicit `examples/basic/%:` one): these targets are
+# declared .PHONY via HELP_TARGETS, and make skips implicit-rule search for phony
+# targets, so an implicit rule here silently expands to "Nothing to be done" and no
+# example runs. A static pattern rule is an explicit rule per target, which .PHONY
+# targets do use.
+$(CACHED_BASIC_EXAMPLE_TARGETS): examples/basic/%:
 	@echo [$@]: Running example $*...
 	$(CARGO_COMMAND) run --example $* --all-features
 
@@ -195,7 +210,10 @@ examples/redis/redis-async-async-std: docker/redis
 	@echo [$@]: Running example redis-async-async-std...
 	$(CARGO_COMMAND) run --example redis-async-async-std --features "redis_smol_native_tls,proc_macro"
 
-examples/redis/%: docker/redis
+# Static pattern rule for the same .PHONY reason as the basic examples above.
+# redis-async-async-std is excluded: it has its own explicit rule with a narrower
+# feature set (smol), and a second recipe from this rule would conflict.
+$(filter-out examples/redis/redis-async-async-std,$(CACHED_REDIS_EXAMPLE_TARGETS)): examples/redis/%: docker/redis
 	@echo [$@]: Running example $*...
 	$(CARGO_COMMAND) run --example $* --all-features
 

--- a/README.md
+++ b/README.md
@@ -246,9 +246,10 @@ Because LRU caches require updating access recency, `ShardedLruCache`, `ShardedL
 - Expired values can remain allocated until a mutating operation, `evict`, or
   store-specific cleanup removes them.
 - `cache_remove` fires the `on_evict` callback (if set) and counts as an eviction for
-  every successful removal, across all stores that track evictions. `ShardedUnboundCache` is the
-  exception: it has no evictions counter and always returns `None` from
-  `metrics().evictions`, though its `on_evict` callback still fires. The `on_evict` column
+  every successful removal, across all stores that track evictions. The unbounded
+  non-expiring stores (`UnboundCache`, `ShardedUnboundCache`) are the exception: they have
+  no evictions counter and always return `None` from
+  `metrics().evictions`, though their `on_evict` callback still fires. The `on_evict` column
   above marks the unbounded stores where explicit removal is the *only* eviction trigger. For stores with
   expiry, removing a present-but-already-expired entry still evicts and fires `on_evict`,
   but `cache_remove` returns `None`; use `cache_delete` or `cache_remove_entry` when you

--- a/cached_proc_macro/Cargo.toml
+++ b/cached_proc_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cached_proc_macro"
-version = "3.0.0-rc.6"
+version = "3.0.0-rc.7"
 authors = ["csos95 <csoscss@gmail.com>", "James Kominick <james@kominick.com>"]
 description = "Generic cache implementations and simplified function memoization"
 repository = "https://github.com/jaemk/cached"

--- a/cached_proc_macro/src/cached.rs
+++ b/cached_proc_macro/src/cached.rs
@@ -787,15 +787,8 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
         .into();
     }
 
-    // The default is already `Disabled`, so when `result_fallback` is set and `sync_writes`
-    // was not explicitly specified, no override is required (the resolved value is already
-    // `Disabled`). This branch is a no-op but is kept for clarity and explicit-conflict
-    // detection above.
-    let sync_writes = if args.result_fallback && !sync_writes_explicit {
-        SyncWriteMode::Disabled
-    } else {
-        sync_writes
-    };
+    // No `sync_writes` override is needed for `result_fallback`: the default is already
+    // `Disabled`, and an explicit non-`Disabled` combination was rejected above.
 
     if args.result_fallback && !is_result_return {
         return syn::Error::new(
@@ -943,8 +936,7 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
     // re-runs and re-caches. `if !(block)` guards each hit return; with no
     // `force_refresh` the guard is `if true` (always take the cached value).
     // This is orthogonal to `refresh` (TTL renewal on hit) (#146).
-    let force_refresh_guard = match build_force_refresh_guard(&args.force_refresh, fn_ident.span())
-    {
+    let force_refresh_guard = match build_force_refresh_guard(&args.force_refresh) {
         Ok(guard) => guard,
         Err(error) => return error.to_compile_error().into(),
     };

--- a/cached_proc_macro/src/concurrent_cached.rs
+++ b/cached_proc_macro/src/concurrent_cached.rs
@@ -925,10 +925,23 @@ pub fn concurrent_cached(args: TokenStream, input: TokenStream) -> TokenStream {
         (Some(expr), false) => {
             // Verify the expression is a closure; other expression types are not
             // valid for `map_error`.
-            if !matches!(expr, syn::Expr::Closure(_)) {
+            let syn::Expr::Closure(closure) = expr else {
                 return syn::Error::new_spanned(
                     expr,
                     "`map_error` must be a closure, e.g. `map_error = |e| MyErr(e)`",
+                )
+                .to_compile_error()
+                .into();
+            };
+            // An async closure would pass the closure check but fail downstream at
+            // the `.map_err(...)` bound (`FnOnce`) with an opaque type error;
+            // reject it here with a pointed message instead.
+            if closure.asyncness.is_some() {
+                return syn::Error::new_spanned(
+                    expr,
+                    "`map_error` must be a synchronous closure (it is passed to \
+                     `Result::map_err`); remove the `async` keyword, e.g. \
+                     `map_error = |e| MyErr(e)`",
                 )
                 .to_compile_error()
                 .into();
@@ -1104,8 +1117,7 @@ pub fn concurrent_cached(args: TokenStream, input: TokenStream) -> TokenStream {
     // Orthogonal to `refresh` (TTL renewal on hit) (#146).
     // Parse the `force_refresh` predicate once; both the cached-hit guard and the
     // `result_fallback` bypass token below are built from this single parsed block.
-    let force_refresh_block = match parse_force_refresh_block(&args.force_refresh, fn_ident.span())
-    {
+    let force_refresh_block = match parse_force_refresh_block(&args.force_refresh) {
         Ok(block) => block,
         Err(error) => return error.to_compile_error().into(),
     };

--- a/cached_proc_macro/src/helpers.rs
+++ b/cached_proc_macro/src/helpers.rs
@@ -2,8 +2,8 @@ use darling::ast::NestedMeta;
 use darling::{Error, FromMeta};
 use proc_macro::TokenStream;
 use proc_macro_crate::{FoundCrate, crate_name};
+use proc_macro2::Span;
 use proc_macro2::TokenStream as TokenStream2;
-use quote::__private::Span;
 use quote::{format_ident, quote};
 use std::ops::Deref;
 use syn::punctuated::Punctuated;
@@ -580,7 +580,6 @@ pub(super) fn with_cache_flag_error(output_span: Span, output_type_display: Stri
 /// `force_refresh = true`) with a diagnostic directing the user to the block form.
 pub(super) fn parse_force_refresh_block(
     force_refresh: &Option<syn::Expr>,
-    _span: Span,
 ) -> Result<Option<Block>, syn::Error> {
     match force_refresh {
         Some(expr) => {
@@ -653,9 +652,8 @@ pub(super) fn expr_value_tokens(expr: &syn::Expr) -> TokenStream2 {
 /// on hit) (#146). Shared by `#[cached]`, `#[concurrent_cached]`, and `#[once]`.
 pub(super) fn build_force_refresh_guard(
     force_refresh: &Option<syn::Expr>,
-    span: Span,
 ) -> Result<TokenStream2, syn::Error> {
-    match parse_force_refresh_block(force_refresh, span)? {
+    match parse_force_refresh_block(force_refresh)? {
         Some(block) => Ok(quote! { if !(#block) }),
         None => Ok(quote! { if true }),
     }

--- a/cached_proc_macro/src/lib.rs
+++ b/cached_proc_macro/src/lib.rs
@@ -382,9 +382,10 @@ pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
 /// - `ty`: (optional, string type) explicitly specify the cache store type to use. When `ty` is
 ///   specified, `create` must also be specified (the macro cannot construct a custom store type without
 ///   a matching `create` block; omitting `create` is a compile error on every path).
-/// - `cache_prefix_block`: (optional, string expr; **redis path only**) specify an expression used to
+/// - `cache_prefix_block`: (optional, expr; **redis path only**) specify an expression used to
 ///   create the string used as a prefix for redis keys for this function, e.g.
-///   `cache_prefix_block = r##"{ "my_prefix" }"##`. Only meaningful when `redis = true` without a
+///   `cache_prefix_block = { "my_prefix" }` (or the legacy quoted form
+///   `cache_prefix_block = r##"{ "my_prefix" }"##`). Only meaningful when `redis = true` without a
 ///   `create` block; has no effect on the in-memory or disk paths, and is rejected when combined with
 ///   `create` (a `create` block constructs the entire store, making the prefix irrelevant).
 ///   When not specified, the prefix defaults to `"cached::macros::concurrent_cached::{fn_name}"`.

--- a/cached_proc_macro/src/once.rs
+++ b/cached_proc_macro/src/once.rs
@@ -584,8 +584,7 @@ pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
     // return is skipped so the body re-runs and re-caches the single shared value.
     // The guard wraps the whole cached-value check (not just the return), so a
     // TTL'd entry's expiry test is bypassed too and the body always re-runs.
-    let force_refresh_guard = match build_force_refresh_guard(&args.force_refresh, fn_ident.span())
-    {
+    let force_refresh_guard = match build_force_refresh_guard(&args.force_refresh) {
         Ok(guard) => guard,
         Err(error) => return error.to_compile_error().into(),
     };

--- a/docs/migrations/2.0-to-3.0.md
+++ b/docs/migrations/2.0-to-3.0.md
@@ -104,7 +104,7 @@ and an exhaustive `{ .. }` field match must add a `..` rest pattern; build one w
 
 ### 5. Builder `refresh()` → `refresh_on_hit()`
 
-Detection: grep for `.refresh(` on a cache builder (`TtlCacheBuilder`, `LruTtlCacheBuilder`, sharded TTL builders, `DiskCacheBuilder`, `RedisCacheBuilder`, `AsyncRedisCacheBuilder`).
+Detection: grep for `.refresh(` on a cache builder (`TtlCacheBuilder`, `LruTtlCacheBuilder`, sharded TTL builders, the 2.x `DiskCacheBuilder` — renamed `RedbCacheBuilder` in 3.0, see #6 — `RedisCacheBuilder`, `AsyncRedisCacheBuilder`).
 
 Action: rename the builder method call to `.refresh_on_hit(`. The `#[cached(refresh = true)]` macro attribute is unchanged.
 
@@ -158,13 +158,30 @@ Action: add a TLS backend feature alongside the runtime feature:
 `.connection_manager(true)` opt-in rather than cfg-swapping every cache's connection type as in
 2.x. See #57 for the full capability/runtime feature axis.
 
-### 9. `RedisCacheBuilder::build()` / `AsyncRedisCacheBuilder::build()` return `EmptyScope` when namespace and prefix are both empty
+### 9. `RedisCacheBuilder::build()` / `AsyncRedisCacheBuilder::build()` reject an empty prefix
 
-`EmptyScope` fires only when the namespace (after trimming all trailing `:` characters) resolves to an empty string AND the prefix is also empty. The default namespace is `"cached-redis-store:"`, which trims to the non-empty `"cached-redis-store"`, so a plain `RedisCache::builder("").ttl(ttl)` (empty prefix, default namespace) does NOT trigger this error. `EmptyScope` is only reachable if you explicitly set the namespace to `""` (or an all-colon string such as `":::"`) AND leave the prefix empty.
+The prefix is what scopes `cache_clear` / `async_cache_clear` to one logical cache: with an
+empty prefix, clear matches `<namespace>:*` and deletes the entries of every cache sharing the
+namespace (all of them, under the shared default namespace `"cached-redis-store:"`). In 2.x an
+empty prefix was accepted silently; `build()` now returns
+`Err(RedisCacheBuildError::Build(BuildError::InvalidValue { field: "prefix", .. }))` for a
+prefix explicitly set to `""` (an unset prefix still returns
+`Build(BuildError::MissingRequired("prefix"))`).
 
-Detection: a `build()` call returns `Err(RedisCacheBuildError::EmptyScope)` at runtime, or (on the `redis = true` macro path, where the builder is called internally) a panic at the first cache call.
+Detection: a `build()` call returns the `InvalidValue { field: "prefix", .. }` error at runtime,
+or (on the `redis = true` macro path, where the builder is called internally) a panic at the
+first cache call. Grep for `.prefix("")` and `RedisCache::builder("")` /
+`AsyncRedisCache::builder("")`.
 
-Action: set a non-empty namespace (`.namespace("my_ns")`) or a non-empty prefix (`.prefix("my_prefix")`) on the builder before calling `build()`. The `#[concurrent_cached(redis = true)]` macro always supplies the function name as the cache prefix, so macro-generated caches are unaffected. For hand-constructed builders, `EmptyScope` is only reachable if you explicitly set the namespace to `""` (or call `.namespace("")`) AND leave the prefix unset; the default namespace `"cached-redis-store:"` already prevents it if you do not override the namespace.
+Action: give each logical cache a distinct non-empty prefix. The
+`#[concurrent_cached(redis = true)]` macro always supplies the function name as the cache
+prefix, so macro-generated caches are unaffected. If you previously used an empty prefix with a
+custom namespace as the scope, move that scope string into the prefix (e.g.
+`.prefix("my-scope")`); key layout stays `{namespace}:{prefix}:{key}`.
+
+Note for pre-release users: the `RedisCacheBuildError::EmptyScope` variant introduced in
+3.0.0-rc.3 (which fired only when namespace and prefix were both empty) was removed; the
+empty-prefix rejection above subsumes it.
 
 ### 10. `get_or_set_with` family returns `&V` instead of `&mut V`
 
@@ -1260,16 +1277,20 @@ Type-inferred uses and the defaults (`E = NoEvict`, `H = DefaultShardHasher`) ne
 
 ### 61. `dep:`-gated internal dependencies are not public feature names
 
-`serde`, `rmp-serde`, `serde_json`, and `r2d2` are declared as `dep:serde` / `dep:rmp-serde` /
-`dep:serde_json` / `dep:r2d2` inside the feature definitions. This makes them private to the
-feature resolver and removes them as public feature names. Any `cached = { features = ["serde"]
-}` or `features = ["rmp-serde"]` in a `Cargo.toml` now produces: `the package 'cached' does not
-contain this feature: serde`.
+`rmp-serde`, `serde_json`, and `r2d2` are declared as `dep:rmp-serde` / `dep:serde_json` /
+`dep:r2d2` inside the feature definitions. This makes them private to the feature resolver and
+removes them as public feature names. Any `features = ["rmp-serde"]` in a `Cargo.toml` now
+produces: `the package 'cached' does not contain this feature: rmp-serde`.
 
-These deps are pulled in automatically by `redis_store` (serde, rmp-serde, serde_json, r2d2) and
-`redb_store` (serde, rmp-serde). They are not selectable on their own.
+These deps are pulled in automatically by `redis_store` (rmp-serde, serde_json, r2d2) and
+`redb_store` (rmp-serde). They are not selectable on their own.
 
-Detection: `the package 'cached' does not contain this feature: X` for X in {serde, rmp-serde,
+`serde` is different: it IS a public `cached` feature. It enables serialization support
+(`serde` + the MessagePack codec) for implementing `SerializeCached` on a custom store without
+pulling an IO-store feature; `redis_store` and `redb_store` enable it transitively. A
+`cached = { features = ["serde"] }` line keeps working.
+
+Detection: `the package 'cached' does not contain this feature: X` for X in {rmp-serde,
 serde_json, r2d2}.
 
 Action: remove the dep name from your `cached` features list. If you need the dep directly in
@@ -1283,6 +1304,7 @@ features is:
 | `time_stores` | yes | `TtlCache`, `LruTtlCache`, `TtlSortedCache` |
 | `async_core` | no | async trait definitions without a runtime |
 | `async` | no | async support (`async-lock`; no tokio) |
+| `serde` | no | `SerializeCached` support for custom stores (serde + MessagePack codec) |
 | `redis_store` | no | synchronous Redis backend |
 | `redis_tokio` | no | async Redis + tokio runtime |
 | `redis_tokio_native_tls` | no | `redis_tokio` + native-tls |
@@ -1376,7 +1398,7 @@ and means entries are written without an expiry command (a plain `SET`), so they
 Detection: a `match` or `if let` that handled `RedisCacheBuildError::Build(BuildError::MissingRequired(f)) if f == "ttl"` to catch an absent TTL.
 
 Action: remove that arm. If you want entries to expire, set `.ttl(Duration)` on the builder
-explicitly. `EmptyScope` and `Build(BuildError::InvalidValue)` (zero TTL) remain reachable.
+explicitly. `Build(BuildError::InvalidValue)` remains reachable (zero TTL, empty prefix — see #9).
 
 ### 66. `#[concurrent_cached(disk = true, cache_prefix_block = ...)]` is now a compile error
 
@@ -1473,7 +1495,7 @@ has a breaking change this major, see #51).
   - unresolved `blocking` in an `async`-only build → depend on `blocking` directly or enable `redb_store` (#56).
   - a redis build that fails to compile inside redis-rs for want of a runtime → pair the capability feature with `redis_tokio*` or `redis_smol*`; a cache that no longer uses the connection manager → call `.connection_manager(true)` (#57).
   - `the trait bound V: Clone`/`V: Eq is not satisfied` on a custom `CloneCached` / `Eq` impl, or a macro error requiring `create` on a `ty`-typed concurrent cache → add the bound or `create = "..."` (#58).
-  - `the package 'cached' does not contain this feature: serde` (or `rmp-serde`, `serde_json`, `r2d2`) → these are private `dep:` dependencies, not public feature names; remove them from your `cached` features list (#61).
+  - `the package 'cached' does not contain this feature: rmp-serde` (or `serde_json`, `r2d2`) → these are private `dep:` dependencies, not public feature names; remove them from your `cached` features list. `serde` itself is a public feature and keeps working (#61).
   - E0053 `method cache_set_ref has an incompatible type` on a custom `impl SerializeCached` → change the return type to `Result<(), Self::Error>` (#62).
   - `no method named len` on a `ConcurrentCacheBase` bound or fully-qualified call → replaced by `cache_size`; `is_empty` renamed to `cache_is_empty` (#63). Note: concrete sharded types keep their inherent `len`/`is_empty` returning plain values.
   - `RedisCache::builder()` / `AsyncRedisCache::builder()` / `RedbCache::builder()` with no arguments fails to compile → pass the prefix/name as a positional argument: `builder("my_prefix")` / `builder("my_name")` (#64).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,9 +245,10 @@ Because LRU caches require updating access recency, `ShardedLruCache`, `ShardedL
 - Expired values can remain allocated until a mutating operation, `evict`, or
   store-specific cleanup removes them.
 - `cache_remove` fires the `on_evict` callback (if set) and counts as an eviction for
-  every successful removal, across all stores that track evictions. `ShardedUnboundCache` is the
-  exception: it has no evictions counter and always returns `None` from
-  `metrics().evictions`, though its `on_evict` callback still fires. The `on_evict` column
+  every successful removal, across all stores that track evictions. The unbounded
+  non-expiring stores (`UnboundCache`, `ShardedUnboundCache`) are the exception: they have
+  no evictions counter and always return `None` from
+  `metrics().evictions`, though their `on_evict` callback still fires. The `on_evict` column
   above marks the unbounded stores where explicit removal is the *only* eviction trigger. For stores with
   expiry, removing a present-but-already-expired entry still evicts and fires `on_evict`,
   but `cache_remove` returns `None`; use `cache_delete` or `cache_remove_entry` when you
@@ -851,7 +852,8 @@ pub mod prelude {
 /// get-or-set family), so `dyn Cached<K, V>` does not work; use a concrete store
 /// type. For a trait-object-friendly cache use the internally-synchronized
 /// [`ConcurrentCached`] family instead, which keeps its one generic method out of
-/// the vtable (`dyn ConcurrentCached<K, V> + ConcurrentCacheBase<Error = E>`).
+/// the vtable (`dyn ConcurrentCached<K, V, Error = E>` — the `Error` associated
+/// type comes from the `ConcurrentCacheBase` supertrait and is specified inline).
 ///
 /// The async traits (`CachedGetOrSetAsync`, `ConcurrentCachedAsync`) use the `async_cache_*` spelling
 /// (`async_cache_get`, `async_cache_set`, `async_cache_remove`, ...) so they never collide

--- a/src/stores/redb.rs
+++ b/src/stores/redb.rs
@@ -223,7 +223,15 @@ where
     /// **Strict mode (`true`):** deserialization failures are surfaced as
     /// `Err(RedbCacheError::CacheDeserialization { .. })` and the entry is left in
     /// place. Use this if you prefer to detect data corruption rather than silently
-    /// skip it.
+    /// skip it. A strict-mode `remove_expired_entries` sweep aborts on the first
+    /// corrupt entry it hits, and because the whole sweep runs in one redb write
+    /// transaction, validly-expired entries removed earlier in that same pass are
+    /// rolled back too — the store is left exactly as it was before the call.
+    ///
+    /// In **both** modes, the previous value displaced by `cache_set` is silently
+    /// discarded when it cannot be decoded (the write itself succeeds and
+    /// `Ok(None)` is returned): the setting governs reads, not the best-effort
+    /// previous-value decode on writes.
     #[must_use]
     pub fn strict_deserialization(mut self, strict: bool) -> Self {
         self.strict_deserialization = strict;
@@ -258,20 +266,13 @@ where
         let mut last_error = None;
 
         for disk_dir in candidates {
-            match create_cache_dir(&disk_dir) {
-                Ok(()) => {
-                    // On unix, validate every directory we pick on the caller's
-                    // behalf (XDG candidates and the temp fallback), not just the
-                    // last one: reject symlinks and world/group-writable dirs to
-                    // guard against symlink-based TOCTOU attacks (SEC-4).
-                    #[cfg(unix)]
-                    validate_cache_dir(&disk_dir)?;
-                    return Ok(disk_dir);
-                }
-                // Fall through to the next candidate when this one is unusable
-                // because the filesystem denies writes: a read-only mount aborts
-                // with `ReadOnlyFilesystem` rather than `PermissionDenied`, so
-                // both must trigger the fallback to temp (DISK-9).
+            match prepare_default_cache_dir(&disk_dir) {
+                Ok(()) => return Ok(disk_dir),
+                // Fall through to the next candidate when this one is unusable:
+                // the filesystem denies writes (a read-only mount aborts with
+                // `ReadOnlyFilesystem` rather than `PermissionDenied`, so both
+                // must trigger the fallback to temp, DISK-9), or the directory
+                // failed the SEC-4 validation and could not be healed.
                 Err(error)
                     if matches!(
                         error.kind(),
@@ -430,6 +431,38 @@ fn create_cache_dir(path: &Path) -> Result<(), std::io::Error> {
     }
 }
 
+/// Create (if needed) and validate one default-path candidate directory.
+///
+/// On unix the candidate must pass `validate_cache_dir` (SEC-4: no symlink, not
+/// group- or world-writable). A directory created by this crate is always 0700,
+/// but a pre-existing one from an earlier `cached` version was created with the
+/// process umask — 0775 under the user-private-group scheme common on
+/// Debian/Ubuntu (umask 002) — and would fail the validation forever. Since the
+/// candidate is an app-derived path (not user-supplied), self-heal that case by
+/// tightening the permissions to 0700 and re-validating. The chmod only succeeds
+/// for the owner, so an attacker-owned directory still fails validation and the
+/// caller falls through to the next candidate.
+fn prepare_default_cache_dir(disk_dir: &Path) -> Result<(), std::io::Error> {
+    create_cache_dir(disk_dir)?;
+    #[cfg(unix)]
+    {
+        if let Err(error) = validate_cache_dir(disk_dir) {
+            // Never chmod through a symlink; that error is not healable here.
+            if std::fs::symlink_metadata(disk_dir)?
+                .file_type()
+                .is_symlink()
+            {
+                return Err(error);
+            }
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(disk_dir, std::fs::Permissions::from_mode(0o700))
+                .map_err(|_| error)?;
+            validate_cache_dir(disk_dir)?;
+        }
+    }
+    Ok(())
+}
+
 /// On unix, validate that a cache directory we resolved on the caller's behalf
 /// (an XDG candidate or the temp fallback) is not a symlink and is not group- or
 /// world-writable. Guards against symlink-based TOCTOU attacks where an adversary
@@ -566,9 +599,14 @@ where
     }
 
     /// Remove all entries whose TTL has elapsed, returning the number of entries
-    /// removed (aligning with [`CacheEvict::evict`](crate::CacheEvict::evict) /
-    /// [`ConcurrentCacheEvict::evict`](crate::ConcurrentCacheEvict::evict), which
-    /// also return `usize`).
+    /// removed. This is `RedbCache`'s counterpart to the in-memory stores'
+    /// [`ConcurrentCacheEvict::evict`](crate::ConcurrentCacheEvict::evict) (which also
+    /// returns the removed count); it has its own name and a `Result` return because
+    /// sweeping a disk store can fail, so `RedbCache` does not implement that trait.
+    ///
+    /// In strict-deserialization mode the sweep aborts on the first corrupt entry and
+    /// the whole pass is rolled back; see
+    /// [`RedbCacheBuilder::strict_deserialization`].
     pub fn remove_expired_entries(&self) -> Result<usize, RedbCacheError> {
         remove_expired_entries_impl::<V>(
             &self.connection,
@@ -2268,6 +2306,46 @@ mod tests {
         );
     }
 
+    /// A strict-mode sweep that errors on a corrupt entry must leave the store
+    /// exactly as it was: the whole sweep runs in one redb write transaction, so
+    /// validly-expired entries removed earlier in the pass are rolled back when
+    /// the transaction aborts.
+    #[test]
+    fn remove_expired_entries_strict_mode_error_rolls_back_prior_evictions() {
+        let tmp_dir = temp_dir!();
+        let cache: RedbCache<u32, u32> = RedbCache::builder("sweep-strict-rolls-back")
+            .disk_directory(tmp_dir.path())
+            .ttl(LIFE_SPAN_1_SEC)
+            .strict_deserialization(true)
+            .build()
+            .expect("error building disk cache");
+
+        // A valid entry that will be expired by sweep time. Its key ("1") sorts
+        // before the corrupt entry's key ("5"), so the sweep visits it first.
+        cache.cache_set(1, 10).unwrap();
+        sleep(LIFE_SPAN_1_SEC + Duration::from_millis(50));
+        raw_insert(&cache, &5u32.to_string(), vec![0xc1, 0xc1, 0xc1]);
+
+        assert!(matches!(
+            cache.remove_expired_entries(),
+            Err(RedbCacheError::CacheDeserialization { .. })
+        ));
+        assert!(
+            raw_get(&cache, &1u32.to_string()).is_some(),
+            "the expired-but-valid entry must be rolled back, not removed"
+        );
+        assert!(
+            raw_get(&cache, &5u32.to_string()).is_some(),
+            "the corrupt entry must be left in place"
+        );
+
+        // A follow-up sweep in self-heal terms: removing the corrupt entry by key
+        // unblocks the sweep, which then removes the expired entry.
+        assert!(cache.cache_delete(&5).unwrap());
+        assert_eq!(cache.remove_expired_entries().unwrap(), 1);
+        assert!(raw_get(&cache, &1u32.to_string()).is_none());
+    }
+
     /// D2: after a self-healed miss the corrupt entry is gone; recomputing via
     /// `cache_set` and reading again must produce a HIT. Guards that the self-heal
     /// delete does not poison subsequent writes to the same key.
@@ -3442,6 +3520,53 @@ mod tests {
                 result.is_err(),
                 "validate_cache_dir must reject a world-writable dir"
             );
+            assert_eq!(
+                result.unwrap_err().kind(),
+                std::io::ErrorKind::PermissionDenied
+            );
+        }
+
+        /// A pre-existing default-path candidate left at 0775 by an earlier
+        /// `cached` version (created with the umask-002 user-private-group
+        /// default of Debian/Ubuntu) must be self-healed to 0700 and accepted,
+        /// not rejected forever.
+        #[test]
+        fn legacy_group_writable_default_dir_is_healed_to_0700() {
+            let parent = temp_dir!();
+            let dir = parent.path().join("legacy_cache");
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::create_dir(&dir).expect("create_dir");
+            std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o775))
+                .expect("set_permissions");
+
+            super::super::prepare_default_cache_dir(&dir)
+                .expect("a legacy 0775 candidate must be healed, not rejected");
+            let mode = std::fs::metadata(&dir).expect("metadata").mode() & 0o777;
+            assert_eq!(mode, 0o700, "healed dir must be 0700; got {mode:o}");
+        }
+
+        /// A fresh (not yet existing) default-path candidate is created at 0700.
+        #[test]
+        fn fresh_default_dir_is_created_and_accepted() {
+            let parent = temp_dir!();
+            let dir = parent.path().join("fresh_cache");
+            super::super::prepare_default_cache_dir(&dir).expect("fresh candidate must succeed");
+            let mode = std::fs::metadata(&dir).expect("metadata").mode() & 0o777;
+            assert_eq!(mode, 0o700, "fresh dir must be 0700; got {mode:o}");
+        }
+
+        /// A symlinked default-path candidate is not healed (never chmod through
+        /// a symlink); it errors with `PermissionDenied` so the default-path
+        /// search falls through to the next candidate.
+        #[test]
+        fn symlinked_default_dir_is_not_healed() {
+            let real_dir = temp_dir!();
+            let link_parent = temp_dir!();
+            let link_path = link_parent.path().join("symlink_cache");
+            std::os::unix::fs::symlink(real_dir.path(), &link_path).expect("symlink");
+
+            let result = super::super::prepare_default_cache_dir(&link_path);
+            assert!(result.is_err(), "a symlink candidate must be rejected");
             assert_eq!(
                 result.unwrap_err().kind(),
                 std::io::ErrorKind::PermissionDenied

--- a/src/stores/redis.rs
+++ b/src/stores/redis.rs
@@ -299,52 +299,109 @@ mod builder_ttl_setter_tests {
 }
 
 #[cfg(test)]
-mod builder_empty_scope_tests {
-    // No Redis server needed -- verifies the empty-scope guard in `build()`.
+mod builder_empty_prefix_tests {
+    // No Redis server needed -- verifies the empty-prefix guard in `build()`.
+    use super::super::BuildError;
     use super::{RedisCacheBuildError, RedisCacheBuilder};
     use crate::time::Duration;
 
     #[test]
-    fn empty_namespace_and_prefix_is_rejected() {
+    fn empty_prefix_with_default_namespace_is_rejected() {
+        // The dangerous shape: the default namespace is shared by every cache, so
+        // an empty prefix would let cache_clear delete all of their entries.
         let result = RedisCacheBuilder::<String, String>::new()
             .prefix("")
             .ttl(Duration::from_secs(1))
-            .namespace("")
             .build();
         assert!(
-            matches!(result, Err(RedisCacheBuildError::EmptyScope)),
-            "expected EmptyScope"
+            matches!(
+                result,
+                Err(RedisCacheBuildError::Build(BuildError::InvalidValue {
+                    field: "prefix",
+                    ..
+                }))
+            ),
+            "expected InvalidValue for empty prefix"
         );
     }
 
     #[test]
-    fn namespace_all_colons_and_empty_prefix_is_rejected() {
-        // ":::" trims to "" so the effective namespace is also empty.
+    fn empty_prefix_with_custom_namespace_is_rejected() {
         let result = RedisCacheBuilder::<String, String>::new()
             .prefix("")
             .ttl(Duration::from_secs(1))
-            .namespace(":::")
+            .namespace("my-ns")
             .build();
         assert!(
-            matches!(result, Err(RedisCacheBuildError::EmptyScope)),
-            "expected EmptyScope"
+            matches!(
+                result,
+                Err(RedisCacheBuildError::Build(BuildError::InvalidValue {
+                    field: "prefix",
+                    ..
+                }))
+            ),
+            "expected InvalidValue for empty prefix"
         );
     }
 
     #[test]
-    fn non_empty_prefix_builds_ok() {
+    fn non_empty_prefix_passes_the_guard() {
         // Guard must not fire when the prefix is set -- no real Redis needed
-        // because the build error would come before the connection attempt.
+        // because a build error past the guard would come from the connection
+        // path, not prefix validation.
         let result = RedisCacheBuilder::<String, String>::new()
             .prefix("my-prefix")
             .ttl(Duration::from_secs(1))
             .namespace("")
             .build();
-        // The only failure here would be a missing connection string, not EmptyScope.
         assert!(
-            !matches!(result, Err(RedisCacheBuildError::EmptyScope)),
-            "EmptyScope must not fire when prefix is non-empty"
+            !matches!(
+                result,
+                Err(RedisCacheBuildError::Build(BuildError::InvalidValue {
+                    field: "prefix",
+                    ..
+                }))
+            ),
+            "prefix guard must not fire when prefix is non-empty"
         );
+    }
+}
+
+#[cfg(test)]
+mod var_error_sanitize_tests {
+    use super::{RedisCacheBuildError, sanitize_var_error};
+
+    #[test]
+    fn not_unicode_value_is_redacted() {
+        #[cfg(unix)]
+        let raw = {
+            use std::os::unix::ffi::OsStringExt;
+            std::ffi::OsString::from_vec(b"redis://user:s3cret@host\xff".to_vec())
+        };
+        #[cfg(not(unix))]
+        let raw = std::ffi::OsString::from("redis://user:s3cret@host");
+
+        let sanitized = sanitize_var_error(std::env::VarError::NotUnicode(raw));
+        let err = RedisCacheBuildError::MissingConnectionString {
+            env_key: "CACHED_REDIS_CONNECTION_STRING".to_string(),
+            error: sanitized,
+        };
+        let display = format!("{err}");
+        let debug = format!("{err:?}");
+        assert!(
+            !display.contains("s3cret"),
+            "Display leaked the value: {display}"
+        );
+        assert!(!debug.contains("s3cret"), "Debug leaked the value: {debug}");
+        assert!(display.contains("[REDACTED connection string]"));
+    }
+
+    #[test]
+    fn not_present_is_preserved() {
+        assert!(matches!(
+            sanitize_var_error(std::env::VarError::NotPresent),
+            std::env::VarError::NotPresent
+        ));
     }
 }
 
@@ -720,7 +777,7 @@ use thiserror::Error;
 /// the variant (e.g. `Connection { .. }`, `Pool { .. }`) rather than
 /// downcast-inspecting the source.
 #[non_exhaustive]
-#[derive(Error, Debug)]
+#[derive(Error)]
 pub enum RedisCacheBuildError {
     /// Redis client or connection failed to open.
     ///
@@ -739,18 +796,19 @@ pub enum RedisCacheBuildError {
     },
     #[error(transparent)]
     Build(#[from] super::BuildError),
+    /// No connection string was set and the env var is absent or invalid.
+    ///
+    /// The `error` is always *sanitized* before it is stored here: a
+    /// [`VarError::NotUnicode`](std::env::VarError::NotUnicode) would otherwise
+    /// carry the raw env-var value — the connection string itself, credentials
+    /// included — and print it through `Display`/`Debug`. See
+    /// [`sanitize_var_error`].
     #[error("Connection string not specified or invalid in env var {env_key:?}: {error}")]
     MissingConnectionString {
         env_key: String,
         #[source]
         error: std::env::VarError,
     },
-    #[error(
-        "empty scope: namespace (after trimming trailing colons) and prefix are both empty; \
-        cache_clear would run SCAN MATCH * and delete every key in the Redis DB. \
-        Set a non-empty namespace or prefix."
-    )]
-    EmptyScope,
     /// The connection URL explicitly pins the RESP2 protocol (`?protocol=resp2`)
     /// while `client_side_caching` is enabled. Client-side caching requires
     /// RESP3; the combination is rejected at build time to prevent the
@@ -762,6 +820,49 @@ pub enum RedisCacheBuildError {
         protocol=resp2; remove the protocol parameter or set it to resp3"
     )]
     Resp2DowngradeWithClientSideCaching,
+}
+
+// Manual `Debug`, matching `RedisCacheError` / `RedbCacheError` / `RedbCacheBuildError`.
+// Every payload here is sanitized at construction (see the variant docs), so a derived
+// impl would not leak today; the manual impl keeps the whole error family on the same
+// pattern and gives future variants a single place where redaction is the norm.
+impl std::fmt::Debug for RedisCacheBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Connection { source } => f
+                .debug_struct("Connection")
+                .field("source", source)
+                .finish(),
+            Self::Pool { source } => f.debug_struct("Pool").field("source", source).finish(),
+            Self::Build(e) => f.debug_tuple("Build").field(e).finish(),
+            Self::MissingConnectionString { env_key, error } => f
+                .debug_struct("MissingConnectionString")
+                .field("env_key", env_key)
+                .field("error", error)
+                .finish(),
+            #[cfg(feature = "redis_async_cache")]
+            Self::Resp2DowngradeWithClientSideCaching => {
+                f.write_str("Resp2DowngradeWithClientSideCaching")
+            }
+        }
+    }
+}
+
+/// Sanitize a [`std::env::VarError`] before storing it in
+/// [`RedisCacheBuildError::MissingConnectionString`].
+///
+/// `VarError::NotUnicode` carries the raw env-var value — for
+/// `CACHED_REDIS_CONNECTION_STRING` that is the connection string itself,
+/// credentials included — and `VarError`'s `Display`/`Debug` both print it.
+/// Replace the payload with a fixed redaction marker; the variant is kept so
+/// callers can still distinguish "unset" from "invalid unicode".
+fn sanitize_var_error(e: std::env::VarError) -> std::env::VarError {
+    match e {
+        std::env::VarError::NotPresent => std::env::VarError::NotPresent,
+        std::env::VarError::NotUnicode(_) => {
+            std::env::VarError::NotUnicode("[REDACTED connection string]".into())
+        }
+    }
 }
 
 impl RedisCacheBuildError {
@@ -871,17 +972,17 @@ where
         self
     }
 
-    /// Set the prefix for cache keys (required).
+    /// Set the prefix for cache keys (required, non-empty).
     /// Used to generate keys formatted as: `{namespace}:{prefix}:{key}`.
-    /// Empty prefix values are omitted from the generated key.
     ///
     /// **Note:** colons in the prefix are not escaped and can cause key collisions
     /// with differently-split namespace/prefix combinations sharing the same segments.
     ///
-    /// **Note:** the prefix is what scopes `cache_clear` to this logical cache.
-    /// With an empty prefix, `cache_clear` matches `<namespace>:*` and will delete
-    /// entries belonging to every cache that shares the same namespace. Set a unique
-    /// prefix per logical cache to ensure `cache_clear` is scoped correctly.
+    /// **Note:** the prefix is what scopes `cache_clear` to this logical cache, so
+    /// give each logical cache a distinct prefix. An empty prefix is rejected by
+    /// [`build`](Self::build) with `BuildError::InvalidValue`: it would make
+    /// `cache_clear` match `<namespace>:*` and delete entries belonging to every
+    /// cache that shares the same namespace.
     #[must_use]
     pub fn prefix<S: AsRef<str>>(mut self, prefix: S) -> Self {
         self.prefix = Some(prefix.as_ref().to_string());
@@ -940,12 +1041,16 @@ where
     /// When `false` (the default), a corrupt or otherwise undecodable cached
     /// value on the `cache_get` path is self-healed: the offending entry is
     /// deleted and the call returns `Ok(None)` (a miss), allowing the cached
-    /// function to recompute and overwrite. The previous-value returned by
-    /// `cache_set` is also silently discarded when it cannot be decoded.
+    /// function to recompute and overwrite.
     ///
-    /// When `true`, any deserialization failure returns
+    /// When `true`, a deserialization failure on the read path returns
     /// `Err(RedisCacheError::CacheDeserialization { .. })` immediately, matching
     /// the behavior of versions prior to 3.0.
+    ///
+    /// In **both** modes, the previous value displaced by `cache_set` is silently
+    /// discarded when it cannot be decoded (the write itself succeeds and
+    /// `Ok(None)` is returned): the setting governs reads, not the best-effort
+    /// previous-value decode on writes.
     #[must_use]
     pub fn strict_deserialization(mut self, strict: bool) -> Self {
         self.strict_deserialization = strict;
@@ -968,7 +1073,8 @@ where
             None => std::env::var(ENV_KEY).map(ConnectionString).map_err(|e| {
                 RedisCacheBuildError::MissingConnectionString {
                     env_key: ENV_KEY.to_string(),
-                    error: e,
+                    // `NotUnicode` carries the raw connection string; redact it.
+                    error: sanitize_var_error(e),
                 }
             }),
         }
@@ -1035,9 +1141,10 @@ where
     ///
     /// - `Build(BuildError::MissingRequired("prefix"))`: no key prefix was set.
     /// - `Build(BuildError::InvalidValue { field: "ttl", .. })`: an explicitly-set TTL is zero.
-    /// - `EmptyScope`: both the namespace (after trimming trailing colons) and
-    ///   the prefix are empty. `cache_clear` would otherwise issue `SCAN MATCH *`
-    ///   and delete every key in the Redis database.
+    /// - `Build(BuildError::InvalidValue { field: "prefix", .. })`: the prefix is
+    ///   empty. The prefix scopes `cache_clear` to this cache; with an empty
+    ///   prefix, `cache_clear` would issue `SCAN MATCH <namespace>:*` and delete
+    ///   the entries of every cache sharing the namespace.
     /// - `MissingConnectionString`: no connection string was set and the
     ///   `CACHED_REDIS_CONNECTION_STRING` env var is absent or invalid.
     /// - `Connection` / `Pool`: the Redis client or connection pool could not
@@ -1061,9 +1168,18 @@ where
             }
             None => Duration::ZERO,
         };
-        let prefix = self.prefix.as_deref().unwrap_or_default();
-        if self.namespace.trim_end_matches(':').is_empty() && prefix.is_empty() {
-            return Err(RedisCacheBuildError::EmptyScope);
+        // The prefix is what scopes `cache_clear` to this logical cache: with an
+        // empty prefix, `cache_clear` matches `<namespace>:*` and deletes the
+        // entries of every cache sharing the namespace (all of them, under the
+        // shared default namespace). Reject it outright.
+        if self.prefix.as_deref().is_some_and(str::is_empty) {
+            return Err(super::BuildError::InvalidValue {
+                field: "prefix",
+                reason: "prefix must be non-empty: it is what scopes cache_clear to this \
+                         cache; with an empty prefix cache_clear would delete every key \
+                         under the namespace",
+            }
+            .into());
         }
         let connection_string = self.resolve_connection_string()?;
         let pool = self.create_pool()?;
@@ -1082,8 +1198,9 @@ where
 
 /// Cache store backed by redis
 ///
-/// Values have a ttl applied and enforced by redis.
-/// Uses an r2d2 connection pool under the hood.
+/// The TTL is optional and enforced by redis itself: entries built with a TTL
+/// expire server-side; entries built without one persist until explicitly
+/// removed. Uses an r2d2 connection pool under the hood.
 pub struct RedisCache<K, V> {
     pub(super) ttl: Mutex<Duration>,
     pub(super) refresh: AtomicBool,
@@ -1830,18 +1947,17 @@ mod async_redis {
             self
         }
 
-        /// Set the prefix for cache keys (required).
+        /// Set the prefix for cache keys (required, non-empty).
         /// Used to generate keys formatted as: `{namespace}:{prefix}:{key}`.
-        /// Empty prefix values are omitted from the generated key.
         ///
         /// **Note:** colons in the prefix are not escaped and can cause key collisions
         /// with differently-split namespace/prefix combinations sharing the same segments.
         ///
         /// **Note:** the prefix is what scopes `async_cache_clear` to this logical
-        /// cache. With an empty prefix, `async_cache_clear` matches `<namespace>:*`
-        /// and will delete entries belonging to every cache that shares the same
-        /// namespace. Set a unique prefix per logical cache to ensure
-        /// `async_cache_clear` is scoped correctly.
+        /// cache, so give each logical cache a distinct prefix. An empty prefix is
+        /// rejected by [`build`](Self::build) with `BuildError::InvalidValue`: it
+        /// would make `async_cache_clear` match `<namespace>:*` and delete entries
+        /// belonging to every cache that shares the same namespace.
         #[must_use]
         pub fn prefix<S: AsRef<str>>(mut self, prefix: S) -> Self {
             self.prefix = Some(prefix.as_ref().to_string());
@@ -1890,8 +2006,13 @@ mod async_redis {
         ///
         /// When `false` (the default), a corrupt or undecodable cached value on the
         /// `async_cache_get` path is self-healed: the entry is deleted and the call
-        /// returns `Ok(None)`. When `true`, any deserialization failure returns
-        /// `Err(RedisCacheError::CacheDeserialization { .. })`.
+        /// returns `Ok(None)`. When `true`, a deserialization failure on the read
+        /// path returns `Err(RedisCacheError::CacheDeserialization { .. })`.
+        ///
+        /// In **both** modes, the previous value displaced by `async_cache_set` is
+        /// silently discarded when it cannot be decoded (the write itself succeeds
+        /// and `Ok(None)` is returned): the setting governs reads, not the
+        /// best-effort previous-value decode on writes.
         #[must_use]
         pub fn strict_deserialization(mut self, strict: bool) -> Self {
             self.strict_deserialization = strict;
@@ -1915,7 +2036,8 @@ mod async_redis {
                 None => std::env::var(ENV_KEY).map(ConnectionString).map_err(|e| {
                     RedisCacheBuildError::MissingConnectionString {
                         env_key: ENV_KEY.to_string(),
-                        error: e,
+                        // `NotUnicode` carries the raw connection string; redact it.
+                        error: super::sanitize_var_error(e),
                     }
                 }),
             }
@@ -2114,9 +2236,10 @@ mod async_redis {
         ///
         /// - `Build(BuildError::MissingRequired("prefix"))`: no key prefix was set.
         /// - `Build(BuildError::InvalidValue { field: "ttl", .. })`: an explicitly-set TTL is zero.
-        /// - `EmptyScope`: both the namespace (after trimming trailing colons) and
-        ///   the prefix are empty. `async_cache_clear` would otherwise issue
-        ///   `SCAN MATCH *` and delete every key in the Redis database.
+        /// - `Build(BuildError::InvalidValue { field: "prefix", .. })`: the prefix
+        ///   is empty. The prefix scopes `async_cache_clear` to this cache; with an
+        ///   empty prefix, `async_cache_clear` would issue `SCAN MATCH <namespace>:*`
+        ///   and delete the entries of every cache sharing the namespace.
         /// - `MissingConnectionString`: no connection string was set and the
         ///   `CACHED_REDIS_CONNECTION_STRING` env var is absent or invalid.
         /// - `Connection`: the Redis client or the selected connection (multiplexed,
@@ -2140,9 +2263,18 @@ mod async_redis {
                 }
                 None => Duration::ZERO,
             };
-            let prefix = self.prefix.as_deref().unwrap_or_default();
-            if self.namespace.trim_end_matches(':').is_empty() && prefix.is_empty() {
-                return Err(RedisCacheBuildError::EmptyScope);
+            // The prefix is what scopes `async_cache_clear` to this logical cache:
+            // with an empty prefix it matches `<namespace>:*` and deletes the
+            // entries of every cache sharing the namespace (all of them, under the
+            // shared default namespace). Reject it outright.
+            if self.prefix.as_deref().is_some_and(str::is_empty) {
+                return Err(super::super::BuildError::InvalidValue {
+                    field: "prefix",
+                    reason: "prefix must be non-empty: it is what scopes cache_clear to this \
+                             cache; with an empty prefix cache_clear would delete every key \
+                             under the namespace",
+                }
+                .into());
             }
             let connection_string = self.resolve_connection_string()?;
             let connection = self.create_connection().await?;
@@ -2161,7 +2293,9 @@ mod async_redis {
 
     /// Async cache store backed by redis.
     ///
-    /// Values have a TTL applied and enforced by Redis.
+    /// The TTL is optional and enforced by Redis itself: entries built with a
+    /// TTL expire server-side; entries built without one persist until
+    /// explicitly removed.
     /// Uses a `redis::aio::MultiplexedConnection` by default, or a
     /// `redis::aio::ConnectionManager` when the cache was built with
     /// [`AsyncRedisCacheBuilder::connection_manager(true)`](AsyncRedisCacheBuilder::connection_manager)
@@ -2589,18 +2723,25 @@ mod async_redis {
                 .as_millis()
         }
 
-        // No Redis server needed -- verifies the empty-scope guard in async `build()`.
+        // No Redis server needed -- verifies the empty-prefix guard in async `build()`.
         #[tokio::test]
-        async fn async_empty_namespace_and_prefix_is_rejected() {
+        async fn async_empty_prefix_is_rejected() {
             let result = AsyncRedisCacheBuilder::<String, String>::new()
                 .prefix("")
                 .ttl(Duration::from_secs(1))
-                .namespace("")
                 .build()
                 .await;
             assert!(
-                matches!(result, Err(RedisCacheBuildError::EmptyScope)),
-                "expected EmptyScope"
+                matches!(
+                    result,
+                    Err(RedisCacheBuildError::Build(
+                        crate::stores::BuildError::InvalidValue {
+                            field: "prefix",
+                            ..
+                        }
+                    ))
+                ),
+                "expected InvalidValue for empty prefix"
             );
         }
 

--- a/src/stores/sharded/expiring.rs
+++ b/src/stores/sharded/expiring.rs
@@ -184,8 +184,8 @@ where
     ///
     /// This is the infallible ergonomic API for the concrete type. Generic code over
     /// [`ConcurrentCached`] should use the `Result`-returning trait methods (`cache_get` or the
-    /// trait's `get` alias), callable as `ConcurrentCached::get(&store, k)` when this inherent
-    /// method is in scope.
+    /// `get` alias from [`ConcurrentCachedExt`](crate::ConcurrentCachedExt)), callable as
+    /// `ConcurrentCachedExt::get(&store, k)` when this inherent method is in scope.
     #[must_use]
     pub fn get(&self, k: &K) -> Option<V> {
         ConcurrentCached::cache_get(self, k).unwrap()

--- a/src/stores/sharded/expiring_lru.rs
+++ b/src/stores/sharded/expiring_lru.rs
@@ -181,8 +181,8 @@ where
     ///
     /// This is the infallible ergonomic API for the concrete type. Generic code over
     /// [`ConcurrentCached`] should use the `Result`-returning trait methods (`cache_get` or the
-    /// trait's `get` alias), callable as `ConcurrentCached::get(&store, k)` when this inherent
-    /// method is in scope.
+    /// `get` alias from [`ConcurrentCachedExt`](crate::ConcurrentCachedExt)), callable as
+    /// `ConcurrentCachedExt::get(&store, k)` when this inherent method is in scope.
     #[must_use]
     pub fn get(&self, k: &K) -> Option<V> {
         ConcurrentCached::cache_get(self, k).unwrap()
@@ -462,28 +462,38 @@ where
         // on_evict can fire after the lock is released; otherwise a plain set. A displaced
         // expired value is counted as an eviction under the lock (matching cache_remove) and
         // filtered from the return; a live displaced value is returned to the caller unchanged.
-        let old: Option<(Option<K>, V)> = {
+        // `is_expired()` is evaluated exactly once, while the write lock is still held, and the
+        // result carried through the tuple (matching the other sharded expiring stores): a value
+        // crossing the expiry threshold between two evaluations would otherwise fire `on_evict`
+        // without counting the eviction.
+        let old: Option<(Option<K>, V, bool)> = {
             let mut guard = shard.lock.write();
             let old = if self.inner.on_evict.is_some() {
                 let removed = guard.pop_raw(&k);
                 guard.cache_set(k, v);
-                removed.map(|(ok, ov)| (Some(ok), ov))
+                removed.map(|(ok, ov)| {
+                    let expired = ov.is_expired();
+                    (Some(ok), ov, expired)
+                })
             } else {
-                guard.cache_set(k, v).map(|ov| (None, ov))
+                guard.cache_set(k, v).map(|ov| {
+                    let expired = ov.is_expired();
+                    (None, ov, expired)
+                })
             };
-            if matches!(&old, Some((_, ov)) if ov.is_expired()) {
+            if matches!(&old, Some((_, _, true))) {
                 guard.evictions.fetch_add(1, Ordering::Relaxed);
             }
             old
         };
         match old {
-            Some((key, ov)) if ov.is_expired() => {
+            Some((key, ov, true)) => {
                 if let (Some(on_evict), Some(key)) = (&self.inner.on_evict, &key) {
                     on_evict(key, &ov);
                 }
                 Ok(None)
             }
-            Some((_, ov)) => Ok(Some(ov)),
+            Some((_, ov, false)) => Ok(Some(ov)),
             None => Ok(None),
         }
     }

--- a/src/stores/sharded/lru.rs
+++ b/src/stores/sharded/lru.rs
@@ -166,8 +166,8 @@ where
     ///
     /// This is the infallible ergonomic API for the concrete type. Generic code over
     /// [`ConcurrentCached`] should use the `Result`-returning trait methods (`cache_get` or the
-    /// trait's `get` alias), callable as `ConcurrentCached::get(&store, k)` when this inherent
-    /// method is in scope.
+    /// `get` alias from [`ConcurrentCachedExt`](crate::ConcurrentCachedExt)), callable as
+    /// `ConcurrentCachedExt::get(&store, k)` when this inherent method is in scope.
     #[must_use]
     pub fn get(&self, k: &K) -> Option<V> {
         ConcurrentCached::cache_get(self, k).unwrap()
@@ -597,11 +597,13 @@ impl<K, V, H> ShardedLruCacheBuilder<K, V, H> {
         }
     }
 
-    /// Set a callback invoked when an entry is evicted by LRU capacity pressure, explicit
-    /// [`cache_remove`](ConcurrentCached::cache_remove), or
-    /// [`cache_remove_entry`](ConcurrentCached::cache_remove_entry).
-    /// Does **not** fire on [`clear`](ShardedLruCacheBase::clear);
-    /// use [`cache_clear_with_on_evict`](ShardedLruCacheBase::cache_clear_with_on_evict) to opt in.
+    /// Set a callback invoked when an entry is evicted. Fires in four situations:
+    /// on LRU capacity pressure; on explicit
+    /// [`cache_remove`](ConcurrentCached::cache_remove); on
+    /// [`cache_remove_entry`](ConcurrentCached::cache_remove_entry); and for every
+    /// entry removed by
+    /// [`cache_clear_with_on_evict`](ShardedLruCacheBase::cache_clear_with_on_evict).
+    /// Does **not** fire on [`clear`](ShardedLruCacheBase::clear).
     ///
     /// Capacity-eviction callbacks run while the affected shard's write lock is held. Do not call
     /// methods on the same sharded cache from the callback; doing so can deadlock if the callback

--- a/src/stores/sharded/lru_ttl.rs
+++ b/src/stores/sharded/lru_ttl.rs
@@ -243,8 +243,8 @@ where
     ///
     /// This is the infallible ergonomic API for the concrete type. Generic code over
     /// [`ConcurrentCached`] should use the `Result`-returning trait methods (`cache_get` or the
-    /// trait's `get` alias), callable as `ConcurrentCached::get(&store, k)` when this inherent
-    /// method is in scope.
+    /// `get` alias from [`ConcurrentCachedExt`](crate::ConcurrentCachedExt)), callable as
+    /// `ConcurrentCachedExt::get(&store, k)` when this inherent method is in scope.
     #[must_use]
     pub fn get(&self, k: &K) -> Option<V> {
         ConcurrentCached::cache_get(self, k).unwrap()

--- a/src/stores/sharded/ttl.rs
+++ b/src/stores/sharded/ttl.rs
@@ -234,8 +234,8 @@ where
     ///
     /// This is the infallible ergonomic API for the concrete type. Generic code over
     /// [`ConcurrentCached`] should use the `Result`-returning trait methods (`cache_get` or the
-    /// trait's `get` alias), callable as `ConcurrentCached::get(&store, k)` when this inherent
-    /// method is in scope.
+    /// `get` alias from [`ConcurrentCachedExt`](crate::ConcurrentCachedExt)), callable as
+    /// `ConcurrentCachedExt::get(&store, k)` when this inherent method is in scope.
     #[must_use]
     pub fn get(&self, k: &K) -> Option<V> {
         ConcurrentCached::cache_get(self, k).unwrap()

--- a/src/stores/sharded/unbound.rs
+++ b/src/stores/sharded/unbound.rs
@@ -183,8 +183,8 @@ where
     ///
     /// This is the infallible ergonomic API for the concrete type. Generic code over
     /// [`ConcurrentCached`] should use the `Result`-returning trait methods (`cache_get` or the
-    /// trait's `get` alias), callable as `ConcurrentCached::get(&store, k)` when this inherent
-    /// method is in scope.
+    /// `get` alias from [`ConcurrentCachedExt`](crate::ConcurrentCachedExt)), callable as
+    /// `ConcurrentCachedExt::get(&store, k)` when this inherent method is in scope.
     #[must_use]
     pub fn get(&self, k: &K) -> Option<V> {
         ConcurrentCached::cache_get(self, k).unwrap()

--- a/tests/ui/concurrent_cached_map_error_async_closure.rs
+++ b/tests/ui/concurrent_cached_map_error_async_closure.rs
@@ -1,0 +1,10 @@
+use cached::macros::concurrent_cached;
+
+// map_error is passed to Result::map_err, so an async closure must be rejected
+// at the macro with a pointed message rather than failing the FnOnce bound.
+#[concurrent_cached(disk = true, ttl_secs = 60, map_error = async |e| format!("{e:?}"))]
+async fn my_fn(k: u32) -> Result<u32, String> {
+    Ok(k)
+}
+
+fn main() {}

--- a/tests/ui/concurrent_cached_map_error_async_closure.stderr
+++ b/tests/ui/concurrent_cached_map_error_async_closure.stderr
@@ -1,0 +1,5 @@
+error: `map_error` must be a synchronous closure (it is passed to `Result::map_err`); remove the `async` keyword, e.g. `map_error = |e| MyErr(e)`
+ --> tests/ui/concurrent_cached_map_error_async_closure.rs:5:61
+  |
+5 | #[concurrent_cached(disk = true, ttl_secs = 60, map_error = async |e| format!("{e:?}"))]
+  |                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/v3_macros_ui.rs
+++ b/tests/v3_macros_ui.rs
@@ -95,6 +95,9 @@ fn compile_fail_v3_macros() {
     t.compile_fail("tests/ui/cached_convert_malformed_unquoted.rs");
     // Item #2: map_error = 5 (non-closure expression) rejected.
     t.compile_fail("tests/ui/concurrent_cached_map_error_non_closure.rs");
+    // map_error = async |e| ... (async closure) rejected with a pointed message
+    // instead of the opaque downstream FnOnce bound failure.
+    t.compile_fail("tests/ui/concurrent_cached_map_error_async_closure.rs");
     // G1: generic `#[once]` whose value type names a function type parameter.
     t.compile_fail("tests/ui/once_generic_value_type_rejected.rs");
     // G1: value type names the param *nested* inside another generic (`Vec<T>`) -

--- a/tests/v3_sharded_expiring_set_single_eval.rs
+++ b/tests/v3_sharded_expiring_set_single_eval.rs
@@ -1,0 +1,101 @@
+//! `cache_set` on the sharded expiring stores must evaluate the displaced value's
+//! `is_expired()` exactly once, under the shard write lock, and use that single result
+//! for all three outcomes it drives: the eviction counter, the `on_evict` callback, and
+//! whether the displaced value is filtered from the return.
+//!
+//! With two evaluations, a value crossing the expiry threshold between them fires
+//! `on_evict` without counting an eviction (or vice versa). The `FlipVal` type below makes
+//! that transition deterministic: its `is_expired()` reports live on the first call and
+//! expired on every call after, so a double-evaluating implementation visibly disagrees
+//! with itself.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use cached::prelude::*;
+use cached::{ShardedExpiringCache, ShardedExpiringLruCache};
+
+/// Reports live on the first `is_expired()` call, expired afterwards, and counts calls.
+#[derive(Clone)]
+struct FlipVal {
+    calls: Arc<AtomicUsize>,
+}
+
+impl FlipVal {
+    fn new() -> Self {
+        FlipVal {
+            calls: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}
+
+impl Expires for FlipVal {
+    fn is_expired(&self) -> bool {
+        self.calls.fetch_add(1, Ordering::SeqCst) >= 1
+    }
+}
+
+#[test]
+fn sharded_expiring_lru_set_evaluates_displaced_expiry_once() {
+    let evict_calls = Arc::new(AtomicUsize::new(0));
+    let evict_calls_cb = Arc::clone(&evict_calls);
+    let cache: ShardedExpiringLruCache<u32, FlipVal> = ShardedExpiringLruCache::builder()
+        .max_size(16)
+        .shards(1)
+        .on_evict(move |_k, _v| {
+            evict_calls_cb.fetch_add(1, Ordering::SeqCst);
+        })
+        .build()
+        .unwrap();
+
+    let first = FlipVal::new();
+    let first_calls = Arc::clone(&first.calls);
+    cache.set(1, first);
+    assert_eq!(first_calls.load(Ordering::SeqCst), 0);
+
+    // Displace the first value. Its single under-lock evaluation reports live, so it must
+    // be returned to the caller with no eviction counted and no callback fired.
+    let displaced = cache.set(1, FlipVal::new());
+    assert_eq!(
+        first_calls.load(Ordering::SeqCst),
+        1,
+        "displaced value's is_expired() must be evaluated exactly once"
+    );
+    assert!(
+        displaced.is_some(),
+        "a live displaced value is returned to the caller"
+    );
+    assert_eq!(evict_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(cache.metrics().evictions, Some(0));
+}
+
+#[test]
+fn sharded_expiring_set_evaluates_displaced_expiry_once() {
+    let evict_calls = Arc::new(AtomicUsize::new(0));
+    let evict_calls_cb = Arc::clone(&evict_calls);
+    let cache: ShardedExpiringCache<u32, FlipVal> = ShardedExpiringCache::builder()
+        .shards(1)
+        .on_evict(move |_k, _v| {
+            evict_calls_cb.fetch_add(1, Ordering::SeqCst);
+        })
+        .build()
+        .unwrap();
+
+    let first = FlipVal::new();
+    let first_calls = Arc::clone(&first.calls);
+    cache.set(1, first);
+    assert_eq!(first_calls.load(Ordering::SeqCst), 0);
+
+    let displaced = cache.set(1, FlipVal::new());
+    assert_eq!(
+        first_calls.load(Ordering::SeqCst),
+        1,
+        "displaced value's is_expired() must be evaluated exactly once"
+    );
+    assert!(
+        displaced.is_some(),
+        "a live displaced value is returned to the caller"
+    );
+    assert_eq!(evict_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(cache.metrics().evictions, Some(0));
+}


### PR DESCRIPTION
Fixes from a full-surface review of the 3.0.0 release candidate (2.0.2 -> rc.6 diff, cross-store parity, and an external consumer-experience pass).

Breaking (rc-only surface):
- `RedisCacheBuilder::build()` / `AsyncRedisCacheBuilder::build()` reject an empty prefix with `Build(BuildError::InvalidValue { field: "prefix", .. })`. The prefix scopes `cache_clear`; an empty one made it delete every key under the (shared, by default) namespace. Removes the rc.3 `EmptyScope` variant, which the new guard subsumes.
- `#[concurrent_cached]` rejects an `async` closure for `map_error` with a pointed error instead of the opaque downstream `FnOnce` bound failure.

Fixed:
- `ShardedExpiringLruCache::cache_set` evaluates the displaced entry's `is_expired()` exactly once, under the shard write lock; the double evaluation could fire `on_evict` without counting the eviction.
- `RedisCacheBuildError::MissingConnectionString` redacts the env value carried by `VarError::NotUnicode` (it is the connection string itself, credentials included, and was printed by `Display`/`Debug`); the enum now uses a manual `Debug` matching its siblings.
- `RedbCache` self-heals an app-derived default cache directory left group-writable by an earlier version (umask-002 systems hit a permanent "I/O error preparing the disk cache directory"); unhealable candidates fall through to the next candidate.
- `make examples` runs the registered examples again: the per-example targets are `.PHONY` and make skips implicit-rule search for phony targets, so the pattern rules expanded to nothing and only the two explicitly-ruled examples ran. Static pattern rules fix it; `expires_per_key` and `struct_method` are now registered; the expansion guard checks each example individually. (This is what surfaced the redb directory bug.)

Docs:
- `dyn ConcurrentCached<K, V, Error = E>` as the trait-object form (the documented two-trait `dyn` fails E0225); `ConcurrentCachedExt::get` as the qualified alias call (compiler-verified, the documented forms did not compile)
- migration guide: `serde` is a public feature (the guide said the opposite of rc.5's change); empty-prefix rejection section; `DiskCacheBuilder` grep hint names the 3.0 type
- `UnboundCache` included in the `None`-evictions exception; optional-TTL redis struct docs; `strict_deserialization` write-path and sweep-rollback notes; `ShardedLruCache` `on_evict` firing sites; unquoted `cache_prefix_block` form

New tests: single-evaluation contract for both sharded expiring stores, redb legacy-dir healing and symlink rejection, strict-sweep rollback observability, empty-prefix guards (sync and async), `NotUnicode` redaction, async `map_error` UI golden.