### PR TITLE
reject inert `sync_writes_buckets`, drop expiring-store struct bounds, derive `ConnectionString` eq, store format and doc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- `#[cached]` rejects an explicit `sync_writes_buckets` when `sync_writes` is not `"by_key"` with a pointed compile error. The value was previously accepted and silently ignored (buckets only exist on the `by_key` path); `#[once]` already rejected the same inert combination.
+
+### Changed
+
+- `ExpiringCache`, `ExpiringLruCache`, and their builders (including the sharded `ShardedExpiringCacheBuilder` / `ShardedExpiringLruCacheBuilder`) drop the `K: Hash + Eq` / `V: Expires` bounds from the type definitions, matching every other store (bounds live on the impls). Purely a relaxation: all previously-valid code still compiles, and the types can now be named in generic contexts without carrying the bounds.
+- `ConnectionString` derives `PartialEq`, `Eq`, and `Hash` (comparing the raw unredacted URL).
+- `NoEvict` / `HasEvict` derive `Clone`, `Copy`, `Debug`, and `Default`, and are documented at the crate root (previously `#[doc(hidden)]` there but documented at `cached::stores`). They appear in `LruTtlCacheBuilder` / `ShardedLruTtlCacheBuilder` signatures, so they are findable on docs.rs now.
+- `cached::prelude` re-exports `CacheTtl` unconditionally, matching `ConcurrentCacheTtl` (the trait was never feature-gated; only the built-in stores implementing it require `time_stores`).
+- `Return::set_was_cached` is `#[doc(hidden)]` (macro plumbing, not supported public API).
+- `#[must_use]` added to `CacheMetrics::hit_ratio` and the `iter_order` / `key_order` / `value_order` accessors on `LruCache` / `LruTtlCache`.
+
+### Documentation
+
+- The redis on-wire format (msgpack `value`/`version` fields, `REDIS_VALUE_VERSION`) and the redb on-disk format (versioned file name, table name, msgpack fields) are documented as stable for the 3.x series; changes bump the embedded version and are reserved for a major release.
+- `AsyncRedisCacheBuilder` explains why it has no `connection_pool_*` methods (multiplexed connection, no r2d2 pool; pool sizing does not apply).
+- The expiring stores document the `cache_remove` / `cache_remove_entry` asymmetry: `cache_remove` filters expired values (`None`), `cache_remove_entry` returns the entry regardless of expiry.
+- `ShardedLruTtlCacheBuilder::on_evict` enumerates the `cache_set`-over-expired-entry trigger, matching the other sharded TTL/expiring builders.
+- `#[concurrent_cached]`'s `expires` doc lists `result_fallback` in its mutual-exclusion set (the combination was already a compile error).
+- `#[cached]`'s `unsync_reads` doc names the built-in `CachedRead` stores (`UnboundCache`, `TtlSortedCache`); `result_fallback` distinguishes TTL-store refresh semantics from `expires`-store behavior; `#[once]`'s `in_impl` doc notes `companions_vis` also overrides the `_no_cache` sibling's visibility.
+- The crate-doc custom-store example uses the unquoted `create` / `convert` forms.
+- The error-source downcast tests are labeled as pinning non-contract behavior (the concrete source types stay out of the semver contract).
+
 ## [3.0.0-rc.7 / cached_proc_macro 3.0.0-rc.7] - 2026-07-12
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -397,8 +397,8 @@ use cached::LruCache;
 /// Use an explicit cache-type with a custom creation block and custom cache-key generating block
 #[cached(
     ty = "LruCache<String, usize>",
-    create = "{ LruCache::builder().max_size(100).build().unwrap() }",
-    convert = r#"{ format!("{}{}", a, b) }"#
+    create = LruCache::builder().max_size(100).build().unwrap(),
+    convert = { format!("{}{}", a, b) }
 )]
 fn keyed(a: &str, b: &str) -> usize {
     let size = a.len() + b.len();

--- a/cached_proc_macro/src/cached.rs
+++ b/cached_proc_macro/src/cached.rs
@@ -76,8 +76,11 @@ struct CachedMacroArgs {
     /// `Some(ByKey)` = explicit `sync_writes = "by_key"`.
     #[darling(default)]
     sync_writes: Option<SyncWriteMode>,
-    #[darling(default = "default_sync_writes_buckets")]
-    sync_writes_buckets: usize,
+    /// `None` = not specified by user (resolves to `default_sync_writes_buckets()`).
+    /// Kept as an `Option` so an explicit value combined with a non-`by_key`
+    /// `sync_writes` can be rejected instead of silently ignored.
+    #[darling(default)]
+    sync_writes_buckets: Option<usize>,
     #[darling(default)]
     sync_lock: Option<SyncLock>,
     #[darling(default)]
@@ -769,7 +772,23 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
         (true, true) => unreachable!("return type cannot be both Result and Option"),
     };
 
-    if let Err(error) = validate_sync_writes_buckets(args.sync_writes_buckets, fn_ident.span()) {
+    // An explicit `sync_writes_buckets` only takes effect with `sync_writes = "by_key"`;
+    // reject the inert combination instead of silently ignoring the value.
+    if args.sync_writes_buckets.is_some() && sync_writes != SyncWriteMode::ByKey {
+        return syn::Error::new(
+            fn_ident.span(),
+            "`sync_writes_buckets` only applies to `sync_writes = \"by_key\"` \
+             (it sets the number of per-key lock buckets); it has no effect with \
+             any other `sync_writes` mode. Add `sync_writes = \"by_key\"` or \
+             remove `sync_writes_buckets`.",
+        )
+        .to_compile_error()
+        .into();
+    }
+    let sync_writes_buckets = args
+        .sync_writes_buckets
+        .unwrap_or_else(default_sync_writes_buckets);
+    if let Err(error) = validate_sync_writes_buckets(sync_writes_buckets, fn_ident.span()) {
         return error.to_compile_error().into();
     }
 
@@ -832,8 +851,6 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
         .to_compile_error()
         .into();
     }
-
-    let sync_writes_buckets = args.sync_writes_buckets;
 
     let set_cache_and_return = quote! {
         #set_cache_block

--- a/cached_proc_macro/src/lib.rs
+++ b/cached_proc_macro/src/lib.rs
@@ -71,12 +71,15 @@ use proc_macro::TokenStream;
 ///   hash into a bucket, so two different keys may share a bucket and serialize unnecessarily
 ///   (false sharing). Increase this if you observe contention under high concurrency - a value
 ///   around 2-4x your expected peak concurrency eliminates most false sharing. Must be > 0.
+///   Only valid together with `sync_writes = "by_key"`; setting it with any other `sync_writes`
+///   mode is a compile error (the value would otherwise be silently ignored).
 /// - `sync_lock`: (optional, string) choose the generated cache lock. Defaults to `"rwlock"`. Use `"mutex"`
 ///   to force a mutex. `unsync_reads = true` requires an RwLock.
 /// - `unsync_reads`: (optional, bool) use `CachedRead::cache_get_read` under a shared read lock for the initial
 ///   cache lookup, while keeping writes synchronized. This only works for stores that implement `CachedRead`;
-///   recency-updating or refresh-on-hit stores intentionally do not. For non-mutating diagnostic lookups,
-///   use the separate `CachedPeek` trait directly on stores.
+///   recency-updating or refresh-on-hit stores intentionally do not. The built-in compliant stores are
+///   `UnboundCache` (the default) and `TtlSortedCache`; a custom `ty` may also implement `CachedRead`.
+///   For non-mutating diagnostic lookups, use the separate `CachedPeek` trait directly on stores.
 /// - `ty`: (optional, string type) The cache store type to use. Defaults to `UnboundCache`.
 ///   When `max_size` is specified, defaults to `LruCache`.
 ///   When `ttl` is specified, defaults to `TtlCache`.
@@ -108,11 +111,14 @@ use proc_macro::TokenStream;
 ///   to be named `Return<T>` passes the attribute check but then fails to
 ///   compile in the generated body (it calls `::cached::Return::new` /
 ///   `.set_was_cached`). Use a different name for any non-`cached` `Return` type.
-/// - `result_fallback`: (optional, bool) If your function returns a `Result` and it fails, the cache will instead refresh the recently expired `Ok` value.
+/// - `result_fallback`: (optional, bool) If your function returns a `Result` and it fails, the cache will instead serve the expired `Ok` value.
 ///   In other words, refreshes are best-effort - returning `Ok` refreshes as usual but `Err` falls back to the last `Ok`.
-///   **Note:** the stale value's TTL is refreshed on *every* `Err` call - if the underlying
+///   **Note (TTL stores):** the stale value's TTL is refreshed on *every* `Err` call - if the underlying
 ///   operation stays down indefinitely, the stale entry will never expire. `ttl` bounds staleness
 ///   under normal (transient) failure; it does not bound it under permanent failure.
+///   **Note (`expires` stores):** there is no store TTL to refresh; the stale entry is re-stored
+///   as-is and each value's own `is_expired()` continues to govern access, so the stale value keeps
+///   being served while it reports itself expired and the operation keeps failing.
 ///   This is useful, for example, for keeping the last successful result of a network operation even during network disconnects.
 ///   *Note*, this option requires the cache type to implement `CloneCached`. The compatible built-in options are:
 ///   `ttl`, `ttl_secs`, or `ttl_millis` (uses `TtlCache`), `max_size` + `ttl`/`ttl_secs`/`ttl_millis` (uses `LruTtlCache`), and
@@ -194,8 +200,8 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
 ///   the `{fn}_prime_cache` companion is not generated for `in_impl` methods, because the cache static
 ///   is function-local and cannot be shared with a separate prime sibling. A `{fn}_no_cache` companion
 ///   (the uncached origin function) is generated as a `#[doc(hidden)]` impl method and inherits the
-///   method's visibility, so a `pub` cached method exposes a `pub {fn}_no_cache` cache-bypass sibling
-///   on the same `impl`.
+///   method's visibility (overridable with `companions_vis`), so a `pub` cached method exposes a
+///   `pub {fn}_no_cache` cache-bypass sibling on the same `impl`.
 /// - `sync_writes`: (optional, bool or string) specify whether to synchronize the execution of writing of uncached values.
 ///   **Default: `"disabled"`** - when not specified, uncached calls are not synchronized.
 ///   When set to `true` or `"default"`, uncached execution is synchronized by locking the whole
@@ -372,7 +378,7 @@ pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
 /// - `expires`: (optional, bool) select a per-value expiry store. The cached value type must
 ///   implement the `Expires` trait. Without `max_size`, selects `ShardedExpiringCache` (unbounded);
 ///   with `max_size = N`, selects `ShardedExpiringLruCache` (LRU-bounded). Mutually exclusive with
-///   `ttl`, `redis`, `disk`, `ty`, `create`, `refresh`, `cache_none`, and `cache_err`. May be
+///   `ttl`, `redis`, `disk`, `ty`, `create`, `refresh`, `result_fallback`, `cache_none`, and `cache_err`. May be
 ///   combined with `with_cached_flag`; in that case the inner `T` of `Return<T>` (not `Return<T>`
 ///   itself) must implement `Expires`. When the function returns `Option<T>`, `None` is not cached
 ///   by default (implicit smart-option), and the inner `T` (not `Option<T>`)

--- a/cached_proc_macro_types/src/lib.rs
+++ b/cached_proc_macro_types/src/lib.rs
@@ -18,7 +18,9 @@ impl<T> Return<T> {
         self.was_cached
     }
 
-    /// Sets the `was_cached` flag. Used by generated macro code.
+    /// Sets the `was_cached` flag. Used by generated macro code; not part of
+    /// the supported public API.
+    #[doc(hidden)]
     pub fn set_was_cached(&mut self, was_cached: bool) {
         self.was_cached = was_cached;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -397,8 +397,8 @@ use cached::LruCache;
 /// Use an explicit cache-type with a custom creation block and custom cache-key generating block
 #[cached(
     ty = "LruCache<String, usize>",
-    create = "{ LruCache::builder().max_size(100).build().unwrap() }",
-    convert = r#"{ format!("{}{}", a, b) }"#
+    create = LruCache::builder().max_size(100).build().unwrap(),
+    convert = { format!("{}{}", a, b) }
 )]
 fn keyed(a: &str, b: &str) -> usize {
     let size = a.len() + b.len();
@@ -682,7 +682,7 @@ pub use stores::{
     ConnectionString, RedisCache, RedisCacheBuildError, RedisCacheBuilder, RedisCacheError,
 };
 #[cfg(feature = "time_stores")]
-#[doc(hidden)]
+#[cfg_attr(docsrs, doc(cfg(feature = "time_stores")))]
 pub use stores::{HasEvict, NoEvict};
 #[cfg(feature = "time_stores")]
 #[cfg_attr(docsrs, doc(cfg(feature = "time_stores")))]
@@ -831,8 +831,10 @@ pub mod prelude {
         ConcurrentCached, ConcurrentCachedExt, ConcurrentCloneCached, Expires, SerializeCached,
     };
 
-    #[cfg(feature = "time_stores")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "time_stores")))]
+    // Unconditional, like `ConcurrentCacheTtl` above: the trait itself is not
+    // feature-gated (only the built-in stores implementing it require
+    // `time_stores`), so custom-store authors get it from the prelude in any
+    // feature configuration.
     pub use crate::CacheTtl;
 
     #[cfg(feature = "async_core")]
@@ -1430,6 +1432,7 @@ pub struct CacheMetrics {
 
 impl CacheMetrics {
     /// Return the cache hit ratio as a value in `[0.0, 1.0]`, or `None` if no lookups have occurred.
+    #[must_use]
     pub fn hit_ratio(&self) -> Option<f64> {
         let hits = self.hits?;
         let misses = self.misses?;

--- a/src/stores/expiring.rs
+++ b/src/stores/expiring.rs
@@ -51,7 +51,7 @@ use {super::CachedGetOrSetAsync, std::collections::hash_map::Entry, std::future:
 /// ```
 ///
 /// Note: This cache is in-memory only.
-pub struct ExpiringCache<K: Hash + Eq, V: Expires, S = DefaultHashBuilder> {
+pub struct ExpiringCache<K, V, S = DefaultHashBuilder> {
     pub(super) store: UnboundCache<K, V, S>,
     pub(super) hits: AtomicU64,
     pub(super) misses: AtomicU64,
@@ -59,7 +59,7 @@ pub struct ExpiringCache<K: Hash + Eq, V: Expires, S = DefaultHashBuilder> {
     pub(super) on_evict: Option<super::OnEvict<K, V>>,
 }
 
-impl<K: Hash + Eq, V: Expires, S> std::fmt::Debug for ExpiringCache<K, V, S> {
+impl<K, V, S> std::fmt::Debug for ExpiringCache<K, V, S> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ExpiringCache")
             .field("hits", &self.hits.load(Ordering::Relaxed))
@@ -76,7 +76,7 @@ impl<K: Hash + Eq, V: Expires, S> std::fmt::Debug for ExpiringCache<K, V, S> {
 impl<K, V, S> PartialEq for ExpiringCache<K, V, S>
 where
     K: Hash + Eq,
-    V: Expires + PartialEq,
+    V: PartialEq,
     S: BuildHasher,
 {
     fn eq(&self, other: &Self) -> bool {
@@ -87,7 +87,7 @@ where
 impl<K, V, S> Eq for ExpiringCache<K, V, S>
 where
     K: Hash + Eq,
-    V: Expires + Eq,
+    V: Eq,
     S: BuildHasher,
 {
 }
@@ -95,7 +95,7 @@ where
 impl<K, V, S> Clone for ExpiringCache<K, V, S>
 where
     K: Clone + Hash + Eq,
-    V: Expires + Clone,
+    V: Clone,
     S: Clone,
 {
     fn clone(&self) -> Self {
@@ -116,13 +116,13 @@ where
 /// single global TTL applied to every entry, use [`TtlCache`](crate::stores::TtlCache) or
 /// [`LruTtlCache`](crate::stores::LruTtlCache) instead.
 #[doc(alias = "ttl")]
-pub struct ExpiringCacheBuilder<K, V: Expires, S = DefaultHashBuilder> {
+pub struct ExpiringCacheBuilder<K, V, S = DefaultHashBuilder> {
     capacity: Option<usize>,
     on_evict: Option<super::OnEvict<K, V>>,
     hasher: S,
 }
 
-impl<K, V: Expires> Default for ExpiringCacheBuilder<K, V, DefaultHashBuilder> {
+impl<K, V> Default for ExpiringCacheBuilder<K, V, DefaultHashBuilder> {
     fn default() -> Self {
         Self {
             capacity: None,
@@ -132,7 +132,7 @@ impl<K, V: Expires> Default for ExpiringCacheBuilder<K, V, DefaultHashBuilder> {
     }
 }
 
-impl<K, V: Expires, S> ExpiringCacheBuilder<K, V, S> {
+impl<K, V, S> ExpiringCacheBuilder<K, V, S> {
     /// Set the initial allocation capacity (optional).
     #[must_use]
     pub fn initial_capacity(mut self, capacity: usize) -> Self {
@@ -448,6 +448,10 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> Cached<K, V> for ExpiringCache<K,
         }
     }
 
+    /// Removes the entry and returns the value only if it is still live;
+    /// an expired value is removed but reported as `None`. Use
+    /// [`cache_remove_entry`](Cached::cache_remove_entry) to receive the
+    /// value regardless of expiry.
     fn cache_remove<Q>(&mut self, k: &Q) -> Option<V>
     where
         K: std::borrow::Borrow<Q>,
@@ -457,6 +461,8 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> Cached<K, V> for ExpiringCache<K,
             .and_then(|(_, v)| if v.is_expired() { None } else { Some(v) })
     }
 
+    /// Removes the entry and returns it **regardless of expiry** (unlike
+    /// [`cache_remove`](Cached::cache_remove), which filters expired values).
     fn cache_remove_entry<Q>(&mut self, k: &Q) -> Option<(K, V)>
     where
         K: std::borrow::Borrow<Q>,

--- a/src/stores/expiring_lru.rs
+++ b/src/stores/expiring_lru.rs
@@ -79,7 +79,7 @@ pub trait Expires {
 /// behavior here could be folded into [`LruCache`] via a specialized `Cached<K, V>` impl
 /// for `V: Expires`, eliminating this separate type. Until then, the two must remain
 /// distinct because overlapping blanket impls are not allowed on stable Rust.
-pub struct ExpiringLruCache<K: Hash + Eq, V: Expires, S = DefaultHashBuilder> {
+pub struct ExpiringLruCache<K, V, S = DefaultHashBuilder> {
     pub(super) store: LruCache<K, V, S>,
     pub(super) hits: AtomicU64,
     pub(super) misses: AtomicU64,
@@ -87,7 +87,7 @@ pub struct ExpiringLruCache<K: Hash + Eq, V: Expires, S = DefaultHashBuilder> {
     pub(super) on_evict: Option<super::OnEvict<K, V>>,
 }
 
-impl<K: Hash + Eq, V: Expires, S> std::fmt::Debug for ExpiringLruCache<K, V, S> {
+impl<K, V, S> std::fmt::Debug for ExpiringLruCache<K, V, S> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ExpiringLruCache")
             .field("hits", &self.hits.load(Ordering::Relaxed))
@@ -105,7 +105,7 @@ impl<K: Hash + Eq, V: Expires, S> std::fmt::Debug for ExpiringLruCache<K, V, S> 
 impl<K, V, S> PartialEq for ExpiringLruCache<K, V, S>
 where
     K: Clone + Hash + Eq,
-    V: Expires + PartialEq,
+    V: PartialEq,
     S: BuildHasher,
 {
     fn eq(&self, other: &Self) -> bool {
@@ -116,7 +116,7 @@ where
 impl<K, V, S> Eq for ExpiringLruCache<K, V, S>
 where
     K: Clone + Hash + Eq,
-    V: Expires + Eq,
+    V: Eq,
     S: BuildHasher,
 {
 }
@@ -124,7 +124,7 @@ where
 impl<K, V, S> Clone for ExpiringLruCache<K, V, S>
 where
     K: Clone + Hash + Eq,
-    V: Expires + Clone,
+    V: Clone,
     S: Clone,
 {
     fn clone(&self) -> Self {
@@ -145,13 +145,13 @@ where
 /// `max_size` bounds the entry count via LRU. For a single global TTL applied to every entry,
 /// use [`LruTtlCache`](crate::stores::LruTtlCache) instead.
 #[doc(alias = "ttl")]
-pub struct ExpiringLruCacheBuilder<K, V: Expires, S = DefaultHashBuilder> {
+pub struct ExpiringLruCacheBuilder<K, V, S = DefaultHashBuilder> {
     size: Option<usize>,
     on_evict: Option<super::OnEvict<K, V>>,
     hasher: S,
 }
 
-impl<K, V: Expires> Default for ExpiringLruCacheBuilder<K, V, DefaultHashBuilder> {
+impl<K, V> Default for ExpiringLruCacheBuilder<K, V, DefaultHashBuilder> {
     fn default() -> Self {
         Self {
             size: None,
@@ -161,7 +161,7 @@ impl<K, V: Expires> Default for ExpiringLruCacheBuilder<K, V, DefaultHashBuilder
     }
 }
 
-impl<K, V: Expires, S> ExpiringLruCacheBuilder<K, V, S> {
+impl<K, V, S> ExpiringLruCacheBuilder<K, V, S> {
     /// Set the maximum number of entries.
     #[doc(alias = "size")]
     #[doc(alias = "capacity")]
@@ -522,6 +522,10 @@ impl<K: Hash + Eq + Clone, V: Expires, S: BuildHasher> Cached<K, V> for Expiring
             other => other,
         }
     }
+    /// Removes the entry and returns the value only if it is still live;
+    /// an expired value is removed but reported as `None`. Use
+    /// [`cache_remove_entry`](Cached::cache_remove_entry) to receive the
+    /// value regardless of expiry.
     fn cache_remove<Q>(&mut self, k: &Q) -> Option<V>
     where
         K: std::borrow::Borrow<Q>,
@@ -531,6 +535,8 @@ impl<K: Hash + Eq + Clone, V: Expires, S: BuildHasher> Cached<K, V> for Expiring
             .and_then(|(_, v)| if v.is_expired() { None } else { Some(v) })
     }
 
+    /// Removes the entry and returns it **regardless of expiry** (unlike
+    /// [`cache_remove`](Cached::cache_remove), which filters expired values).
     fn cache_remove_entry<Q>(&mut self, k: &Q) -> Option<(K, V)>
     where
         K: std::borrow::Borrow<Q>,

--- a/src/stores/lru.rs
+++ b/src/stores/lru.rs
@@ -328,6 +328,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruCache<K, V, S> {
     }
 
     /// Return all entries in current LRU order (most-recently-used first) as a `Vec` of `(K, V)` pairs.
+    #[must_use]
     pub fn iter_order(&self) -> Vec<(K, V)>
     where
         K: Clone,
@@ -338,6 +339,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruCache<K, V, S> {
 
     /// Return a `Vec` of keys in the current order from most
     /// to least recently used.
+    #[must_use]
     pub fn key_order(&self) -> Vec<K>
     where
         K: Clone,
@@ -347,6 +349,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruCache<K, V, S> {
 
     /// Return a `Vec` of values in the current order from most
     /// to least recently used.
+    #[must_use]
     pub fn value_order(&self) -> Vec<V>
     where
         V: Clone,

--- a/src/stores/lru_ttl.rs
+++ b/src/stores/lru_ttl.rs
@@ -81,13 +81,19 @@ where
 }
 
 /// Typestate marker for [`LruTtlCacheBuilder`]: no eviction callback set.
+///
+/// This appears as the builder's `E` type parameter default. It only encodes
+/// builder state; most code never names it directly.
+#[derive(Clone, Copy, Debug, Default)]
 pub struct NoEvict;
 
 /// Typestate marker for [`LruTtlCacheBuilder`]: eviction callback has been set.
 ///
 /// When this marker is active, [`LruTtlCacheBuilder::build`] requires
 /// `K: 'static` and `V: 'static` because the callback must be wired into
-/// the inner LRU store.
+/// the inner LRU store. It only encodes builder state; most code never
+/// names it directly.
+#[derive(Clone, Copy, Debug, Default)]
 pub struct HasEvict;
 
 /// Builder for [`LruTtlCache`].
@@ -396,6 +402,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruTtlCache<K, V, S> {
     /// Return an iterator of key-value pairs with their expiry instants
     /// in the current order from most to least recently used.
     /// Items past their expiry will be excluded.
+    #[must_use]
     pub fn iter_order(&self) -> Vec<(K, (Option<Instant>, V))>
     where
         K: Clone,
@@ -418,6 +425,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruTtlCache<K, V, S> {
     /// Return a `Vec` of keys in the current order from most
     /// to least recently used.
     /// Items past their expiry will be excluded.
+    #[must_use]
     pub fn key_order(&self) -> Vec<K>
     where
         K: Clone,
@@ -438,6 +446,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruTtlCache<K, V, S> {
     /// Return a `Vec` of (expiry, value) pairs in the current order
     /// from most to least recently used.
     /// Items past their expiry will be excluded.
+    #[must_use]
     pub fn value_order(&self) -> Vec<(Option<Instant>, V)>
     where
         V: Clone,

--- a/src/stores/redb.rs
+++ b/src/stores/redb.rs
@@ -94,6 +94,12 @@ static DISK_FILE_PREFIX: &str = "cached_disk_cache";
 // per-entry `version` field), so an incompatible older file is never read.
 // Starts at 3 to distinguish from the sled-era DiskCache format (versions 1 and 2
 // were the sled-backed DiskCache; those files are incompatible and are never read).
+//
+// Stability: the on-disk format (this version in the file name, the redb table
+// name, and the MessagePack `CachedDiskValue` field names/order) is stable for the
+// 3.x series — files written by any 3.x release remain readable by every later 3.x
+// release. A format change bumps this version (isolating old files rather than
+// corrupting them) and is otherwise reserved for a major release.
 const DISK_FILE_VERSION: u64 = 3;
 
 impl<K, V> Default for RedbCacheBuilder<K, V>
@@ -3374,7 +3380,9 @@ mod tests {
     }
 
     /// `std::error::Error::source()` on `RedbCacheError::CacheDeserialization`
-    /// must return the underlying decode error.
+    /// must return the underlying decode error. The downcast below pins current
+    /// behavior only — the concrete source type is non-contract (see the semver
+    /// note on the error type) and may change with the codec in a major release.
     #[test]
     fn cache_deserialization_error_source_is_wired() {
         use std::error::Error;
@@ -3400,7 +3408,10 @@ mod tests {
     }
 
     /// `RedbCacheBuildError::Storage`'s `source` field is wired as the
-    /// `std::error::Error::source()` of the wrapper.
+    /// `std::error::Error::source()` of the wrapper. The downcast below pins
+    /// current behavior only — the concrete source type is non-contract (see
+    /// the semver note on the error type) and may change with the storage
+    /// engine in a major release.
     #[test]
     fn build_error_storage_source_is_wired() {
         use std::error::Error;

--- a/src/stores/redis.rs
+++ b/src/stores/redis.rs
@@ -722,7 +722,10 @@ mod legacy_json_version_gate_tests {
 /// `[REDACTED connection string]`, so the value is safe to log or include in error messages.
 /// The raw URL (including any password) is available via [`reveal`](Self::reveal) and must not
 /// be logged or exposed in error messages.
-#[derive(Clone)]
+///
+/// Equality and hashing compare the raw (unredacted) URL, so two values compare
+/// equal exactly when their underlying connection strings match.
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ConnectionString(String);
 
 impl ConnectionString {
@@ -1399,6 +1402,12 @@ impl RedisCacheError {
 /// On-disk schema version stamped into every value written by this store.
 /// Shared by [`CachedRedisValue::new`] and [`CachedRedisValueRef::new`] so the
 /// two constructors cannot drift. The field type is `Option<u64>`.
+///
+/// Stability: the on-wire encoding (MessagePack, named fields `value`/`version`)
+/// is stable for the 3.x series — entries written by any 3.x release remain
+/// readable by every later 3.x release. Any schema change bumps this version,
+/// keeps a backward-read path within the same major version, and is otherwise
+/// reserved for a major release.
 const REDIS_VALUE_VERSION: Option<u64> = Some(1);
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -1824,6 +1833,13 @@ mod async_redis {
     /// `redis_smol_rustls`. The capability features `redis_async_cache` /
     /// `redis_connection_manager` are additive opt-ins layered on top of a runtime; they do not
     /// provide `AsyncRedisCache` on their own.
+    ///
+    /// **No connection-pool settings:** unlike [`RedisCacheBuilder`](crate::stores::RedisCacheBuilder),
+    /// there are no `connection_pool_*` methods here. The async cache does not use an r2d2
+    /// pool; it multiplexes all operations over a single pipelined connection (or the
+    /// auto-reconnecting connection manager when enabled via
+    /// `connection_manager(true)`), so pool sizing does not apply. Throughput is governed
+    /// by redis pipelining rather than a pool bound.
     #[cfg_attr(
         docsrs,
         doc(cfg(any(
@@ -3612,8 +3628,10 @@ mod error_source_tests {
         );
     }
 
-    /// `RedisCacheError::CacheDeserialization` must expose its inner
-    /// `rmp_serde::decode::Error` via `Error::source()`.
+    /// `RedisCacheError::CacheDeserialization` must expose its inner decode
+    /// error via `Error::source()`. The downcast below pins current behavior
+    /// only — the concrete source type is non-contract (see the semver note on
+    /// the error type) and may change with the codec in a major release.
     #[test]
     fn cache_deserialization_has_source() {
         // Construct a decode error by trying to decode garbage bytes.
@@ -3647,8 +3665,10 @@ mod error_source_tests {
         }
     }
 
-    /// `RedisCacheError::CacheSerialization` must expose its inner
-    /// `rmp_serde::encode::Error` via `Error::source()`.
+    /// `RedisCacheError::CacheSerialization` must expose its inner encode
+    /// error via `Error::source()`. The downcast below pins current behavior
+    /// only — the concrete source type is non-contract (see the semver note on
+    /// the error type) and may change with the codec in a major release.
     #[test]
     fn cache_serialization_has_source() {
         // Construct an encode error via a type that fails to serialize.

--- a/src/stores/sharded/expiring.rs
+++ b/src/stores/sharded/expiring.rs
@@ -495,6 +495,10 @@ where
         }
     }
 
+    /// Removes the entry and returns the value only if it is still live;
+    /// an expired value is removed but reported as `Ok(None)`. Use
+    /// [`cache_remove_entry`](ConcurrentCached::cache_remove_entry) to
+    /// receive the value regardless of expiry.
     fn cache_remove(&self, k: &K) -> Result<Option<V>, Self::Error> {
         let shard = self.shard_of(k);
         let removed = shard.lock.write().remove_entry(k);
@@ -513,6 +517,9 @@ where
         }
     }
 
+    /// Removes the entry and returns it **regardless of expiry** (unlike
+    /// [`cache_remove`](ConcurrentCached::cache_remove), which filters
+    /// expired values).
     fn cache_remove_entry(&self, k: &K) -> Result<Option<(K, V)>, Self::Error> {
         let shard = self.shard_of(k);
         let removed = shard.lock.write().remove_entry(k);
@@ -600,7 +607,7 @@ where
 /// [`ShardedTtlCache`](crate::ShardedTtlCache) or
 /// [`ShardedLruTtlCache`](crate::ShardedLruTtlCache) instead.
 #[doc(alias = "ttl")]
-pub struct ShardedExpiringCacheBuilder<K, V: Expires, H = DefaultShardHasher> {
+pub struct ShardedExpiringCacheBuilder<K, V, H = DefaultShardHasher> {
     shards: Option<usize>,
     hasher: Option<H>,
     on_evict: Option<OnEvict<K, V>>,
@@ -608,7 +615,7 @@ pub struct ShardedExpiringCacheBuilder<K, V: Expires, H = DefaultShardHasher> {
     _v: std::marker::PhantomData<V>,
 }
 
-impl<K, V: Expires> Default for ShardedExpiringCacheBuilder<K, V, DefaultShardHasher> {
+impl<K, V> Default for ShardedExpiringCacheBuilder<K, V, DefaultShardHasher> {
     fn default() -> Self {
         Self {
             shards: None,
@@ -620,7 +627,7 @@ impl<K, V: Expires> Default for ShardedExpiringCacheBuilder<K, V, DefaultShardHa
     }
 }
 
-impl<K, V: Expires, H> ShardedExpiringCacheBuilder<K, V, H> {
+impl<K, V, H> ShardedExpiringCacheBuilder<K, V, H> {
     /// Set the number of shards (rounded up to the next power of two).
     #[must_use]
     pub fn shards(mut self, shards: usize) -> Self {
@@ -688,7 +695,7 @@ impl<K, V: Expires, H> ShardedExpiringCacheBuilder<K, V, H> {
     ) -> Result<ShardedExpiringCacheBase<K, V, H>, BuildError>
     where
         K: Clone + Hash + Eq,
-        V: Clone,
+        V: Clone + Expires,
         H: ShardHasher<K>,
     {
         let new_cache = self.build()?;

--- a/src/stores/sharded/expiring_lru.rs
+++ b/src/stores/sharded/expiring_lru.rs
@@ -482,6 +482,9 @@ where
                 })
             };
             if matches!(&old, Some((_, _, true))) {
+                // `guard.evictions` is the inner LRU counter (unlike expired-on-access removals
+                // in `cache_get`, which use the outer `self.inner.evictions` because `pop_raw`
+                // bypasses the inner counter). Both feed the combined sum in `metrics()`.
                 guard.evictions.fetch_add(1, Ordering::Relaxed);
             }
             old
@@ -498,6 +501,10 @@ where
         }
     }
 
+    /// Removes the entry and returns the value only if it is still live;
+    /// an expired value is removed but reported as `Ok(None)`. Use
+    /// [`cache_remove_entry`](ConcurrentCached::cache_remove_entry) to
+    /// receive the value regardless of expiry.
     fn cache_remove(&self, k: &K) -> Result<Option<V>, Self::Error> {
         let shard = self.shard_of(k);
         let removed = {
@@ -521,6 +528,9 @@ where
         }
     }
 
+    /// Removes the entry and returns it **regardless of expiry** (unlike
+    /// [`cache_remove`](ConcurrentCached::cache_remove), which filters
+    /// expired values).
     fn cache_remove_entry(&self, k: &K) -> Result<Option<(K, V)>, Self::Error> {
         let shard = self.shard_of(k);
         let removed = {
@@ -660,7 +670,7 @@ where
 /// while `max_size` bounds the entry count via LRU. For a single global TTL applied to every
 /// entry, use [`ShardedLruTtlCache`](crate::ShardedLruTtlCache) instead.
 #[doc(alias = "ttl")]
-pub struct ShardedExpiringLruCacheBuilder<K, V: Expires, H = DefaultShardHasher> {
+pub struct ShardedExpiringLruCacheBuilder<K, V, H = DefaultShardHasher> {
     shards: Option<usize>,
     max_size: Option<usize>,
     per_shard_max_size: Option<usize>,
@@ -670,7 +680,7 @@ pub struct ShardedExpiringLruCacheBuilder<K, V: Expires, H = DefaultShardHasher>
     _v: std::marker::PhantomData<V>,
 }
 
-impl<K, V: Expires> Default for ShardedExpiringLruCacheBuilder<K, V, DefaultShardHasher> {
+impl<K, V> Default for ShardedExpiringLruCacheBuilder<K, V, DefaultShardHasher> {
     fn default() -> Self {
         Self {
             shards: None,
@@ -684,7 +694,7 @@ impl<K, V: Expires> Default for ShardedExpiringLruCacheBuilder<K, V, DefaultShar
     }
 }
 
-impl<K, V: Expires, H> ShardedExpiringLruCacheBuilder<K, V, H> {
+impl<K, V, H> ShardedExpiringLruCacheBuilder<K, V, H> {
     /// Set the requested total capacity (divided across shards via `div_ceil`).
     /// Mutually exclusive with [`per_shard_max_size`](Self::per_shard_max_size).
     ///
@@ -852,7 +862,7 @@ impl<K, V: Expires, H> ShardedExpiringLruCacheBuilder<K, V, H> {
     ) -> Result<ShardedExpiringLruCacheBase<K, V, H>, BuildError>
     where
         K: Clone + Hash + Eq,
-        V: Clone,
+        V: Clone + Expires,
         H: ShardHasher<K>,
     {
         let new_cache = self.build()?;

--- a/src/stores/sharded/lru_ttl.rs
+++ b/src/stores/sharded/lru_ttl.rs
@@ -203,6 +203,9 @@ impl<K: Clone + Hash + Eq, V: Clone, H: ShardHasher<K>> ShardedLruTtlCacheBase<K
         let n = self.inner.shards.len();
         let shards = (0..n)
             .map(|i| {
+                // Load the hit/miss counters under the read lock so the metrics snapshot is
+                // consistent with the entry snapshot (B4: loading after drop(guard) could yield
+                // counters newer than the cloned entries).
                 let guard = self.inner.shards[i].lock.read();
                 let store_copy = guard.clone();
                 let hits = self.inner.shards[i].hits.load(Ordering::Relaxed);
@@ -988,8 +991,9 @@ impl<K, V, E, H> ShardedLruTtlCacheBuilder<K, V, E, H> {
 impl<K, V, H> ShardedLruTtlCacheBuilder<K, V, NoEvict, H> {
     /// Set a callback invoked when an entry is evicted by LRU capacity pressure,
     /// TTL-expiry sweeps via [`evict`](ShardedLruTtlCacheBase::evict), explicit
-    /// [`cache_remove`](ConcurrentCached::cache_remove), or
-    /// [`cache_remove_entry`](ConcurrentCached::cache_remove_entry).
+    /// [`cache_remove`](ConcurrentCached::cache_remove) or
+    /// [`cache_remove_entry`](ConcurrentCached::cache_remove_entry), and on
+    /// [`cache_set`](ConcurrentCached::cache_set) when the displaced entry is already expired.
     /// Does **not** fire on [`clear`](ShardedLruTtlCacheBase::clear);
     /// use [`cache_clear_with_on_evict`](ShardedLruTtlCacheBase::cache_clear_with_on_evict) to opt in.
     ///

--- a/src/stores/sharded/ttl.rs
+++ b/src/stores/sharded/ttl.rs
@@ -197,6 +197,9 @@ impl<K: Clone + Hash + Eq, V: Clone, H: ShardHasher<K>> ShardedTtlCacheBase<K, V
         let n = self.inner.shards.len();
         let shards = (0..n)
             .map(|i| {
+                // Load the hit/miss counters under the read lock so the metrics snapshot is
+                // consistent with the entry snapshot (B4: loading after drop(guard) could yield
+                // counters newer than the cloned entries).
                 let guard = self.inner.shards[i].lock.read();
                 let store_copy = guard.clone();
                 let hits = self.inner.shards[i].hits.load(Ordering::Relaxed);

--- a/src/stores/sharded/unbound.rs
+++ b/src/stores/sharded/unbound.rs
@@ -315,7 +315,9 @@ where
     /// If no `on_evict` callback is configured, this is equivalent to [`clear`](Self::clear).
     ///
     /// **Note:** `ShardedUnboundCache` does not track eviction counts — `metrics().evictions` always
-    /// returns `None` regardless of whether `on_evict` fires.
+    /// returns `None` regardless of whether `on_evict` fires. This differs from the
+    /// eviction-tracking sharded stores, whose `cache_clear_with_on_evict` always counts the
+    /// removed entries as evictions; the unbounded store has no eviction counter to increment.
     pub fn cache_clear_with_on_evict(&self) {
         if self.inner.on_evict.is_none() {
             return self.clear();

--- a/src/stores/ttl_sorted.rs
+++ b/src/stores/ttl_sorted.rs
@@ -219,8 +219,8 @@ pub struct TtlSortedCache<K, V, S = DefaultHashBuilder> {
     // to support retaining/evicting without full traversal
     keys: BTreeSet<Stamped<K>>,
 
-    pub(crate) ttl: Duration,
-    pub(crate) size_limit: Option<usize>,
+    pub(super) ttl: Duration,
+    pub(super) size_limit: Option<usize>,
     // Preallocation hint captured at build so `cache_reset` can shrink back to
     // it instead of to zero, matching `TtlCache` (CORE-8).
     pub(super) initial_capacity: Option<usize>,

--- a/tests/ui/cached_expires_non_expires_type.stderr
+++ b/tests/ui/cached_expires_non_expires_type.stderr
@@ -4,9 +4,44 @@ error[E0277]: the trait bound `u32: Expires` is not satisfied
 3 | #[cached(expires = true)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Expires` is not implemented for `u32`
   |
-note: required by a bound in `ExpiringCache`
+note: required by a bound in `ExpiringCache::<K, V>::builder`
  --> src/stores/expiring.rs
   |
-  | pub struct ExpiringCache<K: Hash + Eq, V: Expires, S = DefaultHashBuilder> {
-  |                                           ^^^^^^^ required by this bound in `ExpiringCache`
+  | impl<K: Hash + Eq, V: Expires> ExpiringCache<K, V> {
+  |                       ^^^^^^^ required by this bound in `ExpiringCache::<K, V>::builder`
+...
+  |     pub fn builder() -> ExpiringCacheBuilder<K, V> {
+  |            ------- required by a bound in this associated function
+  = note: this error originates in the attribute macro `cached` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0599]: the method `cache_get` exists for struct `lock_api::rwlock::RwLockWriteGuard<'_, parking_lot::raw_rwlock::RawRwLock, ExpiringCache<u32, u32>>`, but its trait bounds were not satisfied
+ --> tests/ui/cached_expires_non_expires_type.rs:3:1
+  |
+3 | #[cached(expires = true)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^ method cannot be called due to unsatisfied trait bounds
+  |
+ ::: src/stores/expiring.rs
+  |
+  | pub struct ExpiringCache<K, V, S = DefaultHashBuilder> {
+  | ------------------------------------------------------ doesn't satisfy `ExpiringCache<u32, u32>: Cached<u32, u32>`
+  |
+  = note: the following trait bounds were not satisfied:
+          `u32: Expires`
+          which is required by `ExpiringCache<u32, u32>: Cached<u32, u32>`
+  = note: this error originates in the attribute macro `cached` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0599]: the method `cache_set` exists for struct `lock_api::rwlock::RwLockWriteGuard<'_, parking_lot::raw_rwlock::RawRwLock, ExpiringCache<u32, u32>>`, but its trait bounds were not satisfied
+ --> tests/ui/cached_expires_non_expires_type.rs:3:1
+  |
+3 | #[cached(expires = true)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^ method cannot be called due to unsatisfied trait bounds
+  |
+ ::: src/stores/expiring.rs
+  |
+  | pub struct ExpiringCache<K, V, S = DefaultHashBuilder> {
+  | ------------------------------------------------------ doesn't satisfy `ExpiringCache<u32, u32>: Cached<u32, u32>`
+  |
+  = note: the following trait bounds were not satisfied:
+          `u32: Expires`
+          which is required by `ExpiringCache<u32, u32>: Cached<u32, u32>`
   = note: this error originates in the attribute macro `cached` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/cached_sync_writes_buckets_inert.rs
+++ b/tests/ui/cached_sync_writes_buckets_inert.rs
@@ -1,0 +1,16 @@
+use cached::macros::cached;
+
+// `sync_writes_buckets` only applies to `sync_writes = "by_key"`. Supplying it
+// with any other `sync_writes` mode (including unset) must be rejected with a
+// clear error instead of being silently ignored.
+#[cached(sync_writes_buckets = 128)]
+fn unset_mode(x: u32) -> u32 {
+    x
+}
+
+#[cached(sync_writes = true, sync_writes_buckets = 128)]
+fn default_mode(x: u32) -> u32 {
+    x
+}
+
+fn main() {}

--- a/tests/ui/cached_sync_writes_buckets_inert.stderr
+++ b/tests/ui/cached_sync_writes_buckets_inert.stderr
@@ -1,0 +1,11 @@
+error: `sync_writes_buckets` only applies to `sync_writes = "by_key"` (it sets the number of per-key lock buckets); it has no effect with any other `sync_writes` mode. Add `sync_writes = "by_key"` or remove `sync_writes_buckets`.
+ --> tests/ui/cached_sync_writes_buckets_inert.rs:7:4
+  |
+7 | fn unset_mode(x: u32) -> u32 {
+  |    ^^^^^^^^^^
+
+error: `sync_writes_buckets` only applies to `sync_writes = "by_key"` (it sets the number of per-key lock buckets); it has no effect with any other `sync_writes` mode. Add `sync_writes = "by_key"` or remove `sync_writes_buckets`.
+  --> tests/ui/cached_sync_writes_buckets_inert.rs:12:4
+   |
+12 | fn default_mode(x: u32) -> u32 {
+   |    ^^^^^^^^^^^^

--- a/tests/v3_macros_ui.rs
+++ b/tests/v3_macros_ui.rs
@@ -119,6 +119,9 @@ fn compile_fail_v3_macros() {
     t.compile_fail("tests/ui/concurrent_cached_name_reserved_raw_prefix.rs");
     // D11: `sync_writes_buckets` is inert on `#[once]` (no `by_key` support).
     t.compile_fail("tests/ui/once_sync_writes_buckets_inert.rs");
+    // `sync_writes_buckets` on `#[cached]` without `sync_writes = "by_key"` is
+    // inert and must be rejected rather than silently ignored.
+    t.compile_fail("tests/ui/cached_sync_writes_buckets_inert.rs");
     // T1: `force_refresh = true` (bare bool) is a compile error on `#[once]` and
     // `#[concurrent_cached]`: the bare bool reaches `expr_to_block` which panics
     // because `parse_quote! { true }` is not a valid Stmt without a semicolon.


### PR DESCRIPTION
- `#[cached]` rejects an explicit `sync_writes_buckets` when `sync_writes` is not "by_key" instead of silently ignoring it, matching `#[once]`; adds a ui test
- Remove `K: Hash + Eq` / `V: Expires` bounds from the `ExpiringCache` / `ExpiringLruCache` type definitions and their builders (sharded builders included), matching every other store; bounds stay on the impls
- Derive `PartialEq`/`Eq`/`Hash` on `ConnectionString` (compares the raw unredacted URL)
- Derive `Clone`/`Copy`/`Debug`/`Default` on `NoEvict`/`HasEvict` and document them at the crate root (they appear in public `LruTtlCacheBuilder` signatures but were `#[doc(hidden)]` at the root)
- Re-export `CacheTtl` from the prelude unconditionally, matching `ConcurrentCacheTtl` (the trait was never feature-gated)
- `#[doc(hidden)]` on `Return::set_was_cached` (macro plumbing, not supported API); `#[must_use]` on `CacheMetrics::hit_ratio` and the `iter_order`/`key_order`/`value_order` accessors; narrow `TtlSortedCache`'s `ttl`/`size_limit` fields to `pub(super)`
- Document the redis on-wire format (msgpack `value`/`version`, `REDIS_VALUE_VERSION`) and redb on-disk format (versioned file name, table name, msgpack fields) as stable for the 3.x series
- Document why `AsyncRedisCacheBuilder` has no `connection_pool_*` methods (multiplexed connection, no r2d2 pool)
- Document the expiring stores' `cache_remove` vs `cache_remove_entry` expiry filtering, and the `cache_set`-over-expired `on_evict` trigger on `ShardedLruTtlCacheBuilder`
- Label the error-source downcast tests as pinning non-contract behavior (concrete source types stay out of the semver contract)
- Doc fixes on the macros: `expires` lists `result_fallback` in its mutual-exclusion set, `unsync_reads` names the built-in `CachedRead` stores, `result_fallback` distinguishes ttl-store refresh from `expires`-store behavior, `in_impl` notes the `companions_vis` override; the crate-doc custom-store example uses unquoted `create`/`convert`