### PR TITLE
feat: add runtime `set_max_size` to sharded LRU stores, rename `RedbCacheBuilder::disk_dir`, add `resilience` example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 ### Breaking Changes
 
 - `#[cached]` rejects an explicit `sync_writes_buckets` when `sync_writes` is not `"by_key"` with a pointed compile error. The value was previously accepted and silently ignored (buckets only exist on the `by_key` path); `#[once]` already rejected the same inert combination.
+- `RedbCacheBuilder::disk_directory` renamed to `disk_dir`, matching the `disk_dir` attribute on `#[concurrent_cached]`. Breaking only vs the 3.0 rcs (the method did not exist in 2.x under either name).
+
+### Added
+
+- `ShardedLruCacheBase`, `ShardedLruTtlCacheBase`, and `ShardedExpiringLruCacheBase` (and their default-hasher aliases) now support runtime capacity resizing via `set_max_size(&self, usize) -> Option<usize>` and `try_set_max_size(&self, usize) -> Result<Option<usize>, SetMaxSizeError>`. Shrinking evicts LRU-excess entries per shard, fires `on_evict`, and increments the eviction counter; the same ceiling-division-plus-16-per-shard-floor policy the builders use is applied; resize is not atomic across shards (matches the documented `set_ttl` behavior).
+- New runnable example `examples/resilience.rs` covering `sync_writes = "by_key"`, `result_fallback`, and `force_refresh`.
 
 ### Changed
 
@@ -12,7 +18,7 @@
 - `ConnectionString` derives `PartialEq`, `Eq`, and `Hash` (comparing the raw unredacted URL).
 - `NoEvict` / `HasEvict` derive `Clone`, `Copy`, `Debug`, and `Default`, and are documented at the crate root (previously `#[doc(hidden)]` there but documented at `cached::stores`). They appear in `LruTtlCacheBuilder` / `ShardedLruTtlCacheBuilder` signatures, so they are findable on docs.rs now.
 - `cached::prelude` re-exports `CacheTtl` unconditionally, matching `ConcurrentCacheTtl` (the trait was never feature-gated; only the built-in stores implementing it require `time_stores`).
-- `Return::set_was_cached` is `#[doc(hidden)]` (macro plumbing, not supported public API).
+- `Return::set_was_cached` is `#[doc(hidden)]` (macro plumbing, not supported public API). The method remains `pub` and callable (no compile breakage); it is de-documented because only macro-generated code should set the flag -- use `Return::new` to construct a value and `was_cached()` to read the flag.
 - `#[must_use]` added to `CacheMetrics::hit_ratio` and the `iter_order` / `key_order` / `value_order` accessors on `LruCache` / `LruTtlCache`.
 
 ### Documentation
@@ -25,6 +31,8 @@
 - `#[cached]`'s `unsync_reads` doc names the built-in `CachedRead` stores (`UnboundCache`, `TtlSortedCache`); `result_fallback` distinguishes TTL-store refresh semantics from `expires`-store behavior; `#[once]`'s `in_impl` doc notes `companions_vis` also overrides the `_no_cache` sibling's visibility.
 - The crate-doc custom-store example uses the unquoted `create` / `convert` forms.
 - The error-source downcast tests are labeled as pinning non-contract behavior (the concrete source types stay out of the semver contract).
+- The `#[concurrent_cached(redis = true)]` shorthand now appears in the macro quick-reference table.
+- `Cached::cache_capacity` / `ConcurrentCacheBase::cache_capacity` docs clarify that capacity means the eviction bound (`max_size`), not pre-allocated memory.
 
 ## [3.0.0-rc.7 / cached_proc_macro 3.0.0-rc.7] - 2026-07-12
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ CACHED_BASIC_EXAMPLES = async_std \
                         basic \
                         expires_per_key \
                         kitchen_sink \
+                        resilience \
                         struct_method \
                         tokio \
                         sharded \

--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ the short aliases come for free via the blanket extension trait impl.
 For `Cached` stores, `len`/`is_empty` are also on `CachedExt`. For `ConcurrentCached` stores,
 size introspection is `cache_size` and `cache_is_empty` on `ConcurrentCacheBase` (the shared base
 trait), not on `ConcurrentCachedExt`: bring `ConcurrentCacheBase` into scope to call them on a
-generic bound. (The sharded stores keep their inherent infallible `len`/`is_empty` too.)
+generic bound. Note that `ConcurrentCacheBase::cache_size` returns `Result<Option<usize>, _>`:
+fallible for IO-backed stores, and `None` when the backend cannot report an exact count. The sharded
+stores keep their inherent infallible `len`/`is_empty` too, which take priority at the call site.
 
 Both async traits use the `async_cache_*` spelling. `ConcurrentCachedAsync` mirrors the sync
 `ConcurrentCached` surface (`async_cache_get`, `async_cache_set`, `async_cache_remove`, ...) for
@@ -161,6 +163,7 @@ Any custom cache that implements `cached::ConcurrentCached`/`cached::ConcurrentC
 | Force-refresh via a dedicated flag (exclude it from the key) | `#[concurrent_cached(key = "u64", convert = { id }, force_refresh = { refresh })] fn fetch(id: u64, refresh: bool) -> Data { let _ = refresh; … }` — the generated guard reads `refresh` to decide whether to bypass the cache; the body still receives it as a normal parameter, so add `let _ = refresh;` (or `#[allow(unused_variables)]`) if your body does not otherwise use it |
 | Cache a method inside an `impl` block (one cache shared across all instances) | `#[concurrent_cached(in_impl = true)] fn load(&self, id: u64) -> Data` |
 | Persist results to disk (with `map_error`; or omit when `E: From<RedbCacheError>`) | `#[concurrent_cached(disk = true, map_error = \|e\| MyErr(e))] fn crunch(n: u64) -> Result<Data, MyErr>` |
+| Redis-backed async cache (shorthand; uses the default connection/builder) | `#[concurrent_cached(redis = true, ttl_secs = 30, map_error = \|e\| MyErr(e))] async fn api(id: u64) -> Result<Resp, MyErr>` |
 | Redis-backed async cache (quoted or unquoted `create`/`map_error`) | `#[concurrent_cached(ty = "AsyncRedisCache<u64, String>", create = { ... }, map_error = \|e\| MyErr(e))] async fn api(id: u64) -> Result<Resp, MyErr>` |
 
 On `#[cached]` and `#[concurrent_cached]`, the LRU bound is set with `max_size = N` (mirroring the `max_size` builder/constructor methods on the stores). The `size = N` spelling — a deprecated alias in 2.x — has been removed; only `max_size = N` is accepted.
@@ -294,7 +297,7 @@ It is also the idiomatic way to give entries a **dynamic, per-entry TTL** — a 
 
 When using the `#[cached]` or `#[once]` proc macros, add `expires = true` to opt into per-value expiry automatically. For `#[cached]`, this selects `ExpiringCache` (unbounded) by default or `ExpiringLruCache` when `max_size` is also specified. For `#[once]`, this stores a single value whose expiry is polled on each call.
 
-The macro form below derives each entry's TTL from a function argument — `key`/`convert` keep the TTL out of the cache key so it influences only the entry's lifetime, not which slot it occupies (`ignore`d as a doctest because it requires the default `proc_macro` feature; the same code runs in the [`expires_per_key`](https://github.com/jaemk/cached/blob/master/examples/expires_per_key.rs) example):
+The macro form below derives each entry's TTL from a function argument — `key`/`convert` keep the TTL out of the cache key so it influences only the entry's lifetime, not which slot it occupies (the same code runs in the [`expires_per_key`](https://github.com/jaemk/cached/blob/master/examples/expires_per_key.rs) example):
 
 ```rust
 use cached::macros::cached;
@@ -309,7 +312,7 @@ impl Expires for Token {
 }
 
 // `ttl_secs` is a runtime argument — each user's token expires on its own schedule.
-#[cached(expires = true, key = "u64", convert = "{ user_id }")]
+#[cached(expires = true, key = "u64", convert = { user_id })]
 fn fetch_token(user_id: u64, ttl_secs: u64) -> Token {
     Token {
         value: format!("token-{user_id}"),

--- a/cached_proc_macro/src/concurrent_cached.rs
+++ b/cached_proc_macro/src/concurrent_cached.rs
@@ -1623,7 +1623,7 @@ fn get_disk_cache_type_and_create(
             let create = match &args.disk_dir {
                 None => create,
                 Some(disk_dir) => {
-                    quote! { (#create).disk_directory(#disk_dir) }
+                    quote! { (#create).disk_dir(#disk_dir) }
                 }
             };
             quote! { (#create).build().unwrap_or_else(|e| panic!("error constructing RedbCache in #[concurrent_cached] macro: {e}")) }

--- a/docs/migrations/2.0-to-3.0.md
+++ b/docs/migrations/2.0-to-3.0.md
@@ -1035,6 +1035,7 @@ in a hot path), recreate the cache with the same builder settings instead of cal
 - `ConcurrentCloneCached::cache_peek_with_expiry_status` (and the `CloneCached` equivalent) — a read that returns the cached value along with its expiry status without renewing the TTL, updating LRU recency, or incrementing hit/miss counters. This is now a *required* method (see breaking change #16); the built-in sharded and in-memory expiry stores implement it with a genuine side-effect-free read.
 - `in_impl = true` macro attribute — cache a method inside an `impl` block (the cache static is emitted in the method body); a `self` receiver is allowed and excluded from the key. The `_prime_cache` companion is not generated for `in_impl` methods.
 - `LruCache::set_max_size` / `try_set_max_size`, `LruTtlCache::set_max_size` / `try_set_max_size`, `ExpiringLruCache::set_max_size` / `try_set_max_size` — resize a live LRU-backed cache (evicts LRU entries when shrinking). All three `try_set_max_size` methods return `Result<Option<usize>, cached::SetMaxSizeError>` where the inner value is the previous bound (same shape as `set_max_size`; `ZeroSize` on a zero argument).
+- `ShardedLruCache::set_max_size` / `try_set_max_size`, `ShardedLruTtlCache::set_max_size` / `try_set_max_size`, `ShardedExpiringLruCache::set_max_size` / `try_set_max_size` (and the `*Base` generic forms) — runtime capacity resize on the sharded LRU stores. Shrinking evicts LRU-excess entries per shard, fires `on_evict`, and increments the eviction counter; the same ceiling-division-plus-16-per-shard-floor policy the builders use is applied. Resize is not atomic across shards (matches the documented `set_ttl` behavior). Return type matches the non-sharded `set_max_size` / `try_set_max_size`.
 - `RedisCache` / `AsyncRedisCache` now implement `cache_clear` / `async_cache_clear` (namespace-scoped `SCAN` + `DEL`); `cache_reset` / `async_cache_reset` delegate to them (redis tracks no in-memory metrics).
 - Reference arguments (`&T`, `Option<&T>`) now form the default macro key without a `convert`.
 - `Expires::expires_at(&self) -> Option<cached::time::Instant>` -- default trait method returning the value's expiry instant when tracked (`None` by default / when unknown). Advisory/observability only; `is_expired()` remains the authoritative liveness check. Existing `impl Expires` blocks (which provide only `is_expired`) get the default for free. The instant type is the crate's `time::Instant` (`web_time` on wasm, `std` elsewhere), not `std::time::Instant`; a custom override must use that type.
@@ -1432,6 +1433,38 @@ without the `redis_async_cache` feature.
 Action: gate the arm with `#[cfg(feature = "redis_async_cache")]` or drop it and rely on the
 `_` arm.
 
+### 68. `#[cached]` rejects `sync_writes_buckets` without `sync_writes = "by_key"`
+
+Using `sync_writes_buckets = N` on `#[cached]` without `sync_writes = "by_key"` is now a compile
+error. The attribute was previously accepted and silently ignored; buckets only exist on the
+`by_key` path. `#[once]` already rejected this combination before this change.
+
+Compile error text:
+```
+error: `sync_writes_buckets` only applies to `sync_writes = "by_key"` (it sets the number of
+per-key lock buckets); it has no effect with any other `sync_writes` mode. Add
+`sync_writes = "by_key"` or remove `sync_writes_buckets`.
+```
+
+Detection: grep for `sync_writes_buckets` and verify each site also has `sync_writes = "by_key"`.
+
+Action: either add `sync_writes = "by_key"` to opt into per-key locking with the configured
+bucket count, or remove `sync_writes_buckets` to keep the previous effective behavior (no write
+synchronization):
+```rust
+// Before (compiled, sync_writes_buckets was silently ignored)
+#[cached(sync_writes_buckets = 128)]
+fn compute(x: u64) -> u64 { expensive(x) }
+
+// After -- option A: opt into per-key locking with 128 buckets
+#[cached(sync_writes = "by_key", sync_writes_buckets = 128)]
+fn compute(x: u64) -> u64 { expensive(x) }
+
+// After -- option B: remove the inert attribute (keeps no-synchronization default)
+#[cached]
+fn compute(x: u64) -> u64 { expensive(x) }
+```
+
 ## Required Cargo.toml change
 
 ```toml
@@ -1501,4 +1534,5 @@ has a breaking change this major, see #51).
   - `RedisCache::builder()` / `AsyncRedisCache::builder()` / `RedbCache::builder()` with no arguments fails to compile → pass the prefix/name as a positional argument: `builder("my_prefix")` / `builder("my_name")` (#64).
   - a `match` arm on `RedisCacheBuildError::Build(BuildError::MissingRequired(..))` for `"ttl"` is now unreachable → remove the arm; set `.ttl(Duration)` explicitly if you need expiry (#65).
   - a `#[concurrent_cached(disk = true, cache_prefix_block = ...)]` annotation that previously compiled → remove `cache_prefix_block`; disk stores key by redb table name, set via `name = "..."` (#66).
+  - `` `sync_writes_buckets` only applies to `sync_writes = "by_key"` `` → add `sync_writes = "by_key"` to opt into per-key locking, or remove `sync_writes_buckets` to keep no-synchronization behavior (#68).
 - `cargo test` — no behavior changes beyond the above; disk caches will be empty on first run after upgrade (format change). The default `#[cached]` write behavior is unchanged from 2.x (no synchronization); `sync_writes = "by_key"` is an opt-in (#39).

--- a/examples/resilience.rs
+++ b/examples/resilience.rs
@@ -1,0 +1,289 @@
+/*
+Three 3.0 resilience attributes on `#[cached]` functions - in-memory, no external services.
+
+1. `sync_writes = "by_key"`: concurrent first calls for the same key are deduplicated -
+   only one thread runs the function body; the others wait and reuse that result.
+   Independent keys compute in parallel.
+
+2. `result_fallback = true`: a TTL-cached fallible function serves the last `Ok` value
+   when the function returns `Err` instead of propagating the error. Requires a TTL store
+   (`ttl_secs`, `ttl_millis`, or `ttl`).
+
+3. `force_refresh = { expr }`: bypass the cache and recompute when a boolean expression
+   over the function arguments is true. Uses a call counter to show the difference between
+   a cache hit (expression false) and a forced recompute (expression true).
+
+Run:
+    cargo run --example resilience --all-features
+*/
+
+use cached::macros::cached;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier};
+use std::thread;
+use std::time::Duration;
+
+// ============================================================================
+// 1. sync_writes = "by_key"
+//
+// Concurrent calls for the same key serialize: one thread computes, the rest
+// wait and reuse the result. Distinct keys compute independently (in parallel).
+//
+// The body counter shows how many times the function actually executed -
+// with deduplication this equals the number of DISTINCT keys, not total calls.
+// ============================================================================
+
+static BY_KEY_CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+#[cached(sync_writes = "by_key")]
+fn slow_lookup(key: u32) -> String {
+    BY_KEY_CALL_COUNT.fetch_add(1, Ordering::SeqCst);
+    // Simulate a slow operation (database call, HTTP request, etc.)
+    thread::sleep(Duration::from_millis(50));
+    format!("value-for-{key}")
+}
+
+fn demo_sync_writes_by_key() {
+    println!("\n--- 1. sync_writes = \"by_key\" ---");
+
+    BY_KEY_CALL_COUNT.store(0, Ordering::SeqCst);
+
+    // Spawn 5 threads all calling with the same key (42). Only one should
+    // actually run the body; the other 4 wait and reuse the computed result.
+    let barrier = Arc::new(Barrier::new(5));
+    let handles: Vec<_> = (0..5)
+        .map(|_| {
+            let b = Arc::clone(&barrier);
+            thread::spawn(move || {
+                b.wait(); // release all threads simultaneously
+                slow_lookup(42)
+            })
+        })
+        .collect();
+
+    let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+    let body_runs = BY_KEY_CALL_COUNT.load(Ordering::SeqCst);
+    println!(
+        "  5 concurrent calls for key=42: body ran {body_runs} time(s), \
+         all returned '{}'",
+        results[0]
+    );
+    // The body ran exactly once; all callers received the same value.
+    assert_eq!(
+        body_runs, 1,
+        "body must run exactly once for 5 concurrent same-key calls"
+    );
+    assert!(
+        results.iter().all(|r| r == &results[0]),
+        "all callers must receive the same value"
+    );
+
+    // Reset counter and show distinct keys compute independently.
+    BY_KEY_CALL_COUNT.store(0, Ordering::SeqCst);
+
+    let barrier2 = Arc::new(Barrier::new(3));
+    let distinct_handles: Vec<_> = [10u32, 20, 30]
+        .into_iter()
+        .map(|key| {
+            let b = Arc::clone(&barrier2);
+            thread::spawn(move || {
+                b.wait();
+                slow_lookup(key)
+            })
+        })
+        .collect();
+
+    for h in distinct_handles {
+        h.join().unwrap();
+    }
+
+    let distinct_runs = BY_KEY_CALL_COUNT.load(Ordering::SeqCst);
+    println!(
+        "  3 concurrent calls for distinct keys (10, 20, 30): body ran {distinct_runs} time(s)"
+    );
+    assert_eq!(distinct_runs, 3, "each distinct key must run the body once");
+
+    println!("  PASS: by_key deduplication confirmed");
+}
+
+// ============================================================================
+// 2. result_fallback = true
+//
+// A TTL-cached fallible function that succeeds once and is then made to fail.
+// Instead of propagating the Err, the cache serves the last Ok value.
+//
+// Requires: a TTL store (`ttl_secs`, `ttl_millis`, or `ttl`).
+// Not compatible with any explicitly-set `sync_writes` value (`"by_key"`, `true`,
+// or `"default"`); leave `sync_writes` unset (or `false`).
+// ============================================================================
+
+static FALLBACK_SHOULD_FAIL: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+static FALLBACK_CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+// ttl_secs ensures the store is a TtlCache, which implements CloneCached (required
+// by result_fallback). A long TTL means the entry stays live during the demo.
+#[cached(ttl_secs = 60, result_fallback = true)]
+fn fetch_config() -> Result<String, String> {
+    FALLBACK_CALL_COUNT.fetch_add(1, Ordering::SeqCst);
+    if FALLBACK_SHOULD_FAIL.load(Ordering::SeqCst) {
+        Err("upstream unavailable".to_string())
+    } else {
+        Ok("config-v1".to_string())
+    }
+}
+
+fn demo_result_fallback() {
+    println!("\n--- 2. result_fallback = true ---");
+
+    FALLBACK_SHOULD_FAIL.store(false, Ordering::SeqCst);
+    FALLBACK_CALL_COUNT.store(0, Ordering::SeqCst);
+
+    // First call: succeeds, result is cached.
+    let first = fetch_config();
+    assert_eq!(
+        first,
+        Ok("config-v1".to_string()),
+        "first call must succeed"
+    );
+    println!("  First call (Ok): {:?}", first);
+
+    // Make the function start failing.
+    FALLBACK_SHOULD_FAIL.store(true, Ordering::SeqCst);
+
+    // Second call: cache still has the live Ok value - returned as a hit.
+    let second = fetch_config();
+    assert_eq!(
+        second,
+        Ok("config-v1".to_string()),
+        "cache hit must return stale Ok"
+    );
+    println!("  Second call (cache hit, no recompute): {:?}", second);
+
+    // Expire the cache entry by writing a failure marker into the cache manually,
+    // then calling again. Because the TTL is long, simulate TTL expiry by clearing
+    // the cache and calling again while the function still fails.
+    {
+        use cached::Cached;
+        FETCH_CONFIG.write().cache_clear();
+    }
+
+    // Third call: cache miss, function runs and returns Err. result_fallback has
+    // no prior Ok to fall back to (cache was cleared), so Err is propagated.
+    let third = fetch_config();
+    assert!(
+        third.is_err(),
+        "Err with no prior Ok in cache must propagate"
+    );
+    println!(
+        "  Third call (cache cleared, no fallback available): {:?}",
+        third
+    );
+
+    // Seed a known Ok value directly into the cache, then fail again.
+    {
+        use cached::Cached;
+        FETCH_CONFIG.write().cache_set((), "config-v2".to_string());
+    }
+
+    // Fourth call: function runs, returns Err, but fallback serves the seeded Ok.
+    let fourth = fetch_config();
+    assert_eq!(
+        fourth,
+        Ok("config-v2".to_string()),
+        "Err with prior Ok in cache must serve stale Ok"
+    );
+    println!("  Fourth call (Err, falls back to stale Ok): {:?}", fourth);
+
+    println!("  PASS: result_fallback confirmed");
+}
+
+// ============================================================================
+// 3. force_refresh = { expr }
+//
+// When the expression evaluates to true, any cached value is bypassed and the
+// function body is re-run. The result is stored back into the cache.
+// When the expression is false, the normal cache hit path is used.
+//
+// The call counter shows the body only runs when the expression is true or on
+// the initial cache miss; subsequent false-expression calls are pure cache hits.
+// ============================================================================
+
+static REFRESH_CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+// `force_refresh` uses `bypass` directly as the predicate. `key`/`convert` exclude
+// `bypass` from the cache key so both call shapes resolve to the same cache entry.
+#[cached(
+    key = "u32",
+    convert = { id },
+    force_refresh = { bypass }
+)]
+fn get_value(id: u32, bypass: bool) -> u32 {
+    // The generated guard reads `bypass` to decide whether to bypass the cache;
+    // the body still receives it as a normal parameter, so silence the
+    // unused-variable warning here.
+    let _ = bypass;
+    REFRESH_CALL_COUNT.fetch_add(1, Ordering::SeqCst);
+    id * 100
+}
+
+fn demo_force_refresh() {
+    println!("\n--- 3. force_refresh = {{ expr }} ---");
+
+    REFRESH_CALL_COUNT.store(0, Ordering::SeqCst);
+
+    // First call: cache miss, body runs.
+    let v1 = get_value(7, false);
+    assert_eq!(v1, 700);
+    let runs_after_miss = REFRESH_CALL_COUNT.load(Ordering::SeqCst);
+    assert_eq!(runs_after_miss, 1, "initial miss must run the body once");
+    println!("  get_value(7, bypass=false) = {v1} [body ran: {runs_after_miss} time(s) total]");
+
+    // Second call: same key, bypass=false -> cache hit, body does NOT run.
+    let v2 = get_value(7, false);
+    assert_eq!(v2, 700);
+    let runs_after_hit = REFRESH_CALL_COUNT.load(Ordering::SeqCst);
+    assert_eq!(
+        runs_after_hit, 1,
+        "cache hit must not increment the body counter"
+    );
+    println!(
+        "  get_value(7, bypass=false) = {v2} [body ran: {runs_after_hit} time(s) total - cache hit]"
+    );
+
+    // Third call: same key, bypass=true -> force-refresh, body runs again.
+    let v3 = get_value(7, true);
+    assert_eq!(v3, 700);
+    let runs_after_refresh = REFRESH_CALL_COUNT.load(Ordering::SeqCst);
+    assert_eq!(
+        runs_after_refresh, 2,
+        "force_refresh must run the body once more"
+    );
+    println!(
+        "  get_value(7, bypass=true)  = {v3} [body ran: {runs_after_refresh} time(s) total - forced recompute]"
+    );
+
+    // Fourth call: back to false -> cache hit again, no body run.
+    let v4 = get_value(7, false);
+    assert_eq!(v4, 700);
+    let runs_final = REFRESH_CALL_COUNT.load(Ordering::SeqCst);
+    assert_eq!(
+        runs_final, 2,
+        "subsequent false-expression call must be a cache hit"
+    );
+    println!(
+        "  get_value(7, bypass=false) = {v4} [body ran: {runs_final} time(s) total - cache hit]"
+    );
+
+    println!("  PASS: force_refresh confirmed");
+}
+
+fn main() {
+    demo_sync_writes_by_key();
+    demo_result_fallback();
+    demo_force_refresh();
+
+    println!("\ndone!");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,9 @@ the short aliases come for free via the blanket extension trait impl.
 For `Cached` stores, `len`/`is_empty` are also on `CachedExt`. For `ConcurrentCached` stores,
 size introspection is `cache_size` and `cache_is_empty` on `ConcurrentCacheBase` (the shared base
 trait), not on `ConcurrentCachedExt`: bring `ConcurrentCacheBase` into scope to call them on a
-generic bound. (The sharded stores keep their inherent infallible `len`/`is_empty` too.)
+generic bound. Note that `ConcurrentCacheBase::cache_size` returns `Result<Option<usize>, _>`:
+fallible for IO-backed stores, and `None` when the backend cannot report an exact count. The sharded
+stores keep their inherent infallible `len`/`is_empty` too, which take priority at the call site.
 
 Both async traits use the `async_cache_*` spelling. `ConcurrentCachedAsync` mirrors the sync
 `ConcurrentCached` surface (`async_cache_get`, `async_cache_set`, `async_cache_remove`, ...) for
@@ -160,6 +162,7 @@ Any custom cache that implements `cached::ConcurrentCached`/`cached::ConcurrentC
 | Force-refresh via a dedicated flag (exclude it from the key) | `#[concurrent_cached(key = "u64", convert = { id }, force_refresh = { refresh })] fn fetch(id: u64, refresh: bool) -> Data { let _ = refresh; … }` — the generated guard reads `refresh` to decide whether to bypass the cache; the body still receives it as a normal parameter, so add `let _ = refresh;` (or `#[allow(unused_variables)]`) if your body does not otherwise use it |
 | Cache a method inside an `impl` block (one cache shared across all instances) | `#[concurrent_cached(in_impl = true)] fn load(&self, id: u64) -> Data` |
 | Persist results to disk (with `map_error`; or omit when `E: From<RedbCacheError>`) | `#[concurrent_cached(disk = true, map_error = \|e\| MyErr(e))] fn crunch(n: u64) -> Result<Data, MyErr>` |
+| Redis-backed async cache (shorthand; uses the default connection/builder) | `#[concurrent_cached(redis = true, ttl_secs = 30, map_error = \|e\| MyErr(e))] async fn api(id: u64) -> Result<Resp, MyErr>` |
 | Redis-backed async cache (quoted or unquoted `create`/`map_error`) | `#[concurrent_cached(ty = "AsyncRedisCache<u64, String>", create = { ... }, map_error = \|e\| MyErr(e))] async fn api(id: u64) -> Result<Resp, MyErr>` |
 
 On `#[cached]` and `#[concurrent_cached]`, the LRU bound is set with `max_size = N` (mirroring the `max_size` builder/constructor methods on the stores). The `size = N` spelling — a deprecated alias in 2.x — has been removed; only `max_size = N` is accepted.
@@ -293,9 +296,9 @@ It is also the idiomatic way to give entries a **dynamic, per-entry TTL** — a 
 
 When using the `#[cached]` or `#[once]` proc macros, add `expires = true` to opt into per-value expiry automatically. For `#[cached]`, this selects `ExpiringCache` (unbounded) by default or `ExpiringLruCache` when `max_size` is also specified. For `#[once]`, this stores a single value whose expiry is polled on each call.
 
-The macro form below derives each entry's TTL from a function argument — `key`/`convert` keep the TTL out of the cache key so it influences only the entry's lifetime, not which slot it occupies (`ignore`d as a doctest because it requires the default `proc_macro` feature; the same code runs in the [`expires_per_key`](https://github.com/jaemk/cached/blob/master/examples/expires_per_key.rs) example):
+The macro form below derives each entry's TTL from a function argument — `key`/`convert` keep the TTL out of the cache key so it influences only the entry's lifetime, not which slot it occupies (the same code runs in the [`expires_per_key`](https://github.com/jaemk/cached/blob/master/examples/expires_per_key.rs) example):
 
-```rust,ignore
+```rust,no_run
 use cached::macros::cached;
 use cached::Expires;
 use cached::time::{Duration, Instant};
@@ -308,7 +311,7 @@ impl Expires for Token {
 }
 
 // `ttl_secs` is a runtime argument — each user's token expires on its own schedule.
-#[cached(expires = true, key = "u64", convert = "{ user_id }")]
+#[cached(expires = true, key = "u64", convert = { user_id })]
 fn fetch_token(user_id: u64, ttl_secs: u64) -> Token {
     Token {
         value: format!("token-{user_id}"),
@@ -1075,6 +1078,9 @@ pub trait Cached<K, V> {
     }
 
     /// Return the cache capacity, if bounded.
+    ///
+    /// "Capacity" here means the eviction bound — the configured `max_size` — not pre-allocated
+    /// storage like `Vec::capacity`. Unbounded stores return `None`.
     #[must_use]
     fn cache_capacity(&self) -> Option<usize> {
         None
@@ -1866,8 +1872,9 @@ pub trait ConcurrentCacheBase {
 
     /// Return the cache capacity, if bounded.
     ///
-    /// Bounded stores (e.g. `ShardedLruCache`, `ShardedLruTtlCache`, `ShardedExpiringLruCache`)
-    /// return `Some(total_capacity)`; unbounded stores return `None`.
+    /// "Capacity" here means the eviction bound — the configured `max_size` — not pre-allocated
+    /// storage like `Vec::capacity`. Bounded stores (e.g. `ShardedLruCache`, `ShardedLruTtlCache`,
+    /// `ShardedExpiringLruCache`) return `Some(total_capacity)`; unbounded stores return `None`.
     ///
     /// This mirrors [`Cached::cache_capacity`] on the non-concurrent family.
     #[must_use]

--- a/src/stores/expiring.rs
+++ b/src/stores/expiring.rs
@@ -492,10 +492,6 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> Cached<K, V> for ExpiringCache<K,
         self.store.cache_size()
     }
 
-    fn cache_capacity(&self) -> Option<usize> {
-        None
-    }
-
     fn cache_hits(&self) -> Option<u64> {
         Some(self.hits.load(Ordering::Relaxed))
     }

--- a/src/stores/redb.rs
+++ b/src/stores/redb.rs
@@ -191,9 +191,16 @@ where
         self
     }
 
-    /// Set the disk path for where the data will be stored
+    /// Set the disk path for where the data will be stored.
+    ///
+    /// When not called, the builder falls back to a platform-appropriate default
+    /// directory keyed by the executable name: the user cache dir (e.g.
+    /// `$XDG_CACHE_HOME` / `~/.cache` on Linux) when writable, otherwise the
+    /// system temp dir. Data in a temp dir may be cleaned up by the OS; set an
+    /// explicit directory for anything that should persist. The resolved path is
+    /// available via [`RedbCache::disk_path`] after building.
     #[must_use]
-    pub fn disk_directory<P: AsRef<Path>>(mut self, dir: P) -> Self {
+    pub fn disk_dir<P: AsRef<Path>>(mut self, dir: P) -> Self {
         self.disk_dir = Some(dir.as_ref().into());
         self
     }
@@ -1594,7 +1601,7 @@ mod tests {
         // setter produces a working disk cache that respects the TTL.
         let dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("ttl-secs-roundtrip")
-            .disk_directory(dir.path())
+            .disk_dir(dir.path())
             .ttl_secs(60)
             .build()
             .expect("build must succeed");
@@ -1609,7 +1616,7 @@ mod tests {
         // past it once expiry is disabled.
         let dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("set-ttl-zero-disables")
-            .disk_directory(dir.path())
+            .disk_dir(dir.path())
             .ttl_millis(20)
             .build()
             .expect("build must succeed");
@@ -1633,7 +1640,7 @@ mod tests {
         // evicted it). Neither entry is ever rewritten.
         let dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("set-ttl-retroactive")
-            .disk_directory(dir.path())
+            .disk_dir(dir.path())
             .ttl_secs(3600)
             .build()
             .expect("build must succeed");
@@ -1675,7 +1682,7 @@ mod tests {
         // cannot pre-delete the entry and mask the revival.
         let dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("unset-ttl-retroactive")
-            .disk_directory(dir.path())
+            .disk_dir(dir.path())
             .ttl_millis(5)
             .build()
             .expect("build must succeed");
@@ -1787,7 +1794,7 @@ mod tests {
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, SerializeFailsAfterDeserialize> =
             RedbCache::builder("serialize_error_on_refresh")
-                .disk_directory(tmp_dir.path())
+                .disk_dir(tmp_dir.path())
                 .ttl(Duration::from_secs(10))
                 .refresh_on_hit(true)
                 .build()
@@ -1811,7 +1818,7 @@ mod tests {
     fn cache_get_returns_decode_error_for_corrupted_value_in_strict_mode() {
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("corrupted-cache-get-strict")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .strict_deserialization(true)
             .build()
             .expect("error building disk cache");
@@ -1830,7 +1837,7 @@ mod tests {
     fn cache_get_self_heals_corrupted_entry_by_default() {
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("corrupted-cache-get-default")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .build()
             .expect("error building disk cache");
         raw_insert(&cache, &TEST_KEY.to_string(), vec![0xc1, 0xc1, 0xc1]);
@@ -1845,7 +1852,7 @@ mod tests {
     fn cache_delete_removes_corrupted_value_without_decoding() {
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("corrupted-cache-delete")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .build()
             .expect("error building disk cache");
         raw_insert(&cache, &TEST_KEY.to_string(), vec![0xc1, 0xc1, 0xc1]);
@@ -1859,7 +1866,7 @@ mod tests {
     fn cache_set_overwrites_corrupted_value() {
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("corrupted-cache-set")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .build()
             .expect("error building disk cache");
         raw_insert(&cache, &TEST_KEY.to_string(), vec![0xc1, 0xc1, 0xc1]);
@@ -1874,7 +1881,7 @@ mod tests {
     fn cache_remove_removes_corrupted_value() {
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("corrupted-cache-remove")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .build()
             .expect("error building disk cache");
         raw_insert(&cache, &TEST_KEY.to_string(), vec![0xc1, 0xc1, 0xc1]);
@@ -1889,7 +1896,7 @@ mod tests {
     fn cache_remove_entry_round_trips_and_removes_corrupted_value() {
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("remove-entry-roundtrip")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .build()
             .expect("error building disk cache");
 
@@ -1914,7 +1921,7 @@ mod tests {
     fn cache_remove_entry_returns_expired_but_present_entry() {
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("remove-entry-expired")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .ttl(LIFE_SPAN_1_SEC)
             .build()
             .expect("error building disk cache");
@@ -1936,7 +1943,7 @@ mod tests {
         let tmp_dir = temp_dir!();
         // Opt into Durability::None writes so flush() has buffered writes to persist.
         let cache: RedbCache<u32, u32> = RedbCache::builder("flush-test")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .durable(false)
             .build()
             .expect("error building disk cache");
@@ -1957,14 +1964,14 @@ mod tests {
         // in-process reopen, so this checks the round-trip, not crash durability.)
         drop(cache);
         let reopened: RedbCache<u32, u32> = RedbCache::builder("flush-test")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .build()
             .expect("error re-opening cache");
         assert_that!(reopened.cache_get(&TEST_KEY), ok(some(eq(&TEST_VAL))));
 
         // flush is a safe no-op on an already-durable cache, and on an empty cache.
         let durable: RedbCache<u32, u32> = RedbCache::builder("flush-test-durable")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .durable(true)
             .build()
             .unwrap();
@@ -1987,7 +1994,7 @@ mod tests {
         let target = temp_dir!();
         {
             let _seed: RedbCache<u32, u32> = RedbCache::builder(NAME)
-                .disk_directory(target.path())
+                .disk_dir(target.path())
                 .build()
                 .unwrap();
         }
@@ -1997,7 +2004,7 @@ mod tests {
         std::os::unix::fs::symlink(&target_file, dir.path().join(&file_name)).unwrap();
 
         let result = RedbCache::<u32, u32>::builder(NAME)
-            .disk_directory(dir.path())
+            .disk_dir(dir.path())
             .build();
         assert!(result.is_err(), "a symlinked db path must be rejected");
     }
@@ -2005,14 +2012,14 @@ mod tests {
     // SEC-4: an explicitly configured directory that is a symlink is rejected.
     #[cfg(unix)]
     #[test]
-    fn symlinked_disk_directory_is_rejected() {
+    fn symlinked_disk_dir_is_rejected() {
         let real = temp_dir!();
         let link_parent = temp_dir!();
         let link = link_parent.path().join("linkdir");
         std::os::unix::fs::symlink(real.path(), &link).unwrap();
 
         let result = RedbCache::<u32, u32>::builder("symlink-dir")
-            .disk_directory(&link)
+            .disk_dir(&link)
             .build();
         assert!(
             result.is_err(),
@@ -2035,7 +2042,7 @@ mod tests {
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
 
         let _c: RedbCache<u32, u32> = RedbCache::builder(NAME)
-            .disk_directory(dir.path())
+            .disk_dir(dir.path())
             .build()
             .unwrap();
 
@@ -2057,7 +2064,7 @@ mod tests {
         let dir_a = temp_dir!();
         let src = dir_a.path().join(&file_name);
         let a: RedbCache<u32, u32> = RedbCache::builder(NAME)
-            .disk_directory(dir_a.path())
+            .disk_dir(dir_a.path())
             .durable(false) // opt into Durability::None writes
             .build()
             .unwrap();
@@ -2067,7 +2074,7 @@ mod tests {
         let dir_before = temp_dir!();
         std::fs::copy(&src, dir_before.path().join(&file_name)).unwrap();
         let before: RedbCache<u32, u32> = RedbCache::builder(NAME)
-            .disk_directory(dir_before.path())
+            .disk_dir(dir_before.path())
             .build()
             .unwrap();
         assert_that!(
@@ -2081,7 +2088,7 @@ mod tests {
         let dir_after = temp_dir!();
         std::fs::copy(&src, dir_after.path().join(&file_name)).unwrap();
         let after: RedbCache<u32, u32> = RedbCache::builder(NAME)
-            .disk_directory(dir_after.path())
+            .disk_dir(dir_after.path())
             .build()
             .unwrap();
         assert_that!(
@@ -2096,7 +2103,7 @@ mod tests {
     fn remove_expired_entries_returns_decode_error_for_corrupted_value_in_strict_mode() {
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("corrupted-sweep-strict")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .ttl(Duration::from_secs(1))
             .strict_deserialization(true)
             .build()
@@ -2115,7 +2122,7 @@ mod tests {
     fn remove_expired_entries_self_heals_corrupted_entries_by_default() {
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("corrupted-sweep-default")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .ttl(Duration::from_secs(1))
             .build()
             .expect("error building disk cache");
@@ -2134,7 +2141,7 @@ mod tests {
     fn remove_expired_entries_returns_count_of_removed_entries() {
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("sweep-count")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .ttl(LIFE_SPAN_1_SEC)
             .build()
             .expect("error building disk cache");
@@ -2170,7 +2177,7 @@ mod tests {
     fn remove_expired_entries_uses_single_time_snapshot() {
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("sweep-single-snapshot")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .ttl(LIFE_SPAN_1_SEC)
             .build()
             .expect("error building disk cache");
@@ -2205,7 +2212,7 @@ mod tests {
     fn remove_expired_entries_returns_zero_when_no_ttl_configured() {
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("sweep-no-ttl")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             // No TTL set -- entries never expire.
             .build()
             .expect("error building disk cache");
@@ -2228,7 +2235,7 @@ mod tests {
     fn remove_expired_entries_sweeps_corrupt_and_expired_but_keeps_live() {
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("sweep-mixed-corrupt-live-expired")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .ttl(Duration::from_secs(60))
             .build()
             .expect("error building disk cache");
@@ -2295,7 +2302,7 @@ mod tests {
     fn remove_expired_entries_strict_mode_aborts_and_leaves_corrupt_entry() {
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("sweep-strict-leaves-corrupt")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .ttl(Duration::from_secs(1))
             .strict_deserialization(true)
             .build()
@@ -2320,7 +2327,7 @@ mod tests {
     fn remove_expired_entries_strict_mode_error_rolls_back_prior_evictions() {
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("sweep-strict-rolls-back")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .ttl(LIFE_SPAN_1_SEC)
             .strict_deserialization(true)
             .build()
@@ -2359,7 +2366,7 @@ mod tests {
     fn cache_get_self_heal_then_recompute_produces_hit() {
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("self-heal-then-recompute")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .build()
             .expect("error building disk cache");
         raw_insert(&cache, &TEST_KEY.to_string(), vec![0xc1, 0xc1, 0xc1]);
@@ -2405,7 +2412,7 @@ mod tests {
     fn cache_get_after_cache_remove_returns_none() {
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("test-cache")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .build()
             .unwrap();
 
@@ -2450,7 +2457,7 @@ mod tests {
     fn cache_clear_empties_the_table() {
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("test-cache-clear")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .build()
             .unwrap();
 
@@ -2475,7 +2482,7 @@ mod tests {
     fn values_expire_when_lifespan_elapses_returning_none() {
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("test-cache")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .ttl(LIFE_SPAN_2_SECS)
             .build()
             .unwrap();
@@ -2512,7 +2519,7 @@ mod tests {
         // COPY PASTE of [values_expire_when_lifespan_elapses_returning_none]
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("test-cache")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .ttl(LIFE_SPAN_2_SECS)
             .build()
             .unwrap();
@@ -2591,7 +2598,7 @@ mod tests {
         const HALF_LIFE_SPAN: Duration = LIFE_SPAN_1_SEC;
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("test-cache")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .ttl(LIFE_SPAN)
             .refresh_on_hit(true) // ENABLE REFRESH - this is what we're testing
             .build()
@@ -2628,8 +2635,8 @@ mod tests {
 
     #[googletest::test]
     // Smoke test for the default disk directory: a full get/set/remove
-    // round-trip succeeds when `disk_directory` is left at its default.
-    fn does_not_break_when_constructed_using_default_disk_directory() {
+    // round-trip succeeds when `disk_dir` is left at its default.
+    fn does_not_break_when_constructed_using_default_disk_dir() {
         let cache: RedbCache<u32, u32> =
             RedbCache::builder(format!("{}-disk-cache-test-default-dir", now_millis()))
                 // use the default disk directory
@@ -2686,7 +2693,7 @@ mod tests {
 
                 {
                     let cache: RedbCache<u32, u32> = RedbCache::builder(CACHE_NAME)
-                        .disk_directory(cache_tmp_dir.path())
+                        .disk_dir(cache_tmp_dir.path())
                         .durable(set_durable) // WHAT'S BEING TESTED
                         .build()
                         .unwrap();
@@ -2697,7 +2704,7 @@ mod tests {
                 }
 
                 let recovered_cache: RedbCache<u32, u32> = RedbCache::builder(CACHE_NAME)
-                    .disk_directory(cache_tmp_dir.path())
+                    .disk_dir(cache_tmp_dir.path())
                     .durable(set_durable)
                     .build()
                     .expect("error re-opening cache from persisted file");
@@ -2809,7 +2816,7 @@ mod tests {
 
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("test-cache-async")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .ttl(LIFE_SPAN_1_SEC)
             .build()
             .unwrap();
@@ -2856,7 +2863,7 @@ mod tests {
 
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("remove-entry-async")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .build()
             .unwrap();
 
@@ -2887,7 +2894,7 @@ mod tests {
     fn cache_set_ref_round_trips() {
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("set-ref-roundtrip")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .build()
             .expect("error building disk cache");
 
@@ -2923,7 +2930,7 @@ mod tests {
     fn debug_smoke_exposes_non_secret_fields_only() {
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("debug-smoke")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .ttl_secs(60)
             .refresh_on_hit(true)
             .build()
@@ -2961,7 +2968,7 @@ mod tests {
         assert!(
             matches!(
                 RedbCache::<u32, u32>::builder("")
-                    .disk_directory(tmp_dir.path())
+                    .disk_dir(tmp_dir.path())
                     .build(),
                 Err(RedbCacheBuildError::InvalidCacheName)
             ),
@@ -2971,7 +2978,7 @@ mod tests {
         assert!(
             matches!(
                 RedbCache::<u32, u32>::builder("bad/name")
-                    .disk_directory(tmp_dir.path())
+                    .disk_dir(tmp_dir.path())
                     .build(),
                 Err(RedbCacheBuildError::InvalidCacheName)
             ),
@@ -2983,7 +2990,7 @@ mod tests {
         assert!(
             matches!(
                 RedbCache::<u32, u32>::builder("ok:name")
-                    .disk_directory(tmp_dir.path())
+                    .disk_dir(tmp_dir.path())
                     .build(),
                 Err(RedbCacheBuildError::InvalidCacheName)
             ),
@@ -2994,7 +3001,7 @@ mod tests {
         assert!(
             matches!(
                 RedbCache::<u32, u32>::builder("star*name")
-                    .disk_directory(tmp_dir.path())
+                    .disk_dir(tmp_dir.path())
                     .build(),
                 Err(RedbCacheBuildError::InvalidCacheName)
             ),
@@ -3004,7 +3011,7 @@ mod tests {
         assert!(
             matches!(
                 RedbCache::<u32, u32>::builder("q?name")
-                    .disk_directory(tmp_dir.path())
+                    .disk_dir(tmp_dir.path())
                     .build(),
                 Err(RedbCacheBuildError::InvalidCacheName)
             ),
@@ -3014,7 +3021,7 @@ mod tests {
         assert!(
             matches!(
                 RedbCache::<u32, u32>::builder("lt<name")
-                    .disk_directory(tmp_dir.path())
+                    .disk_dir(tmp_dir.path())
                     .build(),
                 Err(RedbCacheBuildError::InvalidCacheName)
             ),
@@ -3024,7 +3031,7 @@ mod tests {
         assert!(
             matches!(
                 RedbCache::<u32, u32>::builder("bad\\name")
-                    .disk_directory(tmp_dir.path())
+                    .disk_dir(tmp_dir.path())
                     .build(),
                 Err(RedbCacheBuildError::InvalidCacheName)
             ),
@@ -3034,7 +3041,7 @@ mod tests {
         assert!(
             matches!(
                 RedbCache::<u32, u32>::builder("..")
-                    .disk_directory(tmp_dir.path())
+                    .disk_dir(tmp_dir.path())
                     .build(),
                 Err(RedbCacheBuildError::InvalidCacheName)
             ),
@@ -3044,7 +3051,7 @@ mod tests {
         assert!(
             matches!(
                 RedbCache::<u32, u32>::builder(".")
-                    .disk_directory(tmp_dir.path())
+                    .disk_dir(tmp_dir.path())
                     .build(),
                 Err(RedbCacheBuildError::InvalidCacheName)
             ),
@@ -3054,7 +3061,7 @@ mod tests {
         // A valid name must still build successfully.
         assert!(
             RedbCache::<u32, u32>::builder("valid-cache-name")
-                .disk_directory(tmp_dir.path())
+                .disk_dir(tmp_dir.path())
                 .build()
                 .is_ok(),
             "a valid cache_name must build successfully"
@@ -3063,7 +3070,7 @@ mod tests {
         // Still-allowed characters (alphanumerics, '_', '-') must build.
         assert!(
             RedbCache::<u32, u32>::builder("My_Cache-Name_123")
-                .disk_directory(tmp_dir.path())
+                .disk_dir(tmp_dir.path())
                 .build()
                 .is_ok(),
             "cache_name of alphanumerics, '_' and '-' must build successfully"
@@ -3077,7 +3084,7 @@ mod tests {
         assert!(
             matches!(
                 RedbCache::<u32, u32>::builder("bad\0name")
-                    .disk_directory(tmp_dir.path())
+                    .disk_dir(tmp_dir.path())
                     .build(),
                 Err(RedbCacheBuildError::InvalidCacheName)
             ),
@@ -3093,7 +3100,7 @@ mod tests {
         assert!(
             matches!(
                 RedbCache::<u32, u32>::builder(name)
-                    .disk_directory(tmp_dir.path())
+                    .disk_dir(tmp_dir.path())
                     .build(),
                 Err(RedbCacheBuildError::InvalidCacheName)
             ),
@@ -3106,7 +3113,7 @@ mod tests {
         let tmp_dir = temp_dir!();
         assert!(
             RedbCache::<u32, u32>::builder(name)
-                .disk_directory(tmp_dir.path())
+                .disk_dir(tmp_dir.path())
                 .build()
                 .is_ok(),
             "{why}"
@@ -3172,7 +3179,7 @@ mod tests {
 
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("set-ref-roundtrip-async")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .build()
             .expect("error building disk cache");
 
@@ -3212,7 +3219,7 @@ mod tests {
 
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("flush-test-async")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .build()
             .unwrap();
 
@@ -3240,7 +3247,7 @@ mod tests {
 
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, u32> = RedbCache::builder("futures-block-on-test")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .build()
             .unwrap();
 
@@ -3301,7 +3308,7 @@ mod tests {
         let tmp_dir = temp_dir!();
         // strict_deserialization=true so we get an error to inspect.
         let cache: RedbCache<u32, u32> = RedbCache::builder("decode-error-carries-bytes")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .strict_deserialization(true)
             .build()
             .expect("error building disk cache");
@@ -3331,7 +3338,7 @@ mod tests {
         let tmp_dir = temp_dir!();
         // strict_deserialization=true so we get an error to inspect.
         let cache: RedbCache<u32, u32> = RedbCache::builder("sweep-decode-error-bytes")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .ttl(Duration::from_secs(1))
             .strict_deserialization(true)
             .build()
@@ -3361,7 +3368,7 @@ mod tests {
         let tmp_dir = temp_dir!();
         let cache: RedbCache<u32, SerializeFailsAfterDeserialize> =
             RedbCache::builder("ser-error-struct-variant")
-                .disk_directory(tmp_dir.path())
+                .disk_dir(tmp_dir.path())
                 .ttl(Duration::from_secs(10))
                 .refresh_on_hit(true)
                 .build()
@@ -3389,7 +3396,7 @@ mod tests {
         let tmp_dir = temp_dir!();
         // Use strict mode so we get an error from cache_get.
         let cache: RedbCache<u32, u32> = RedbCache::builder("deser-source-wired")
-            .disk_directory(tmp_dir.path())
+            .disk_dir(tmp_dir.path())
             .strict_deserialization(true)
             .build()
             .expect("error building disk cache");
@@ -3442,7 +3449,7 @@ mod tests {
         use super::*;
         use std::os::unix::fs::MetadataExt;
 
-        /// The cache directory created by `disk_directory(path)` must have
+        /// The cache directory created by `disk_dir(path)` must have
         /// mode 0700 (owner rwx only).
         #[test]
         fn explicit_disk_dir_is_created_with_mode_0700() {
@@ -3450,7 +3457,7 @@ mod tests {
             // Point to a non-existent subdirectory so create_cache_dir must create it.
             let cache_dir = parent.path().join("sub").join("cache");
             let cache: RedbCache<u32, u32> = RedbCache::builder("perm-dir-explicit")
-                .disk_directory(&cache_dir)
+                .disk_dir(&cache_dir)
                 .build()
                 .expect("build must succeed");
             let meta = std::fs::metadata(&cache_dir).expect("metadata");
@@ -3469,7 +3476,7 @@ mod tests {
         fn redb_file_is_created_with_mode_0600() {
             let dir = temp_dir!();
             let cache: RedbCache<u32, u32> = RedbCache::builder("perm-file")
-                .disk_directory(dir.path())
+                .disk_dir(dir.path())
                 .build()
                 .expect("build must succeed");
             let file_path = cache.disk_path().to_owned();

--- a/src/stores/redis.rs
+++ b/src/stores/redis.rs
@@ -3954,6 +3954,26 @@ mod connection_string_tests {
         // The raw value is still recoverable via reveal().
         assert!(cs.reveal().contains("s3cr3t"));
     }
+
+    /// `PartialEq`/`Eq`/`Hash` compare the raw unredacted URL, and `Hash` is
+    /// consistent with `Eq`.
+    #[test]
+    fn eq_and_hash_on_raw_url() {
+        use std::hash::{DefaultHasher, Hash, Hasher};
+
+        fn hash_of(cs: &ConnectionString) -> u64 {
+            let mut hasher = DefaultHasher::new();
+            cs.hash(&mut hasher);
+            hasher.finish()
+        }
+
+        let a = ConnectionString("redis://:secret@127.0.0.1:6379".to_string());
+        let b = ConnectionString("redis://:secret@127.0.0.1:6379".to_string());
+        let c = ConnectionString("redis://:other@127.0.0.1:6379".to_string());
+        assert_eq!(a, b, "same raw URL must compare equal");
+        assert_ne!(a, c, "different raw URLs must compare unequal");
+        assert_eq!(hash_of(&a), hash_of(&b), "Hash must be consistent with Eq");
+    }
 }
 
 #[cfg(test)]

--- a/src/stores/sharded/expiring_lru.rs
+++ b/src/stores/sharded/expiring_lru.rs
@@ -1,6 +1,6 @@
 use std::hash::Hash;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
 #[cfg(feature = "async_core")]
 use crate::ConcurrentCachedAsync;
@@ -10,7 +10,8 @@ use crate::{
 };
 
 use super::{
-    CachePadded, DefaultShardHasher, Shard, ShardHasher, checked_shard_count, shard_index,
+    CachePadded, DefaultShardHasher, Shard, ShardHasher, checked_shard_count,
+    per_shard_cap_from_total, shard_index,
 };
 use crate::Cached;
 use crate::ConcurrentCacheEvict;
@@ -25,7 +26,9 @@ struct ExpiringLruInner<K, V, H> {
     hasher: H,
     on_evict: Option<OnEvict<K, V>>,
     evictions: AtomicU64,
-    total_capacity: usize,
+    /// Total logical capacity (sum of per-shard caps). Stored as `AtomicUsize` so
+    /// [`set_max_size`](ShardedExpiringLruCacheBase::set_max_size) can update it from `&self`.
+    total_capacity: AtomicUsize,
 }
 
 /// A fully-concurrent, partitioned, LRU size-bounded in-memory cache with per-value expiry.
@@ -73,7 +76,10 @@ impl<K, V, H> std::fmt::Debug for ShardedExpiringLruCacheBase<K, V, H> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ShardedExpiringLruCache")
             .field("shards", &self.inner.shards.len())
-            .field("capacity", &self.inner.total_capacity)
+            .field(
+                "capacity",
+                &self.inner.total_capacity.load(Ordering::Relaxed),
+            )
             .field("evictions", &self.inner.evictions.load(Ordering::Relaxed))
             .finish_non_exhaustive()
     }
@@ -166,7 +172,7 @@ impl<K: Clone + Hash + Eq, V: Clone + Expires, H: ShardHasher<K>>
                 hasher: self.inner.hasher.clone(),
                 on_evict: self.inner.on_evict.clone(),
                 evictions: AtomicU64::new(self.inner.evictions.load(Ordering::Relaxed)),
-                total_capacity: self.inner.total_capacity,
+                total_capacity: AtomicUsize::new(self.inner.total_capacity.load(Ordering::Relaxed)),
             }),
         }
     }
@@ -278,7 +284,7 @@ where
             misses: Some(misses),
             evictions: Some(inner_evictions + self.inner.evictions.load(Ordering::Relaxed)),
             entry_count: Some(size),
-            capacity: Some(self.inner.total_capacity),
+            capacity: Some(self.inner.total_capacity.load(Ordering::Relaxed)),
         }
     }
 
@@ -364,7 +370,80 @@ where
     /// up with ceiling division.
     #[must_use]
     pub fn capacity(&self) -> usize {
-        self.inner.total_capacity
+        // Acquire pairs with the Release swap in `set_max_size`: observing a new
+        // total implies every shard has already adopted its new per-shard cap.
+        self.inner.total_capacity.load(Ordering::Acquire)
+    }
+
+    /// Resize the cache to hold up to `max_size` entries in total, returning
+    /// the previous total capacity as `Some(prev)`. The return is always `Some`;
+    /// the `Option` wrapper mirrors the single-owner
+    /// [`ExpiringLruCache::set_max_size`](crate::ExpiringLruCache::set_max_size) signature.
+    ///
+    /// Takes `&self`: shards use interior mutability (per-shard write locks), so
+    /// the method is callable through `Arc` or any shared reference — no external
+    /// lock is needed, unlike the `&mut self` single-owner counterpart.
+    ///
+    /// The new per-shard capacity is recomputed using the same policy the builder
+    /// uses for [`max_size`](ShardedExpiringLruCacheBuilder::max_size): ceiling division
+    /// across shards with a minimum of 16 entries per shard when `shards > 1`.
+    /// After resizing, any configuration previously set via
+    /// [`per_shard_max_size`](ShardedExpiringLruCacheBuilder::per_shard_max_size) is replaced
+    /// by the total-based policy.
+    ///
+    /// On shrink, excess LRU entries are evicted per shard: `on_evict` fires for
+    /// each evicted entry and the eviction counter is incremented accordingly.
+    /// On grow, no pre-allocation occurs; the shards grow on demand.
+    ///
+    /// The resize is **not atomic** across shards: shards are locked one at a time
+    /// (write lock), so concurrent readers may briefly observe mixed capacities
+    /// across shards while the resize is in progress. The new total reported by
+    /// [`capacity`](Self::capacity) is published only after every shard has adopted
+    /// its new per-shard cap.
+    ///
+    /// When the 16-per-shard minimum floor applies (small `max_size` with multiple
+    /// shards), `capacity()` after the call reflects the clamped total, which may
+    /// exceed the requested `max_size` (e.g. `set_max_size(4)` on a 16-shard cache
+    /// yields `capacity() == 256`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_size` is 0. Use
+    /// [`try_set_max_size`](ShardedExpiringLruCacheBase::try_set_max_size) to avoid the panic.
+    ///
+    /// # See also
+    ///
+    /// [`ShardedLruCacheBase::set_max_size`](crate::ShardedLruCacheBase::set_max_size) and
+    /// [`ShardedLruTtlCacheBase::set_max_size`](crate::ShardedLruTtlCacheBase::set_max_size)
+    /// are the parallel methods on the other sharded LRU-bounded stores.
+    pub fn set_max_size(&self, max_size: usize) -> Option<usize> {
+        assert!(max_size > 0, "max_size must be greater than zero");
+        let n_shards = self.inner.shards.len();
+        let (per_shard_cap, total_cap) = per_shard_cap_from_total(max_size, n_shards);
+        for shard in self.inner.shards.iter() {
+            shard.lock.write().set_max_size(per_shard_cap);
+        }
+        // Publish the new total only after every shard has adopted its new cap;
+        // Release pairs with the Acquire load in `capacity()`.
+        let prev = self.inner.total_capacity.swap(total_cap, Ordering::Release);
+        Some(prev)
+    }
+
+    /// Fallible counterpart of [`set_max_size`](ShardedExpiringLruCacheBase::set_max_size):
+    /// validates that `max_size` is non-zero and then delegates to `set_max_size`.
+    /// Returns the previous total capacity wrapped in `Some` on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SetMaxSizeError::ZeroSize`](crate::SetMaxSizeError) if `max_size` is 0.
+    pub fn try_set_max_size(
+        &self,
+        max_size: usize,
+    ) -> Result<Option<usize>, crate::SetMaxSizeError> {
+        if max_size == 0 {
+            return Err(crate::SetMaxSizeError::ZeroSize);
+        }
+        Ok(self.set_max_size(max_size))
     }
 }
 
@@ -401,7 +480,8 @@ where
     }
 
     fn cache_capacity(&self) -> Option<usize> {
-        Some(self.inner.total_capacity)
+        // Acquire: see `capacity()`.
+        Some(self.inner.total_capacity.load(Ordering::Acquire))
     }
 
     fn cache_evictions(&self) -> Option<u64> {
@@ -921,7 +1001,7 @@ impl<K, V, H> ShardedExpiringLruCacheBuilder<K, V, H> {
                     .expect("hasher is always initialized via Default or .hasher()"),
                 on_evict: self.on_evict,
                 evictions: AtomicU64::new(0),
-                total_capacity: total_cap,
+                total_capacity: AtomicUsize::new(total_cap),
             }),
         })
     }

--- a/src/stores/sharded/lru.rs
+++ b/src/stores/sharded/lru.rs
@@ -1,13 +1,14 @@
 use std::hash::Hash;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
 #[cfg(feature = "async_core")]
 use crate::ConcurrentCachedAsync;
 use crate::{CacheMetrics, CachedIter, ConcurrentCacheBase, ConcurrentCached};
 
 use super::{
-    CachePadded, DefaultShardHasher, Shard, ShardHasher, checked_shard_count, shard_index,
+    CachePadded, DefaultShardHasher, Shard, ShardHasher, checked_shard_count,
+    per_shard_cap_from_total, shard_index,
 };
 use crate::stores::{BuildError, LruCache};
 
@@ -19,8 +20,9 @@ struct LruInner<K, V, H> {
     shard_mask: usize,
     hasher: H,
     on_evict: Option<OnEvict<K, V>>,
-    /// Total logical capacity (sum of per-shard caps).
-    total_capacity: usize,
+    /// Total logical capacity (sum of per-shard caps). Stored as `AtomicUsize` so
+    /// [`set_max_size`](ShardedLruCacheBase::set_max_size) can update it from `&self`.
+    total_capacity: AtomicUsize,
 }
 
 /// A fully-concurrent, partitioned, LRU-bounded in-memory cache.
@@ -67,7 +69,10 @@ impl<K, V, H> std::fmt::Debug for ShardedLruCacheBase<K, V, H> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ShardedLruCache")
             .field("shards", &self.inner.shards.len())
-            .field("capacity", &self.inner.total_capacity)
+            .field(
+                "capacity",
+                &self.inner.total_capacity.load(Ordering::Relaxed),
+            )
             .finish_non_exhaustive()
     }
 }
@@ -151,7 +156,7 @@ impl<K: Clone + Hash + Eq, V: Clone, H: ShardHasher<K>> ShardedLruCacheBase<K, V
                 shard_mask: self.inner.shard_mask,
                 hasher: self.inner.hasher.clone(),
                 on_evict: self.inner.on_evict.clone(),
-                total_capacity: self.inner.total_capacity,
+                total_capacity: AtomicUsize::new(self.inner.total_capacity.load(Ordering::Relaxed)),
             }),
         }
     }
@@ -257,7 +262,7 @@ where
             misses: Some(misses),
             evictions: Some(evictions),
             entry_count: Some(size),
-            capacity: Some(self.inner.total_capacity),
+            capacity: Some(self.inner.total_capacity.load(Ordering::Relaxed)),
         }
     }
 
@@ -349,7 +354,80 @@ where
     /// up with ceiling division.
     #[must_use]
     pub fn capacity(&self) -> usize {
-        self.inner.total_capacity
+        // Acquire pairs with the Release swap in `set_max_size`: observing a new
+        // total implies every shard has already adopted its new per-shard cap.
+        self.inner.total_capacity.load(Ordering::Acquire)
+    }
+
+    /// Resize the cache to hold up to `max_size` entries in total, returning
+    /// the previous total capacity as `Some(prev)`. The return is always `Some`;
+    /// the `Option` wrapper mirrors the single-owner
+    /// [`LruCache::set_max_size`](crate::LruCache::set_max_size) signature.
+    ///
+    /// Takes `&self`: shards use interior mutability (per-shard write locks), so
+    /// the method is callable through `Arc` or any shared reference — no external
+    /// lock is needed, unlike the `&mut self` single-owner counterpart.
+    ///
+    /// The new per-shard capacity is recomputed using the same policy the builder
+    /// uses for [`max_size`](ShardedLruCacheBuilder::max_size): ceiling division
+    /// across shards with a minimum of 16 entries per shard when `shards > 1`.
+    /// After resizing, any configuration previously set via
+    /// [`per_shard_max_size`](ShardedLruCacheBuilder::per_shard_max_size) is replaced
+    /// by the total-based policy.
+    ///
+    /// On shrink, excess LRU entries are evicted per shard: `on_evict` fires for
+    /// each evicted entry and the eviction counter is incremented accordingly.
+    /// On grow, no pre-allocation occurs; the shards grow on demand.
+    ///
+    /// The resize is **not atomic** across shards: shards are locked one at a time
+    /// (write lock), so concurrent readers may briefly observe mixed capacities
+    /// across shards while the resize is in progress. The new total reported by
+    /// [`capacity`](Self::capacity) is published only after every shard has adopted
+    /// its new per-shard cap.
+    ///
+    /// When the 16-per-shard minimum floor applies (small `max_size` with multiple
+    /// shards), `capacity()` after the call reflects the clamped total, which may
+    /// exceed the requested `max_size` (e.g. `set_max_size(4)` on a 16-shard cache
+    /// yields `capacity() == 256`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_size` is 0. Use
+    /// [`try_set_max_size`](ShardedLruCacheBase::try_set_max_size) to avoid the panic.
+    ///
+    /// # See also
+    ///
+    /// [`ShardedLruTtlCacheBase::set_max_size`](crate::ShardedLruTtlCacheBase::set_max_size) and
+    /// [`ShardedExpiringLruCacheBase::set_max_size`](crate::ShardedExpiringLruCacheBase::set_max_size)
+    /// are the parallel methods on the other sharded LRU-bounded stores.
+    pub fn set_max_size(&self, max_size: usize) -> Option<usize> {
+        assert!(max_size > 0, "max_size must be greater than zero");
+        let n_shards = self.inner.shards.len();
+        let (per_shard_cap, total_cap) = per_shard_cap_from_total(max_size, n_shards);
+        for shard in self.inner.shards.iter() {
+            shard.lock.write().set_max_size(per_shard_cap);
+        }
+        // Publish the new total only after every shard has adopted its new cap;
+        // Release pairs with the Acquire load in `capacity()`.
+        let prev = self.inner.total_capacity.swap(total_cap, Ordering::Release);
+        Some(prev)
+    }
+
+    /// Fallible counterpart of [`set_max_size`](ShardedLruCacheBase::set_max_size): validates
+    /// that `max_size` is non-zero and then delegates to `set_max_size`.
+    /// Returns the previous total capacity wrapped in `Some` on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SetMaxSizeError::ZeroSize`](crate::SetMaxSizeError) if `max_size` is 0.
+    pub fn try_set_max_size(
+        &self,
+        max_size: usize,
+    ) -> Result<Option<usize>, crate::SetMaxSizeError> {
+        if max_size == 0 {
+            return Err(crate::SetMaxSizeError::ZeroSize);
+        }
+        Ok(self.set_max_size(max_size))
     }
 }
 
@@ -388,7 +466,8 @@ where
     }
 
     fn cache_capacity(&self) -> Option<usize> {
-        Some(self.inner.total_capacity)
+        // Acquire: see `capacity()`.
+        Some(self.inner.total_capacity.load(Ordering::Acquire))
     }
 
     fn cache_evictions(&self) -> Option<u64> {
@@ -705,7 +784,7 @@ impl<K, V, H> ShardedLruCacheBuilder<K, V, H> {
                     .hasher
                     .expect("hasher is always initialized via Default or .hasher()"),
                 on_evict: self.on_evict,
-                total_capacity: total_cap,
+                total_capacity: AtomicUsize::new(total_cap),
             }),
         })
     }

--- a/src/stores/sharded/lru_ttl.rs
+++ b/src/stores/sharded/lru_ttl.rs
@@ -1,7 +1,7 @@
 use std::hash::Hash;
 use std::marker::PhantomData;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 
 /// Encode a TTL into the `ttl_nanos` atomic. A zero duration encodes as `0`
 /// (expiry disabled / no expiry).
@@ -30,7 +30,8 @@ use crate::{
 };
 
 use super::{
-    CachePadded, DefaultShardHasher, Shard, ShardHasher, checked_shard_count, shard_index,
+    CachePadded, DefaultShardHasher, Shard, ShardHasher, checked_shard_count,
+    per_shard_cap_from_total, shard_index,
 };
 use crate::stores::{BuildError, HasEvict, LruCache, NoEvict, TimedEntry};
 use crate::{Cached, CachedIter, CachedPeek};
@@ -54,7 +55,9 @@ struct LruTtlInner<K, V, H> {
     /// [`cache_clear_with_on_evict`](ShardedLruTtlCacheBase::cache_clear_with_on_evict).
     /// LRU capacity evictions are tracked per-shard in the inner `LruCache`.
     non_capacity_evictions: AtomicU64,
-    total_capacity: usize,
+    /// Total logical capacity (sum of per-shard caps). Stored as `AtomicUsize` so
+    /// [`set_max_size`](ShardedLruTtlCacheBase::set_max_size) can update it from `&self`.
+    total_capacity: AtomicUsize,
 }
 
 /// A fully-concurrent, partitioned, LRU-bounded, TTL-expiring in-memory cache.
@@ -118,7 +121,10 @@ impl<K, V, H> std::fmt::Debug for ShardedLruTtlCacheBase<K, V, H> {
         let ttl = self.ttl_duration_impl();
         f.debug_struct("ShardedLruTtlCache")
             .field("shards", &self.inner.shards.len())
-            .field("capacity", &self.inner.total_capacity)
+            .field(
+                "capacity",
+                &self.inner.total_capacity.load(Ordering::Relaxed),
+            )
             .field("ttl", &ttl)
             .finish_non_exhaustive()
     }
@@ -231,7 +237,7 @@ impl<K: Clone + Hash + Eq, V: Clone, H: ShardHasher<K>> ShardedLruTtlCacheBase<K
                 non_capacity_evictions: AtomicU64::new(
                     self.inner.non_capacity_evictions.load(Ordering::Relaxed),
                 ),
-                total_capacity: self.inner.total_capacity,
+                total_capacity: AtomicUsize::new(self.inner.total_capacity.load(Ordering::Relaxed)),
             }),
         }
     }
@@ -337,7 +343,7 @@ where
                 lru_evictions + self.inner.non_capacity_evictions.load(Ordering::Relaxed),
             ),
             entry_count: Some(size),
-            capacity: Some(self.inner.total_capacity),
+            capacity: Some(self.inner.total_capacity.load(Ordering::Relaxed)),
         }
     }
 
@@ -423,7 +429,81 @@ where
     /// up with ceiling division.
     #[must_use]
     pub fn capacity(&self) -> usize {
-        self.inner.total_capacity
+        // Acquire pairs with the Release swap in `set_max_size`: observing a new
+        // total implies every shard has already adopted its new per-shard cap.
+        self.inner.total_capacity.load(Ordering::Acquire)
+    }
+
+    /// Resize the cache to hold up to `max_size` entries in total, returning
+    /// the previous total capacity as `Some(prev)`. The return is always `Some`;
+    /// the `Option` wrapper mirrors the single-owner
+    /// [`LruTtlCache::set_max_size`](crate::LruTtlCache::set_max_size) signature.
+    ///
+    /// Takes `&self`: shards use interior mutability (per-shard write locks), so
+    /// the method is callable through `Arc` or any shared reference — no external
+    /// lock is needed, unlike the `&mut self` single-owner counterpart.
+    ///
+    /// The new per-shard capacity is recomputed using the same policy the builder
+    /// uses for [`max_size`](ShardedLruTtlCacheBuilder::max_size): ceiling division
+    /// across shards with a minimum of 16 entries per shard when `shards > 1`.
+    /// After resizing, any configuration previously set via
+    /// [`per_shard_max_size`](ShardedLruTtlCacheBuilder::per_shard_max_size) is replaced
+    /// by the total-based policy.
+    ///
+    /// On shrink, excess LRU entries are evicted per shard: `on_evict` fires for
+    /// each evicted entry and the eviction counter (LRU capacity evictions) is
+    /// incremented accordingly.
+    /// On grow, no pre-allocation occurs; the shards grow on demand.
+    ///
+    /// The resize is **not atomic** across shards: shards are locked one at a time
+    /// (write lock), so concurrent readers may briefly observe mixed capacities
+    /// across shards while the resize is in progress. The new total reported by
+    /// [`capacity`](Self::capacity) is published only after every shard has adopted
+    /// its new per-shard cap.
+    ///
+    /// When the 16-per-shard minimum floor applies (small `max_size` with multiple
+    /// shards), `capacity()` after the call reflects the clamped total, which may
+    /// exceed the requested `max_size` (e.g. `set_max_size(4)` on a 16-shard cache
+    /// yields `capacity() == 256`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_size` is 0. Use
+    /// [`try_set_max_size`](ShardedLruTtlCacheBase::try_set_max_size) to avoid the panic.
+    ///
+    /// # See also
+    ///
+    /// [`ShardedLruCacheBase::set_max_size`](crate::ShardedLruCacheBase::set_max_size) and
+    /// [`ShardedExpiringLruCacheBase::set_max_size`](crate::ShardedExpiringLruCacheBase::set_max_size)
+    /// are the parallel methods on the other sharded LRU-bounded stores.
+    pub fn set_max_size(&self, max_size: usize) -> Option<usize> {
+        assert!(max_size > 0, "max_size must be greater than zero");
+        let n_shards = self.inner.shards.len();
+        let (per_shard_cap, total_cap) = per_shard_cap_from_total(max_size, n_shards);
+        for shard in self.inner.shards.iter() {
+            shard.lock.write().set_max_size(per_shard_cap);
+        }
+        // Publish the new total only after every shard has adopted its new cap;
+        // Release pairs with the Acquire load in `capacity()`.
+        let prev = self.inner.total_capacity.swap(total_cap, Ordering::Release);
+        Some(prev)
+    }
+
+    /// Fallible counterpart of [`set_max_size`](ShardedLruTtlCacheBase::set_max_size): validates
+    /// that `max_size` is non-zero and then delegates to `set_max_size`.
+    /// Returns the previous total capacity wrapped in `Some` on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SetMaxSizeError::ZeroSize`](crate::SetMaxSizeError) if `max_size` is 0.
+    pub fn try_set_max_size(
+        &self,
+        max_size: usize,
+    ) -> Result<Option<usize>, crate::SetMaxSizeError> {
+        if max_size == 0 {
+            return Err(crate::SetMaxSizeError::ZeroSize);
+        }
+        Ok(self.set_max_size(max_size))
     }
 
     /// Sweep all shards for expired entries, remove them, fire the `on_evict` callback
@@ -557,7 +637,8 @@ where
     }
 
     fn cache_capacity(&self) -> Option<usize> {
-        Some(self.inner.total_capacity)
+        // Acquire: see `capacity()`.
+        Some(self.inner.total_capacity.load(Ordering::Acquire))
     }
 
     fn cache_evictions(&self) -> Option<u64> {
@@ -1069,7 +1150,7 @@ impl<K, V, H> ShardedLruTtlCacheBuilder<K, V, NoEvict, H> {
                 ttl_nanos: AtomicU64::new(encode_ttl(ttl)),
                 refresh: AtomicBool::new(self.refresh),
                 non_capacity_evictions: AtomicU64::new(0),
-                total_capacity: total_cap,
+                total_capacity: AtomicUsize::new(total_cap),
             }),
         })
     }
@@ -1164,7 +1245,7 @@ impl<K, V, H> ShardedLruTtlCacheBuilder<K, V, HasEvict, H> {
                 ttl_nanos: AtomicU64::new(encode_ttl(ttl)),
                 refresh: AtomicBool::new(self.refresh),
                 non_capacity_evictions: AtomicU64::new(0),
-                total_capacity: total_cap,
+                total_capacity: AtomicUsize::new(total_cap),
             }),
         })
     }

--- a/src/stores/sharded/mod.rs
+++ b/src/stores/sharded/mod.rs
@@ -64,6 +64,27 @@ pub(crate) fn default_shard_count() -> usize {
     count.clamp(8, 1024).next_power_of_two()
 }
 
+/// Compute the per-shard capacity for a given total and shard count, applying the
+/// same policy as the sharded LRU builders: ceiling division (`div_ceil`) with a
+/// minimum of 16 per shard when `n_shards > 1`.
+///
+/// Returns `(per_shard_cap, total_cap)`, where `total_cap = n_shards * per_shard_cap`.
+/// The `total_cap` may exceed `total` when the 16-per-shard floor is in effect.
+///
+/// Panics if `n_shards * per_shard_cap` overflows `usize`; in practice
+/// this can only happen with extremely large inputs and is never triggered from the
+/// `set_max_size` call path.
+pub(crate) fn per_shard_cap_from_total(total: usize, n_shards: usize) -> (usize, usize) {
+    let mut per_shard = total.div_ceil(n_shards);
+    if n_shards > 1 {
+        per_shard = per_shard.max(16);
+    }
+    let total_cap = n_shards
+        .checked_mul(per_shard)
+        .expect("per_shard_cap_from_total: n_shards * per_shard overflows usize");
+    (per_shard, total_cap)
+}
+
 pub(crate) fn checked_shard_count(shards: Option<usize>) -> Result<usize, BuildError> {
     if let Some(0) = shards {
         return Err(BuildError::InvalidValue {

--- a/tests/v3_redb_builder.rs
+++ b/tests/v3_redb_builder.rs
@@ -14,7 +14,7 @@ use tempfile::TempDir;
 fn builder_positional_name_builds() {
     let dir = TempDir::new().unwrap();
     let cache: RedbCache<u32, u32> = RedbCache::builder("positional-name")
-        .disk_directory(dir.path())
+        .disk_dir(dir.path())
         .durable(false)
         .build()
         .expect("build with positional name");
@@ -29,7 +29,7 @@ fn builder_positional_name_can_be_overridden() {
     // A later `.name(...)` overrides the positional argument.
     let cache: RedbCache<u32, u32> = RedbCache::builder("initial")
         .name("overridden")
-        .disk_directory(dir.path())
+        .disk_dir(dir.path())
         .durable(false)
         .build()
         .expect("build with overridden name");

--- a/tests/v3_redb_races.rs
+++ b/tests/v3_redb_races.rs
@@ -27,7 +27,7 @@ fn build(
     refresh: bool,
 ) -> Arc<RedbCache<u32, u32>> {
     let mut b = RedbCache::<u32, u32>::builder(name)
-        .disk_directory(dir.path())
+        .disk_dir(dir.path())
         // No fsync for speed; these are in-process races.
         .durable(false)
         .refresh_on_hit(refresh);
@@ -302,7 +302,7 @@ fn self_heal_does_not_delete_concurrent_write() {
         // to the same table, then dropping that handle to release the file lock.
         {
             let corrupt = RedbCache::<u32, String>::builder("self-heal-race")
-                .disk_directory(dir.path())
+                .disk_dir(dir.path())
                 .durable(true)
                 .build()
                 .expect("corrupt-injector build");
@@ -313,7 +313,7 @@ fn self_heal_does_not_delete_concurrent_write() {
         // driving cache_get down the non-strict self-heal path.
         let cache: Arc<RedbCache<u32, u32>> = Arc::new(
             RedbCache::<u32, u32>::builder("self-heal-race")
-                .disk_directory(dir.path())
+                .disk_dir(dir.path())
                 .durable(false)
                 .build()
                 .expect("reader build"),

--- a/tests/v3_redb_races_async.rs
+++ b/tests/v3_redb_races_async.rs
@@ -26,7 +26,7 @@ fn build(
     refresh: bool,
 ) -> Arc<RedbCache<u32, u32>> {
     let mut b = RedbCache::<u32, u32>::builder(name)
-        .disk_directory(dir.path())
+        .disk_dir(dir.path())
         // No fsync for speed; these are in-process races.
         .durable(false)
         .refresh_on_hit(refresh);

--- a/tests/v3_sharded_resize.rs
+++ b/tests/v3_sharded_resize.rs
@@ -1,0 +1,971 @@
+//! Integration tests for runtime capacity resizing of the sharded LRU-bounded stores.
+//!
+//! Covers `ShardedLruCache`, `ShardedLruTtlCache`, and `ShardedExpiringLruCache`.
+//! Each behavioral path is exercised: grow, shrink (with eviction), zero panic, zero
+//! error, min-per-shard clamp, per_shard_max_size migration, and single-shard exact
+//! capacity.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use cached::{ConcurrentCacheBase, ConcurrentCached, SetMaxSizeError};
+
+// ---------------------------------------------------------------------------
+// Helper: a type that impls Expires for ShardedExpiringLruCache tests
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+struct E {
+    v: u32,
+}
+
+impl cached::Expires for E {
+    fn is_expired(&self) -> bool {
+        false // never expires from the value side; capacity drives eviction
+    }
+}
+
+/// A value whose expiry is controlled per-instance, for the expiring_lru
+/// "shrink evicts LRU-order regardless of expiry" contract test.
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+struct ExpVal {
+    v: u32,
+    expired: bool,
+}
+
+impl cached::Expires for ExpVal {
+    fn is_expired(&self) -> bool {
+        self.expired
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ShardedLruCache
+// ---------------------------------------------------------------------------
+
+mod lru {
+    use super::*;
+    use cached::ShardedLruCacheBase;
+
+    #[test]
+    fn grow_keeps_entries_returns_previous_total() {
+        // shards(1): per_shard_cap = max_size (no floor), so capacity == max_size exactly.
+        let c = ShardedLruCacheBase::<u32, u32>::builder()
+            .shards(1)
+            .max_size(4)
+            .build()
+            .unwrap();
+        ConcurrentCached::cache_set(&c, 1, 10).unwrap();
+        ConcurrentCached::cache_set(&c, 2, 20).unwrap();
+
+        let prev = c.set_max_size(8);
+        assert_eq!(prev, Some(4), "must return previous total capacity");
+        assert_eq!(c.capacity(), 8, "capacity() must reflect new size");
+
+        // Existing entries must survive.
+        assert_eq!(ConcurrentCached::cache_get(&c, &1).unwrap(), Some(10));
+        assert_eq!(ConcurrentCached::cache_get(&c, &2).unwrap(), Some(20));
+    }
+
+    #[test]
+    fn shrink_evicts_lru_order_fires_on_evict_and_counts_evictions() {
+        let evicted = Arc::new(AtomicU64::new(0));
+        let evicted2 = evicted.clone();
+
+        let c = ShardedLruCacheBase::<u32, u32>::builder()
+            .shards(1)
+            .max_size(4)
+            .on_evict(move |_, _| {
+                evicted2.fetch_add(1, Ordering::Relaxed);
+            })
+            .build()
+            .unwrap();
+
+        // Insert 4 entries, then promote 1 and 2 to MRU.
+        ConcurrentCached::cache_set(&c, 1, 10).unwrap();
+        ConcurrentCached::cache_set(&c, 2, 20).unwrap();
+        ConcurrentCached::cache_set(&c, 3, 30).unwrap();
+        ConcurrentCached::cache_set(&c, 4, 40).unwrap();
+        ConcurrentCached::cache_get(&c, &1).unwrap();
+        ConcurrentCached::cache_get(&c, &2).unwrap();
+
+        let evictions_before = c.metrics().evictions.unwrap();
+        let prev = c.set_max_size(2);
+        assert_eq!(prev, Some(4), "must return previous capacity");
+        assert_eq!(c.capacity(), 2);
+        assert_eq!(c.len(), 2);
+
+        // Two LRU entries (3 and 4) must have been evicted.
+        assert_eq!(
+            c.metrics().evictions.unwrap() - evictions_before,
+            2,
+            "eviction counter must increment for each evicted entry"
+        );
+        assert_eq!(
+            evicted.load(Ordering::Relaxed),
+            2,
+            "on_evict must fire for each evicted entry"
+        );
+
+        // MRU survivors must still be present.
+        assert_eq!(ConcurrentCached::cache_get(&c, &1).unwrap(), Some(10));
+        assert_eq!(ConcurrentCached::cache_get(&c, &2).unwrap(), Some(20));
+        assert!(ConcurrentCached::cache_get(&c, &3).unwrap().is_none());
+        assert!(ConcurrentCached::cache_get(&c, &4).unwrap().is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "max_size must be greater than zero")]
+    fn zero_set_max_size_panics() {
+        let c = ShardedLruCacheBase::<u32, u32>::builder()
+            .shards(1)
+            .max_size(4)
+            .build()
+            .unwrap();
+        let _ = c.set_max_size(0);
+    }
+
+    #[test]
+    fn zero_try_set_max_size_returns_error() {
+        let c = ShardedLruCacheBase::<u32, u32>::builder()
+            .shards(1)
+            .max_size(4)
+            .build()
+            .unwrap();
+        assert_eq!(
+            c.try_set_max_size(0),
+            Err(SetMaxSizeError::ZeroSize),
+            "try_set_max_size(0) must return ZeroSize error"
+        );
+        // Valid call still works after the failed attempt.
+        let r = c.try_set_max_size(8);
+        assert_eq!(r, Ok(Some(4)));
+        assert_eq!(c.capacity(), 8);
+    }
+
+    #[test]
+    fn min_per_shard_clamp_applied_and_capacity_reflects_clamped_total() {
+        // 4 shards, total = 4 → per_shard = max(4.div_ceil(4)=1, 16) = 16 → total = 64.
+        let c = ShardedLruCacheBase::<u32, u32>::builder()
+            .shards(4)
+            .max_size(1024)
+            .build()
+            .unwrap();
+        assert_eq!(c.capacity(), 1024);
+
+        // Resize to a tiny total that triggers the 16-per-shard floor.
+        let prev = c.set_max_size(4);
+        assert_eq!(prev, Some(1024), "must return previous capacity");
+        // 4 shards * 16 = 64
+        assert_eq!(
+            c.capacity(),
+            64,
+            "capacity() must report the clamped total (4 shards * 16 = 64)"
+        );
+        // Exercise the clamped caps under load: 200 distinct keys over 4 shards
+        // guarantees (by pigeonhole) at least one shard sees >= 50 inserts, so
+        // the 16-entry per-shard floor must be reached and enforced.
+        for i in 0..200u32 {
+            ConcurrentCached::cache_set(&c, i, i).unwrap();
+        }
+        let sizes = c.shard_sizes();
+        for sz in &sizes {
+            assert!(
+                *sz <= 16,
+                "each shard must not hold more entries than its clamped cap; got {sz}"
+            );
+        }
+        assert_eq!(
+            sizes.iter().max().copied(),
+            Some(16),
+            "at least one shard must fill to its clamped 16-entry cap"
+        );
+        assert!(
+            c.len() <= 64,
+            "total entries must respect the clamped total capacity"
+        );
+    }
+
+    #[test]
+    fn resize_cache_built_with_per_shard_max_size_switches_to_total_policy() {
+        // Built with per_shard_max_size = 10, 4 shards → total = 40.
+        let c = ShardedLruCacheBase::<u32, u32>::builder()
+            .shards(4)
+            .per_shard_max_size(10)
+            .build()
+            .unwrap();
+        assert_eq!(c.capacity(), 40, "initial capacity from per_shard_max_size");
+
+        // After resize, total-based policy applies.
+        let prev = c.set_max_size(100);
+        assert_eq!(prev, Some(40), "must return previous total");
+        // 4 shards, total=100 → per_shard = 100.div_ceil(4) = 25 → total = 100.
+        assert_eq!(c.capacity(), 100);
+    }
+
+    #[test]
+    fn single_shard_exact_capacity_no_clamp() {
+        // shards=1: no minimum clamp, capacity == max_size exactly.
+        let c = ShardedLruCacheBase::<u32, u32>::builder()
+            .shards(1)
+            .max_size(3)
+            .build()
+            .unwrap();
+        // Fill to capacity.
+        ConcurrentCached::cache_set(&c, 1, 1).unwrap();
+        ConcurrentCached::cache_set(&c, 2, 2).unwrap();
+        ConcurrentCached::cache_set(&c, 3, 3).unwrap();
+        assert_eq!(c.len(), 3);
+
+        let prev = c.set_max_size(1);
+        assert_eq!(prev, Some(3));
+        assert_eq!(c.capacity(), 1, "no clamp for single shard");
+        assert_eq!(c.len(), 1, "must evict down to new capacity");
+    }
+
+    #[test]
+    fn same_size_resize_is_noop_keeps_entries_and_returns_previous() {
+        // Resizing to the identical size must not evict anything: every entry
+        // survives, no on_evict fires, and the returned prev equals the current cap.
+        let evicted = Arc::new(AtomicU64::new(0));
+        let evicted2 = evicted.clone();
+        let c = ShardedLruCacheBase::<u32, u32>::builder()
+            .shards(1)
+            .max_size(4)
+            .on_evict(move |_, _| {
+                evicted2.fetch_add(1, Ordering::Relaxed);
+            })
+            .build()
+            .unwrap();
+        for i in 0..4u32 {
+            ConcurrentCached::cache_set(&c, i, i * 10).unwrap();
+        }
+        let ev_before = c.metrics().evictions.unwrap();
+
+        let prev = c.set_max_size(4);
+        assert_eq!(
+            prev,
+            Some(4),
+            "same-size resize returns the unchanged total"
+        );
+        assert_eq!(c.capacity(), 4);
+        assert_eq!(c.len(), 4, "no entry evicted on a same-size resize");
+        assert_eq!(
+            c.metrics().evictions.unwrap(),
+            ev_before,
+            "same-size resize must not count any eviction"
+        );
+        assert_eq!(
+            evicted.load(Ordering::Relaxed),
+            0,
+            "same-size resize must not fire on_evict"
+        );
+        for i in 0..4u32 {
+            assert_eq!(ConcurrentCached::cache_get(&c, &i).unwrap(), Some(i * 10));
+        }
+    }
+
+    #[test]
+    fn repeated_resizes_grow_shrink_grow_track_capacity_and_survival() {
+        // Capacity and entry survival must be correct at each step of a
+        // grow -> shrink -> grow sequence. Grow never resurrects evicted entries.
+        let c = ShardedLruCacheBase::<u32, u32>::builder()
+            .shards(1)
+            .max_size(4)
+            .build()
+            .unwrap();
+        // Grow: capacity moves up, existing entries untouched.
+        ConcurrentCached::cache_set(&c, 1, 10).unwrap();
+        ConcurrentCached::cache_set(&c, 2, 20).unwrap();
+        assert_eq!(c.set_max_size(8), Some(4));
+        assert_eq!(c.capacity(), 8);
+        // Fill up to the grown cap; MRU order will be 1..=8 (8 most recent).
+        for i in 3..=8u32 {
+            ConcurrentCached::cache_set(&c, i, i * 10).unwrap();
+        }
+        assert_eq!(c.len(), 8);
+
+        // Shrink to 2: only the two MRU keys (7, 8) survive.
+        assert_eq!(c.set_max_size(2), Some(8));
+        assert_eq!(c.capacity(), 2);
+        assert_eq!(c.len(), 2);
+        assert_eq!(ConcurrentCached::cache_get(&c, &8).unwrap(), Some(80));
+        assert_eq!(ConcurrentCached::cache_get(&c, &7).unwrap(), Some(70));
+        assert!(ConcurrentCached::cache_get(&c, &1).unwrap().is_none());
+
+        // Grow again to 6: capacity moves up but evicted keys are NOT resurrected.
+        assert_eq!(c.set_max_size(6), Some(2));
+        assert_eq!(c.capacity(), 6);
+        assert_eq!(c.len(), 2, "grow must not resurrect evicted entries");
+        assert!(ConcurrentCached::cache_get(&c, &6).unwrap().is_none());
+    }
+
+    #[test]
+    fn grow_past_entry_count_evicts_nothing() {
+        // Growing when the cache holds fewer entries than even the old cap must
+        // touch nothing: no eviction, no on_evict, all entries survive.
+        let evicted = Arc::new(AtomicU64::new(0));
+        let evicted2 = evicted.clone();
+        let c = ShardedLruCacheBase::<u32, u32>::builder()
+            .shards(1)
+            .max_size(4)
+            .on_evict(move |_, _| {
+                evicted2.fetch_add(1, Ordering::Relaxed);
+            })
+            .build()
+            .unwrap();
+        ConcurrentCached::cache_set(&c, 1, 10).unwrap();
+        ConcurrentCached::cache_set(&c, 2, 20).unwrap();
+        let ev_before = c.metrics().evictions.unwrap();
+        c.set_max_size(1024);
+        assert_eq!(c.len(), 2);
+        assert_eq!(c.metrics().evictions.unwrap(), ev_before);
+        assert_eq!(evicted.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn trait_cache_capacity_reflects_resize() {
+        // The ConcurrentCacheBase::cache_capacity trait method (not just the
+        // inherent capacity()) must report the post-resize total.
+        let c = ShardedLruCacheBase::<u32, u32>::builder()
+            .shards(1)
+            .max_size(4)
+            .build()
+            .unwrap();
+        assert_eq!(ConcurrentCacheBase::cache_capacity(&c), Some(4));
+        c.set_max_size(32);
+        assert_eq!(
+            ConcurrentCacheBase::cache_capacity(&c),
+            Some(32),
+            "trait cache_capacity() must reflect the resize, not just inherent capacity()"
+        );
+        assert_eq!(
+            c.capacity(),
+            ConcurrentCacheBase::cache_capacity(&c).unwrap()
+        );
+    }
+
+    #[test]
+    fn shrink_across_multiple_shards_aggregates_eviction_metrics() {
+        // With many shards, shrink evictions spread across shards must all show up
+        // in the aggregated metrics().evictions and total on_evict count. Built with
+        // a generous per-shard cap of 32 (total 256), then resized down. Note that
+        // set_max_size applies the 16-per-shard floor for multi-shard caches, so we
+        // shrink to a total whose per-shard quotient is still >= 16 to guarantee a
+        // real trim: max_size = 8*16 = 128 -> per_shard = 128.div_ceil(8) = 16, so
+        // every shard goes from cap 32 down to cap 16.
+        let evicted = Arc::new(AtomicU64::new(0));
+        let evicted2 = evicted.clone();
+        let c = ShardedLruCacheBase::<u32, u32>::builder()
+            .shards(8)
+            .per_shard_max_size(32)
+            .on_evict(move |_, _| {
+                evicted2.fetch_add(1, Ordering::Relaxed);
+            })
+            .build()
+            .unwrap();
+        assert_eq!(c.capacity(), 256);
+        // Insert enough distinct keys that several shards exceed the post-shrink
+        // per-shard cap of 16. 1024 keys over 8 shards averages 128 per shard, well
+        // above 16, so the shrink is guaranteed to evict.
+        for i in 0..1024u32 {
+            ConcurrentCached::cache_set(&c, i, i).unwrap();
+        }
+        let filled = c.len();
+        let ev_before = c.metrics().evictions.unwrap();
+        // Snapshot on_evict too: fill-time capacity evictions already fired the
+        // callback, so only the delta over the shrink is under test here.
+        let cb_before = evicted.load(Ordering::Relaxed);
+
+        // Shrink: per-shard cap 32 -> 16, total 256 -> 128.
+        c.set_max_size(128);
+        assert_eq!(c.capacity(), 128);
+        let after = c.len();
+        assert!(after < filled, "the shrink must actually drop entries");
+        let shrink_evictions = c.metrics().evictions.unwrap() - ev_before;
+        assert_eq!(
+            shrink_evictions,
+            (filled - after) as u64,
+            "aggregated metrics().evictions must account for every entry dropped by the shrink across all shards"
+        );
+        assert_eq!(
+            evicted.load(Ordering::Relaxed) - cb_before,
+            shrink_evictions,
+            "on_evict must fire exactly once per evicted entry across all shards"
+        );
+    }
+
+    #[test]
+    fn grow_single_shard_built_with_per_shard_max_size() {
+        // A shards=1 cache built via per_shard_max_size must grow correctly:
+        // capacity becomes the new max_size exactly (no floor at shards=1) and
+        // entries survive.
+        let c = ShardedLruCacheBase::<u32, u32>::builder()
+            .shards(1)
+            .per_shard_max_size(4)
+            .build()
+            .unwrap();
+        assert_eq!(c.capacity(), 4);
+        ConcurrentCached::cache_set(&c, 1, 10).unwrap();
+        ConcurrentCached::cache_set(&c, 2, 20).unwrap();
+        assert_eq!(
+            c.set_max_size(100),
+            Some(4),
+            "returns prior per-shard total"
+        );
+        assert_eq!(c.capacity(), 100, "single shard: exact grow, no clamp");
+        assert_eq!(ConcurrentCached::cache_get(&c, &1).unwrap(), Some(10));
+        assert_eq!(ConcurrentCached::cache_get(&c, &2).unwrap(), Some(20));
+    }
+
+    #[test]
+    fn concurrent_ops_during_resize_no_deadlock_and_capacity_consistent() {
+        // Stress: while worker threads hammer get/set, another thread flips the
+        // capacity between two sizes. The resize takes per-shard write locks one
+        // at a time, so this must never deadlock or panic, and once the resizer
+        // finishes the observed capacity must be one of the two target totals.
+        use std::thread;
+        let c = ShardedLruCacheBase::<u32, u32>::builder()
+            .shards(8)
+            .max_size(1024)
+            .build()
+            .unwrap();
+
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let mut handles = Vec::new();
+        for t in 0..4 {
+            let c = c.clone();
+            let stop = stop.clone();
+            handles.push(thread::spawn(move || {
+                let mut i = t;
+                while !stop.load(Ordering::Relaxed) {
+                    let _ = ConcurrentCached::cache_set(&c, i, i);
+                    let _ = ConcurrentCached::cache_get(&c, &(i.wrapping_sub(1)));
+                    i = i.wrapping_add(4);
+                }
+            }));
+        }
+        // Resizer: alternate between two totals. 512 -> 16-floor? no: 512/8=64 exact;
+        // 2048/8=256 exact. Both are floor-free so capacity() lands on one of them.
+        let resizer = {
+            let c = c.clone();
+            thread::spawn(move || {
+                for r in 0..500 {
+                    let target = if r % 2 == 0 { 512 } else { 2048 };
+                    let prev = c.set_max_size(target);
+                    assert!(prev.is_some(), "set_max_size always returns Some(prev)");
+                }
+            })
+        };
+        resizer.join().expect("resizer thread must not panic");
+        stop.store(true, Ordering::Relaxed);
+        for h in handles {
+            h.join().expect("worker thread must not panic");
+        }
+        // After the resizer completed, the last write was set_max_size(2048)
+        // (r = 499 is odd), so capacity settles at exactly 2048.
+        assert_eq!(
+            c.capacity(),
+            2048,
+            "capacity must be eventually consistent with the final resize"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ShardedLruTtlCache
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "time_stores")]
+mod lru_ttl {
+    use super::*;
+    use cached::ShardedLruTtlCacheBase;
+    use cached::time::Duration;
+
+    #[test]
+    fn grow_keeps_entries_returns_previous_total() {
+        let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
+            .shards(1)
+            .max_size(4)
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        ConcurrentCached::cache_set(&c, 1, 10).unwrap();
+        ConcurrentCached::cache_set(&c, 2, 20).unwrap();
+
+        let prev = c.set_max_size(8);
+        assert_eq!(prev, Some(4));
+        assert_eq!(c.capacity(), 8);
+        assert_eq!(ConcurrentCached::cache_get(&c, &1).unwrap(), Some(10));
+        assert_eq!(ConcurrentCached::cache_get(&c, &2).unwrap(), Some(20));
+    }
+
+    #[test]
+    fn shrink_evicts_lru_order_fires_on_evict_and_counts_evictions() {
+        let evicted = Arc::new(AtomicU64::new(0));
+        let evicted2 = evicted.clone();
+
+        let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
+            .shards(1)
+            .max_size(4)
+            .ttl(Duration::from_secs(60))
+            .on_evict(move |_, _| {
+                evicted2.fetch_add(1, Ordering::Relaxed);
+            })
+            .build()
+            .unwrap();
+
+        ConcurrentCached::cache_set(&c, 1, 10).unwrap();
+        ConcurrentCached::cache_set(&c, 2, 20).unwrap();
+        ConcurrentCached::cache_set(&c, 3, 30).unwrap();
+        ConcurrentCached::cache_set(&c, 4, 40).unwrap();
+        // Promote 1 and 2 to MRU.
+        ConcurrentCached::cache_get(&c, &1).unwrap();
+        ConcurrentCached::cache_get(&c, &2).unwrap();
+
+        let evictions_before = c.metrics().evictions.unwrap();
+        let prev = c.set_max_size(2);
+        assert_eq!(prev, Some(4));
+        assert_eq!(c.capacity(), 2);
+        assert_eq!(c.len(), 2);
+        assert_eq!(
+            c.metrics().evictions.unwrap() - evictions_before,
+            2,
+            "eviction counter must reflect shrink evictions"
+        );
+        assert_eq!(
+            evicted.load(Ordering::Relaxed),
+            2,
+            "on_evict must fire for each evicted entry"
+        );
+        // Survivors.
+        assert_eq!(ConcurrentCached::cache_get(&c, &1).unwrap(), Some(10));
+        assert_eq!(ConcurrentCached::cache_get(&c, &2).unwrap(), Some(20));
+        assert!(ConcurrentCached::cache_get(&c, &3).unwrap().is_none());
+        assert!(ConcurrentCached::cache_get(&c, &4).unwrap().is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "max_size must be greater than zero")]
+    fn zero_set_max_size_panics() {
+        let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
+            .shards(1)
+            .max_size(4)
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        let _ = c.set_max_size(0);
+    }
+
+    #[test]
+    fn zero_try_set_max_size_returns_error() {
+        let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
+            .shards(1)
+            .max_size(4)
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        assert_eq!(c.try_set_max_size(0), Err(SetMaxSizeError::ZeroSize));
+        let r = c.try_set_max_size(8);
+        assert_eq!(r, Ok(Some(4)));
+        assert_eq!(c.capacity(), 8);
+    }
+
+    #[test]
+    fn min_per_shard_clamp_applied_and_capacity_reflects_clamped_total() {
+        let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
+            .shards(4)
+            .max_size(1024)
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        let prev = c.set_max_size(4);
+        assert_eq!(prev, Some(1024));
+        // 4 shards * 16 = 64
+        assert_eq!(c.capacity(), 64);
+    }
+
+    #[test]
+    fn resize_cache_built_with_per_shard_max_size_switches_to_total_policy() {
+        let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
+            .shards(4)
+            .per_shard_max_size(10)
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        assert_eq!(c.capacity(), 40);
+        let prev = c.set_max_size(100);
+        assert_eq!(prev, Some(40));
+        assert_eq!(c.capacity(), 100);
+    }
+
+    #[test]
+    fn single_shard_exact_capacity_no_clamp() {
+        let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
+            .shards(1)
+            .max_size(3)
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        ConcurrentCached::cache_set(&c, 1, 1).unwrap();
+        ConcurrentCached::cache_set(&c, 2, 2).unwrap();
+        ConcurrentCached::cache_set(&c, 3, 3).unwrap();
+        assert_eq!(c.len(), 3);
+        let prev = c.set_max_size(1);
+        assert_eq!(prev, Some(3));
+        assert_eq!(c.capacity(), 1);
+        assert_eq!(c.len(), 1);
+    }
+
+    #[test]
+    fn no_evict_typestate_shrink_evicts_and_counts_without_callback() {
+        // Built via the NoEvict typestate (no .on_evict). Shrink must still evict
+        // in LRU order and count those evictions in metrics (the LRU capacity
+        // counter fires whether or not a callback is attached).
+        let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
+            .shards(1)
+            .max_size(4)
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        for i in 0..4u32 {
+            ConcurrentCached::cache_set(&c, i, i * 10).unwrap();
+        }
+        // Promote 0 and 1 so 2 and 3 are the LRU victims.
+        ConcurrentCached::cache_get(&c, &0).unwrap();
+        ConcurrentCached::cache_get(&c, &1).unwrap();
+        let before = c.metrics().evictions.unwrap();
+        c.set_max_size(2);
+        assert_eq!(c.capacity(), 2);
+        assert_eq!(c.len(), 2);
+        assert_eq!(
+            c.metrics().evictions.unwrap() - before,
+            2,
+            "NoEvict cache must still count shrink evictions in metrics"
+        );
+        assert_eq!(ConcurrentCached::cache_get(&c, &0).unwrap(), Some(0));
+        assert_eq!(ConcurrentCached::cache_get(&c, &1).unwrap(), Some(10));
+    }
+
+    #[test]
+    fn has_evict_typestate_shrink_fires_callback() {
+        // Built via the HasEvict typestate (.on_evict called). The typestate
+        // transition must still produce a cache whose set_max_size shrink fires
+        // the callback for each evicted entry.
+        let evicted = Arc::new(AtomicU64::new(0));
+        let evicted2 = evicted.clone();
+        let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
+            .shards(1)
+            .max_size(4)
+            .ttl(Duration::from_secs(60))
+            .on_evict(move |_, _| {
+                evicted2.fetch_add(1, Ordering::Relaxed);
+            })
+            .build()
+            .unwrap();
+        for i in 0..4u32 {
+            ConcurrentCached::cache_set(&c, i, i).unwrap();
+        }
+        c.set_max_size(1);
+        assert_eq!(c.capacity(), 1);
+        assert_eq!(
+            evicted.load(Ordering::Relaxed),
+            3,
+            "HasEvict cache must fire on_evict for each shrink eviction"
+        );
+    }
+
+    #[test]
+    fn trait_cache_capacity_reflects_resize() {
+        let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
+            .shards(1)
+            .max_size(4)
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        assert_eq!(ConcurrentCacheBase::cache_capacity(&c), Some(4));
+        c.set_max_size(32);
+        assert_eq!(ConcurrentCacheBase::cache_capacity(&c), Some(32));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ShardedExpiringLruCache
+// ---------------------------------------------------------------------------
+
+mod expiring_lru {
+    use super::*;
+    use cached::ShardedExpiringLruCacheBase;
+
+    #[test]
+    fn grow_keeps_entries_returns_previous_total() {
+        let c = ShardedExpiringLruCacheBase::<u32, E>::builder()
+            .shards(1)
+            .max_size(4)
+            .build()
+            .unwrap();
+        ConcurrentCached::cache_set(&c, 1, E { v: 10 }).unwrap();
+        ConcurrentCached::cache_set(&c, 2, E { v: 20 }).unwrap();
+
+        let prev = c.set_max_size(8);
+        assert_eq!(prev, Some(4));
+        assert_eq!(c.capacity(), 8);
+        assert!(ConcurrentCached::cache_get(&c, &1).unwrap().is_some());
+        assert!(ConcurrentCached::cache_get(&c, &2).unwrap().is_some());
+    }
+
+    #[test]
+    fn shrink_evicts_lru_order_fires_on_evict_and_counts_evictions() {
+        let evicted = Arc::new(AtomicU64::new(0));
+        let evicted2 = evicted.clone();
+
+        let c = ShardedExpiringLruCacheBase::<u32, E>::builder()
+            .shards(1)
+            .max_size(4)
+            .on_evict(move |_, _| {
+                evicted2.fetch_add(1, Ordering::Relaxed);
+            })
+            .build()
+            .unwrap();
+
+        ConcurrentCached::cache_set(&c, 1, E { v: 10 }).unwrap();
+        ConcurrentCached::cache_set(&c, 2, E { v: 20 }).unwrap();
+        ConcurrentCached::cache_set(&c, 3, E { v: 30 }).unwrap();
+        ConcurrentCached::cache_set(&c, 4, E { v: 40 }).unwrap();
+        // Promote 1 and 2 to MRU.
+        ConcurrentCached::cache_get(&c, &1).unwrap();
+        ConcurrentCached::cache_get(&c, &2).unwrap();
+
+        let evictions_before = c.metrics().evictions.unwrap();
+        let prev = c.set_max_size(2);
+        assert_eq!(prev, Some(4));
+        assert_eq!(c.capacity(), 2);
+        assert_eq!(c.len(), 2);
+        assert_eq!(
+            c.metrics().evictions.unwrap() - evictions_before,
+            2,
+            "eviction counter must reflect shrink evictions"
+        );
+        assert_eq!(
+            evicted.load(Ordering::Relaxed),
+            2,
+            "on_evict must fire for each evicted entry"
+        );
+        // Survivors.
+        assert!(ConcurrentCached::cache_get(&c, &1).unwrap().is_some());
+        assert!(ConcurrentCached::cache_get(&c, &2).unwrap().is_some());
+        assert!(ConcurrentCached::cache_get(&c, &3).unwrap().is_none());
+        assert!(ConcurrentCached::cache_get(&c, &4).unwrap().is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "max_size must be greater than zero")]
+    fn zero_set_max_size_panics() {
+        let c = ShardedExpiringLruCacheBase::<u32, E>::builder()
+            .shards(1)
+            .max_size(4)
+            .build()
+            .unwrap();
+        let _ = c.set_max_size(0);
+    }
+
+    #[test]
+    fn zero_try_set_max_size_returns_error() {
+        let c = ShardedExpiringLruCacheBase::<u32, E>::builder()
+            .shards(1)
+            .max_size(4)
+            .build()
+            .unwrap();
+        assert_eq!(c.try_set_max_size(0), Err(SetMaxSizeError::ZeroSize));
+        let r = c.try_set_max_size(8);
+        assert_eq!(r, Ok(Some(4)));
+        assert_eq!(c.capacity(), 8);
+    }
+
+    #[test]
+    fn min_per_shard_clamp_applied_and_capacity_reflects_clamped_total() {
+        let c = ShardedExpiringLruCacheBase::<u32, E>::builder()
+            .shards(4)
+            .max_size(1024)
+            .build()
+            .unwrap();
+        let prev = c.set_max_size(4);
+        assert_eq!(prev, Some(1024));
+        // 4 shards * 16 = 64
+        assert_eq!(c.capacity(), 64);
+    }
+
+    #[test]
+    fn resize_cache_built_with_per_shard_max_size_switches_to_total_policy() {
+        let c = ShardedExpiringLruCacheBase::<u32, E>::builder()
+            .shards(4)
+            .per_shard_max_size(10)
+            .build()
+            .unwrap();
+        assert_eq!(c.capacity(), 40);
+        let prev = c.set_max_size(100);
+        assert_eq!(prev, Some(40));
+        assert_eq!(c.capacity(), 100);
+    }
+
+    #[test]
+    fn single_shard_exact_capacity_no_clamp() {
+        let c = ShardedExpiringLruCacheBase::<u32, E>::builder()
+            .shards(1)
+            .max_size(3)
+            .build()
+            .unwrap();
+        ConcurrentCached::cache_set(&c, 1, E { v: 1 }).unwrap();
+        ConcurrentCached::cache_set(&c, 2, E { v: 2 }).unwrap();
+        ConcurrentCached::cache_set(&c, 3, E { v: 3 }).unwrap();
+        assert_eq!(c.len(), 3);
+        let prev = c.set_max_size(1);
+        assert_eq!(prev, Some(3));
+        assert_eq!(c.capacity(), 1);
+        assert_eq!(c.len(), 1);
+    }
+
+    #[test]
+    fn trait_cache_capacity_reflects_resize() {
+        let c = ShardedExpiringLruCacheBase::<u32, E>::builder()
+            .shards(1)
+            .max_size(4)
+            .build()
+            .unwrap();
+        assert_eq!(ConcurrentCacheBase::cache_capacity(&c), Some(4));
+        c.set_max_size(32);
+        assert_eq!(ConcurrentCacheBase::cache_capacity(&c), Some(32));
+    }
+
+    #[test]
+    fn shrink_evicts_by_lru_order_not_expiry_and_fires_on_evict_for_expired() {
+        // CONTRACT: a capacity shrink on the sharded expiring-LRU store evicts the
+        // least-recently-used entries *regardless of expiry status*. It is a pure
+        // LRU capacity trim — it does NOT preferentially drop expired entries, and
+        // on_evict fires for every dropped entry including expired ones. (The only
+        // expiry-aware removal path is `evict()`, not `set_max_size`.)
+        //
+        // Layout below (single shard, cap 4), inserted oldest-first:
+        //   key 1 EXPIRED, key 2 live, key 3 EXPIRED, key 4 live
+        // LRU order after inserts (no gets): MRU = 4,3,2,1 = LRU.
+        // Shrink to cap 2 evicts the two LRU keys 1 and 2 (one expired, one live),
+        // leaving keys 3 (expired) and 4 (live). on_evict must fire twice.
+        let evicted_keys = Arc::new(std::sync::Mutex::new(Vec::<u32>::new()));
+        let ek = evicted_keys.clone();
+        let c = ShardedExpiringLruCacheBase::<u32, ExpVal>::builder()
+            .shards(1)
+            .max_size(4)
+            .on_evict(move |k: &u32, _v: &ExpVal| {
+                ek.lock().unwrap().push(*k);
+            })
+            .build()
+            .unwrap();
+        ConcurrentCached::cache_set(
+            &c,
+            1,
+            ExpVal {
+                v: 1,
+                expired: true,
+            },
+        )
+        .unwrap();
+        ConcurrentCached::cache_set(
+            &c,
+            2,
+            ExpVal {
+                v: 2,
+                expired: false,
+            },
+        )
+        .unwrap();
+        ConcurrentCached::cache_set(
+            &c,
+            3,
+            ExpVal {
+                v: 3,
+                expired: true,
+            },
+        )
+        .unwrap();
+        ConcurrentCached::cache_set(
+            &c,
+            4,
+            ExpVal {
+                v: 4,
+                expired: false,
+            },
+        )
+        .unwrap();
+        assert_eq!(c.len(), 4, "no lazy expiry sweep happened during inserts");
+
+        let ev_before = c.metrics().evictions.unwrap();
+        c.set_max_size(2);
+        assert_eq!(c.capacity(), 2);
+
+        let mut fired = evicted_keys.lock().unwrap().clone();
+        fired.sort_unstable();
+        assert_eq!(
+            fired,
+            vec![1, 2],
+            "shrink must evict the two LRU keys (1,2) by recency, NOT the two expired keys (1,3)"
+        );
+        assert_eq!(
+            c.metrics().evictions.unwrap() - ev_before,
+            2,
+            "both LRU-trim evictions (expired and live alike) must be counted"
+        );
+        // Survivors: key 3 (expired but LRU-recent) and key 4 (live). A cache_get on
+        // key 3 is a miss because it is expired, but it was NOT dropped by the shrink.
+        assert!(
+            ConcurrentCached::cache_get(&c, &4).unwrap().is_some(),
+            "live MRU key 4 survives"
+        );
+        assert_eq!(
+            c.len(),
+            2,
+            "expired key 3 survives the capacity shrink (it is LRU-recent); only evict() would sweep it"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared helper: verify per_shard_cap_from_total policy is consistent with
+// what the builder produces. This pins the helper against the builder.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn per_shard_cap_matches_builder_for_various_sizes() {
+    // For each (shards, max_size) pair, the cache built with max_size and the
+    // cache after set_max_size(same) must report the same capacity().
+    let cases: &[(usize, usize)] = &[
+        (1, 1),
+        (1, 64),
+        (4, 8),   // triggers 16-per-shard floor
+        (4, 100), // no floor: 25 per shard
+        (8, 64),  // 8 per shard -> floor kicks in: 16 each -> 128
+    ];
+
+    for &(shards, max_size) in cases {
+        let built = cached::ShardedLruCacheBase::<u32, u32>::builder()
+            .shards(shards)
+            .max_size(max_size)
+            .build()
+            .unwrap();
+        let built_cap = built.capacity();
+
+        // Build a larger cache and resize to max_size.
+        let resized = cached::ShardedLruCacheBase::<u32, u32>::builder()
+            .shards(shards)
+            .max_size(max_size * 10 + 100)
+            .build()
+            .unwrap();
+        resized.set_max_size(max_size);
+        assert_eq!(
+            resized.capacity(),
+            built_cap,
+            "set_max_size({max_size}) on {shards}-shard cache must yield same capacity as builder"
+        );
+    }
+}

--- a/tests/v3_traits.rs
+++ b/tests/v3_traits.rs
@@ -690,7 +690,7 @@ mod redb_serialize_cached {
 
     fn build_cache(dir: &TempDir, name: &str) -> RedbCache<u32, String> {
         RedbCache::<u32, String>::builder(name)
-            .disk_directory(dir.path())
+            .disk_dir(dir.path())
             .build()
             .expect("error building redb cache")
     }
@@ -742,7 +742,7 @@ mod redb_serialize_cached {
     fn cache_set_ref_ttl_expiry() {
         let dir = TempDir::new().unwrap();
         let cache: RedbCache<u32, String> = RedbCache::builder("serialize_cached_ttl_expiry")
-            .disk_directory(dir.path())
+            .disk_dir(dir.path())
             .ttl(Duration::from_millis(100))
             .build()
             .expect("error building redb cache");
@@ -773,7 +773,7 @@ mod redb_serialize_cached_async {
     async fn async_cache_set_ref_round_trip() {
         let dir = TempDir::new().unwrap();
         let cache: RedbCache<u32, String> = RedbCache::builder("serialize_cached_async_round_trip")
-            .disk_directory(dir.path())
+            .disk_dir(dir.path())
             .build()
             .expect("error building redb cache");
 
@@ -800,7 +800,7 @@ mod redb_serialize_cached_async {
     async fn async_cache_set_ref_overwrite() {
         let dir = TempDir::new().unwrap();
         let cache: RedbCache<u32, String> = RedbCache::builder("serialize_cached_async_overwrite")
-            .disk_directory(dir.path())
+            .disk_dir(dir.path())
             .build()
             .expect("error building redb cache");
 
@@ -1200,7 +1200,7 @@ fn concurrent_redb_refresh_on_hit_getter_reflects_setter() {
 
     let dir = TempDir::new().unwrap();
     let cache: RedbCache<u32, u32> = RedbCache::builder("concurrent_redb_refresh_getter")
-        .disk_directory(dir.path())
+        .disk_dir(dir.path())
         .ttl(Duration::from_secs(60))
         .build()
         .expect("build RedbCache");
@@ -1719,7 +1719,7 @@ mod concurrent_trait_split_no_collision {
     fn redb_shared_helpers_resolve_without_fully_qualified_syntax() {
         let dir = tempfile::TempDir::new().expect("temp dir");
         let cache: RedbCache<String, u32> = RedbCache::builder("collision-probe")
-            .disk_directory(dir.path())
+            .disk_dir(dir.path())
             .ttl(Duration::from_secs(60))
             .build()
             .expect("build RedbCache");
@@ -1769,7 +1769,7 @@ mod concurrent_trait_split_no_collision {
     fn concurrent_try_set_ttl_zero_is_rejected() {
         let redb_dir = tempfile::TempDir::new().expect("temp dir");
         let redb: RedbCache<String, u32> = RedbCache::builder("try-set-ttl-zero")
-            .disk_directory(redb_dir.path())
+            .disk_dir(redb_dir.path())
             .ttl(Duration::from_secs(60))
             .build()
             .expect("build RedbCache");
@@ -1833,7 +1833,7 @@ mod concurrent_trait_split_no_collision {
     async fn redb_shared_helpers_resolve_unqualified_in_async_context() {
         let dir = tempfile::TempDir::new().expect("temp dir");
         let cache: RedbCache<String, u32> = RedbCache::builder("collision-probe-async")
-            .disk_directory(dir.path())
+            .disk_dir(dir.path())
             .ttl(Duration::from_secs(60))
             .build()
             .expect("build RedbCache");
@@ -1886,7 +1886,7 @@ mod concurrent_base_unknown_size_defaults {
     fn redb_len_and_is_empty_default_to_unknown() {
         let dir = tempfile::TempDir::new().expect("temp dir");
         let cache: RedbCache<String, u32> = RedbCache::builder("unknown-size-defaults")
-            .disk_directory(dir.path())
+            .disk_dir(dir.path())
             .ttl(Duration::from_secs(60))
             .build()
             .expect("build RedbCache");


### PR DESCRIPTION
- Add `set_max_size(&self)` / `try_set_max_size(&self)` to `ShardedLruCacheBase`, `ShardedLruTtlCacheBase`, and `ShardedExpiringLruCacheBase`: per-shard capacity recomputed with the builders' ceiling-division-plus-16-per-shard-floor policy, shrink evicts per shard and fires `on_evict`, the new total is published (Release/Acquire) only after every shard adopts its new cap. Covered by `tests/v3_sharded_resize.rs`.
- Rename `RedbCacheBuilder::disk_directory` to `disk_dir`, matching the `disk_dir` macro attribute. Breaking vs the 3.0 rcs only (the method did not exist in 2.x). Document the default disk path fallback (user cache dir, else temp dir).
- Add `examples/resilience.rs` covering `sync_writes = "by_key"`, `result_fallback`, and `force_refresh`; wire it into the example CI list.
- Migration guide: add the compile-error entry for `sync_writes_buckets` without `sync_writes = "by_key"` plus its error-index line; note the new resize APIs; test `ConnectionString` eq/hash on the raw URL.
- Docs: `cache_capacity` means the eviction bound (`max_size`), `redis = true` shorthand in the macro quick-reference table, `ConcurrentCacheBase::cache_size` returns `Result<Option<usize>, _>`, unquoted `convert` forms, `expires_per_key` doc example compiles as `no_run`; drop `ExpiringCache`'s dead `cache_capacity` override.