### PR TITLE
fix: `Acquire` load for sharded `metrics().capacity`, document concurrent `set_max_size` semantics, sync specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `cached::prelude` re-exports `CacheTtl` unconditionally, matching `ConcurrentCacheTtl` (the trait was never feature-gated; only the built-in stores implementing it require `time_stores`).
 - `Return::set_was_cached` is `#[doc(hidden)]` (macro plumbing, not supported public API). The method remains `pub` and callable (no compile breakage); it is de-documented because only macro-generated code should set the flag -- use `Return::new` to construct a value and `was_cached()` to read the flag.
 - `#[must_use]` added to `CacheMetrics::hit_ratio` and the `iter_order` / `key_order` / `value_order` accessors on `LruCache` / `LruTtlCache`.
+- `metrics().capacity` on the sharded LRU stores (`ShardedLruCacheBase` / `ShardedLruTtlCacheBase` / `ShardedExpiringLruCacheBase`) loads the total with `Acquire` ordering, matching `capacity()`: after a same-thread `set_max_size`, `metrics().capacity` and `capacity()` now always agree.
 
 ### Documentation
 
@@ -37,6 +38,7 @@
 - The error-source downcast tests are labeled as pinning non-contract behavior (the concrete source types stay out of the semver contract).
 - The `#[concurrent_cached(redis = true)]` shorthand now appears in the macro quick-reference table.
 - `Cached::cache_capacity` / `ConcurrentCacheBase::cache_capacity` docs clarify that capacity means the eviction bound (`max_size`), not pre-allocated memory.
+- `set_max_size` on the sharded LRU stores documents concurrent-caller semantics: overlapping resizes interleave per-shard writes (no data race or lost entries, but the resulting bound blends the two targets and `capacity()` reports whichever total was published last); serialize resizes externally, or re-issue the resize, when a single consistent target matters.
 
 ## [3.0.0-rc.7 / cached_proc_macro 3.0.0-rc.7] - 2026-07-12
 

--- a/examples/resilience.rs
+++ b/examples/resilience.rs
@@ -47,7 +47,14 @@ fn slow_lookup(key: u32) -> String {
 fn demo_sync_writes_by_key() {
     println!("\n--- 1. sync_writes = \"by_key\" ---");
 
+    // Reset both the counter and the cache so the demo holds even if this
+    // function is invoked more than once in the same process (a warm key 42
+    // would otherwise skip the body and break the body_runs == 1 assertion).
     BY_KEY_CALL_COUNT.store(0, Ordering::SeqCst);
+    {
+        use cached::Cached;
+        SLOW_LOOKUP.write().cache_clear();
+    }
 
     // Spawn 5 threads all calling with the same key (42). Only one should
     // actually run the body; the other 4 wait and reuse the computed result.

--- a/specs/builders.md
+++ b/specs/builders.md
@@ -20,8 +20,10 @@ builder-only. Whether infallible builders should return the cache directly is an
 ## BUILD-3
 
 Builders accept `on_evict(|k, v| { ... })`, fired on every evicted entry (LRU capacity eviction,
-TTL/expiry sweeps via `evict()`). The `HasEvict` / `NoEvict` marker types track whether a
-callback is configured. See [metrics.md](metrics.md) for the eviction counter and
+TTL/expiry sweeps via `evict()`). `LruTtlCacheBuilder` and `ShardedLruTtlCacheBuilder` use
+`HasEvict` / `NoEvict` type-state markers to track whether a callback is configured (both
+re-exported at the crate root under the `time_stores` feature); other builders with `on_evict`
+store a plain `Option`. See [metrics.md](metrics.md) for the eviction counter and
 [design/0002-size-iter-evict-semantics.md](design/0002-size-iter-evict-semantics.md) for the
 size/iter/evict semantics.
 

--- a/specs/cargo-features.md
+++ b/specs/cargo-features.md
@@ -29,8 +29,8 @@ build otherwise). Orthogonal runtime x TLS axes are an open direction
 
 ## FEAT-4
 
-Disk: `redb_store` (disk-backed cache via `redb`; see [store-redb.md](store-redb.md)). redb 4.x
-raises the crate MSRV to 1.89.
+Disk: `redb_store` (disk-backed cache via `redb`; see [store-redb.md](store-redb.md)). The crate
+MSRV is 1.89 (set unconditionally in `Cargo.toml`; historically required by redb 4.x).
 
 ## FEAT-5
 

--- a/specs/design/0003-redis-millisecond-ttl.md
+++ b/specs/design/0003-redis-millisecond-ttl.md
@@ -5,7 +5,7 @@ Status: Implemented
 ## Current state
 
 - The Redis store rounds any sub-second TTL up to one whole second and writes with `SETEX` /
-  `EXPIRE` (`src/stores/redis.rs:27`). Builders accept `.ttl_millis(...)` and `.ttl(Duration)`
+  `EXPIRE` (`src/stores/redis.rs:78`). Builders accept `.ttl_millis(...)` and `.ttl(Duration)`
   but the millisecond resolution is discarded at write time, so `ttl_millis(250)` becomes a
   1000ms Redis TTL.
 - `ttl_millis` is advertised as a feature in the macro and store docs, but it is inaccurate
@@ -17,7 +17,7 @@ Status: Implemented
   commands `PSETEX` / `PEXPIRE` (available since Redis 2.6) so the stored TTL matches the
   requested `Duration` to the millisecond.
 - Drop the round-up-to-1s path. Update the internal `ttl_seconds`/`ttl_seconds_i64` helpers and
-  their tests (`src/stores/redis.rs:168`) to millisecond variants. Keep the saturating clamp at
+  their tests (`src/stores/redis.rs:188`) to millisecond variants. Keep the saturating clamp at
   `i64::MAX` in milliseconds.
 - Update docs that describe whole-second Redis TTL granularity.
 

--- a/specs/design/0004-redis-connection-string-redaction.md
+++ b/specs/design/0004-redis-connection-string-redaction.md
@@ -7,7 +7,7 @@ Status: Implemented
 - The internal `ConnectionString` wrapper redacts credentials in `Debug`/`Display`
   (`src/stores/redis.rs:319`).
 - The public `connection_string()` getter on `RedisCache` and `AsyncRedisCache` returns the raw
-  URL including any password (`src/stores/redis.rs:682`, `src/stores/redis.rs:1345`), with only
+  URL including any password (`src/stores/redis.rs:1308`), with only
   a doc-comment warning. This re-exposes exactly what the wrapper hides, and leaks credentials
   into logs via `println!("{}", cache.connection_string())`.
 

--- a/specs/design/0005-store-error-consistency.md
+++ b/specs/design/0005-store-error-consistency.md
@@ -10,7 +10,7 @@ Status: Implemented
   (`src/stores/redb.rs:450`), so build-time and runtime disagree on the vocabulary.
 - Variant shapes are inconsistent across the two backends. Redis uses struct variants with named
   fields: `CacheDeserialization { cached_value: String, error: ... }` and
-  `CacheSerialization { error: ... }` (`src/stores/redis.rs:689`). redb uses tuple variants:
+  `CacheSerialization { error: ... }` (`src/stores/redis.rs:1325`). redb uses tuple variants:
   `CacheDeserialization(...)`, `CacheSerialization(...)`, `Storage(...)`
   (`src/stores/redb.rs:450`).
 

--- a/specs/design/0008-method-name-deduplication.md
+++ b/specs/design/0008-method-name-deduplication.md
@@ -8,8 +8,8 @@ Status: Implemented
   `cache_`-prefixed form. `cache_get`/`get`, `cache_set`/`set`, `cache_remove`/`remove`,
   `cache_remove_entry`/`remove_entry`, `cache_clear`/`clear`, `cache_size`/`len`,
   `cache_delete`/`delete`, `cache_try_set`/`try_set`, the four `*get_or_set_with*` pairs,
-  `cache_hits`/`hits`, `cache_misses`/`misses` (`src/lib.rs:740` onward; aliases from
-  `src/lib.rs:921`). `ConcurrentCached` repeats the pattern (`src/lib.rs:1701`/`1798`).
+  `cache_hits`/`hits`, `cache_misses`/`misses` (`src/lib.rs:913` onward; aliases from
+  `src/lib.rs:1142`). `ConcurrentCached` repeats the pattern (`src/lib.rs:1812`).
 - `Cached` is roughly 40 public methods, over half pure delegations. This is the trait
   implementors read and the prelude pulls in.
 

--- a/specs/design/0009-cached-get-shared-receiver.md
+++ b/specs/design/0009-cached-get-shared-receiver.md
@@ -4,7 +4,7 @@ Status: Needs research
 
 ## Current state
 
-- `Cached::cache_get`/`get` take `&mut self` (`src/lib.rs:740,921`), as do `cache_get_mut`,
+- `Cached::cache_get`/`get` take `&mut self` (`src/lib.rs:913`), as do `cache_get_mut`,
   `contains`, and `CloneCached::cache_get_with_expiry_status`.
 - Justified by LRU recency updates, TTL refresh, and hit/miss metrics mutating on read.
 - `CachedPeek::cache_peek` (&self) and `CachedRead::cache_get_read` (&self) exist as

--- a/specs/design/0011-redis-serialization-codec.md
+++ b/specs/design/0011-redis-serialization-codec.md
@@ -4,16 +4,17 @@ Status: MessagePack switch implemented; pluggable codec needs research
 
 ## Current state
 
-- Redis serializes values with serde_json and stores a UTF-8 String
-  (`src/stores/redis.rs:824`).
-- redb uses rmp-serde (MessagePack) on bytes (`src/stores/redb.rs:776`).
+- Redis serializes values with rmp-serde (MessagePack) as a versioned `value`/`version`
+  envelope stored in bytes (`src/stores/redis.rs:1390`), matching redb; pre-3.0 serde_json
+  String entries are still readable via the exact-version JSON gate (see Notes).
+- redb uses rmp-serde (MessagePack) on bytes (`src/stores/redb.rs:866`).
 - The codec is a private per-store detail; the error enums bake in the concrete serde error
   type.
 
 ## Desired work
 
-- Target 3.0: switch the Redis store from serde_json-as-String to MessagePack (rmp-serde),
-  matching redb, storing bytes. This changes the wire format and the error types those variants
+- Done in 3.0: the Redis store switched from serde_json-as-String to MessagePack (rmp-serde),
+  matching redb, storing bytes. This changed the wire format and the error types those variants
   carry (see 0005).
 - Needs research: a `Codec` abstraction wired into the builders (builder-set, not a generic
   type param, to avoid signature leakage) defaulting to the per-store choice, so users can pick

--- a/specs/design/0012-concurrent-metrics-trait.md
+++ b/specs/design/0012-concurrent-metrics-trait.md
@@ -8,7 +8,9 @@ Status: Implemented
   `cache_capacity`, `cache_evictions`, and a default `metrics() -> CacheMetrics`
   (`src/lib.rs:1059`-`1085`). `CacheMetrics` is shared (`src/lib.rs:1122`).
 - Sharded stores return the same `CacheMetrics` struct but only via inherent methods
-  (`src/stores/sharded/unbound.rs:230`, `src/stores/sharded/lru.rs:223`), plus inherent
+  (`src/stores/sharded/unbound.rs:252`, `src/stores/sharded/lru.rs:245`,
+  `src/stores/sharded/ttl.rs:311`, `src/stores/sharded/lru_ttl.rs:330`,
+  `src/stores/sharded/expiring.rs:254`, `src/stores/sharded/expiring_lru.rs:268`), plus inherent
   `shards()`, `shard_sizes()`, `clear()`, `cache_clear_with_on_evict()`. None of these is on a
   trait, so generic code over `ConcurrentCached` cannot read a hit rate or shard distribution.
 

--- a/specs/design/0016-async-core-internal-feature.md
+++ b/specs/design/0016-async-core-internal-feature.md
@@ -25,4 +25,4 @@ documented feature ("async trait definitions without the async-lock dependency")
 who want the async trait surface without pulling `async-lock`.
 
 5.4 refresh: `blocking` was moved from the `async` feature to `redb_store`; Redis-only and
-in-memory async builds no longer pay for it (`Cargo.toml:63-68`).
+in-memory async builds no longer pay for it (`Cargo.toml:75`).

--- a/specs/design/0017-redis-feature-axes.md
+++ b/specs/design/0017-redis-feature-axes.md
@@ -16,7 +16,7 @@ Status: Capability axis resolved; TLS orthogonality needs research
   opt-in rather than a global type swap); CI feature checks pair each capability with both
   runtimes.
 - `AsyncRedisCache` is gated on the 6 runtime features only; the 2 capability features are
-  deliberately excluded from the gate (`src/lib.rs:619-645`, `src/stores/mod.rs:340-362`).
+  deliberately excluded from the gate (`src/lib.rs:639-665`, `src/stores/mod.rs:340-362`).
 - TLS remains fused with the runtime: `redis_smol_native_tls`, `redis_smol_rustls`,
   `redis_tokio_native_tls`, `redis_tokio_rustls` each encode a runtime+TLS combination rather
   than composable axes.

--- a/specs/design/0019-ahash-default-feature.md
+++ b/specs/design/0019-ahash-default-feature.md
@@ -22,5 +22,5 @@ Status: Decided: keep in defaults (DEC-3=A)
 
 DEC-3=A: keep `ahash` in default features. The hash-flood concern is already addressed via
 runtime-generated random seeds on non-wasm platforms (`Cargo.toml` ahash config block,
-`Cargo.toml:97-107`). Hashing is hot in a cache crate; dropping ahash from defaults would be
+`Cargo.toml:99-114`). Hashing is hot in a cache crate; dropping ahash from defaults would be
 a silent performance regression for users relying on them. No code change.

--- a/specs/design/0023-peek-read-trait-merge.md
+++ b/specs/design/0023-peek-read-trait-merge.md
@@ -5,8 +5,8 @@ Status: Declined (DEC-5=B)
 ## Current state
 
 - The public trait surface is ~16 traits.
-- `CachedRead` (`src/lib.rs:1414`) adds exactly one method that defaults to calling
-  `CachedPeek::cache_peek` (`src/lib.rs:1399`).
+- `CachedRead` (`src/lib.rs:1481`) adds exactly one method that defaults to calling
+  `CachedPeek::cache_peek` (`src/lib.rs:1459`).
 - Basic operations on a TTL store can require importing several traits (Cached + CacheTtl +
   CacheEvict + CloneCached). The prelude re-exports 14 traits.
 

--- a/specs/design/0025-redb-disk-path-introspection.md
+++ b/specs/design/0025-redb-disk-path-introspection.md
@@ -5,7 +5,7 @@ Status: Needs research
 ## Current state
 
 - redb's `name` is validated only at build() and the file is `<name>_v<DISK_FILE_VERSION>.redb`
-  under a default dir derived from the exe name (`src/stores/redb.rs:193,275`).
+  under a default dir derived from the exe name (`src/stores/redb.rs:203,275`).
 - The default-dir logic silently falls back from the system cache dir to the temp dir on
   PermissionDenied (`src/stores/redb.rs:214`), so a cache can land in /tmp without the caller
   knowing.

--- a/specs/design/0027-sync-writes-default-revert.md
+++ b/specs/design/0027-sync-writes-default-revert.md
@@ -42,4 +42,4 @@ default. The CHANGELOG (`[3.0.0-rc.3]`) carries a dedicated note for this revert
 
 - The revert was made before 3.0.0 final; no stable release ever shipped the `"by_key"` default.
 - The seeded per-key lock bucket hasher is documented in spec 0035.
-- `cached_proc_macro/src/cached.rs:781-794` enforces the `result_fallback`/`sync_writes` conflict.
+- `cached_proc_macro/src/cached.rs:800-807` enforces the `result_fallback`/`sync_writes` conflict.

--- a/specs/design/0029-self-healing-deserialization-default.md
+++ b/specs/design/0029-self-healing-deserialization-default.md
@@ -33,13 +33,13 @@ failure path.
 **`is_deserialization()` classifies errors without downcast.** `RedisCacheError::is_deserialization()`
 and `RedbCacheError::is_deserialization()` let strict-mode callers distinguish a corrupt-value
 error from a network or IO error without reaching into the opaque `source` box
-(`src/stores/redis.rs:1214-1221`, `src/stores/redb.rs:702-area`).
+(`src/stores/redis.rs:1406`, `src/stores/redb.rs:770`).
 
 **The GET-then-DEL self-heal on redis is not atomic.** A concurrent `PSETEX` of a valid value
 between the GET and the DEL can be lost. This race is closed on the redis path with a Lua
 conditional-delete script (DEC-9(b); `src/stores/redis.rs:11-35`): the script deletes the key
 only if the stored bytes still match what was read, so a fresher valid write is preserved. The
-redb path re-reads under the write transaction before deleting (C5 fix; `src/stores/redb.rs:808-`),
+redb path re-reads under the write transaction before deleting (C5 fix; `src/stores/redb.rs:866-911`),
 so a concurrent `cache_set` that commits between the read and the self-heal is not silently lost.
 
 ## Notes

--- a/specs/design/0030-force-refresh-result-fallback-interaction.md
+++ b/specs/design/0030-force-refresh-result-fallback-interaction.md
@@ -32,7 +32,7 @@ skip-read branch and the skip-store branch, so the expression is not evaluated t
 attributes conflict: `result_fallback` needs a peek before the call and a conditional store after,
 which is incompatible with the `by_key` lock structure. A compile error is emitted if both are
 set with a non-Disabled sync mode. When `sync_writes` is not set explicitly and `result_fallback`
-is set, `sync_writes` is forced to `Disabled` (`cached_proc_macro/src/cached.rs:781-794`).
+is set, `sync_writes` is forced to `Disabled` (`cached_proc_macro/src/cached.rs:800-807`).
 
 **`result_fallback` is also mutually exclusive with `cache_err` and `with_cached_flag`.** Both
 conflicts are compile errors. `cache_err` caches the error value directly, which is the opposite
@@ -46,6 +46,6 @@ available on TTL-capable and expiring stores.
 
 ## Notes
 
-- `cached_proc_macro/src/cached.rs:1104-1169` contains the full codegen for this interaction.
+- `cached_proc_macro/src/cached.rs:1112-1190` contains the full codegen for this interaction.
 - `force_refresh` alone (without `result_fallback`) uses a simpler guard pattern that short-circuits
   the lookup unconditionally when the predicate is true.

--- a/specs/design/0031-redis-backward-read-version-gate.md
+++ b/specs/design/0031-redis-backward-read-version-gate.md
@@ -13,10 +13,10 @@ struct CachedRedisValue<V> {
 }
 ```
 
-`REDIS_VALUE_VERSION` is `Some(1)` (`src/stores/redis.rs:1227`). Every write since 3.0 stamps
+`REDIS_VALUE_VERSION` is `Some(1)` (`src/stores/redis.rs:1420`). Every write since 3.0 stamps
 this version field.
 
-On read, `deserialize_cached_redis_value` (`src/stores/redis.rs:1275-1300`) tries MessagePack
+On read, `deserialize_cached_redis_value` (`src/stores/redis.rs:1468-1493`) tries MessagePack
 first. On failure it attempts a legacy JSON fallback: the bytes are parsed as a generic JSON
 value, and only if the result carries `"version": 1` (the exact constant value, not merely a
 `version` key) is a `serde_json` deserialization attempted. If neither path succeeds, the
@@ -50,7 +50,7 @@ the backward-read.
 - The legacy JSON gate is temporary scaffolding for the 2.x -> 3.0 migration window. Once all
   keys in a deployment have been rewritten by 3.0, the JSON path is never reached. There is no
   plan to remove it before 4.0; it is cheap (MessagePack succeeds on the fast path) and harmless.
-- Tests: `tests/v3_redis_backward_read.rs`; `src/stores/redis.rs:554-600` (unit tests for the
+- Tests: `tests/v3_redis_backward_read.rs`; `src/stores/redis.rs:664-717` (unit tests for the
   version gate logic).
 - Spec 0011 (redis serialization codec) covers the MessagePack migration itself; this spec covers
   only the backward-read version gate.

--- a/specs/design/0032-cached-async-to-get-or-set-async-rename.md
+++ b/specs/design/0032-cached-async-to-get-or-set-async-rename.md
@@ -46,6 +46,6 @@ as a supertrait.
 
 ## Notes
 
-- The trait is gated on `feature = "async_core"` (`src/lib.rs:1689`).
-- `src/lib.rs:1678-1688` documents the scope distinction between `CachedGetOrSetAsync` and
+- The trait is gated on `feature = "async_core"` (`src/lib.rs:1700-1702`).
+- `src/lib.rs:1688-1699` documents the scope distinction between `CachedGetOrSetAsync` and
   `ConcurrentCachedAsync` in the trait rustdoc.

--- a/specs/design/0033-redb-revalidate-in-write-txn.md
+++ b/specs/design/0033-redb-revalidate-in-write-txn.md
@@ -13,11 +13,11 @@ thread may have written a valid value for the same key via `cache_set`.
 
 Two paths handle this:
 
-**Expiry/refresh mutation path (`src/stores/redb.rs:920-936`):** re-reads the entry under the
+**Expiry/refresh mutation path (`src/stores/redb.rs:942`):** re-reads the entry under the
 write transaction before acting. If the key is now absent or has a fresh value, the stale action
 is skipped. This was the original design.
 
-**Self-heal path (`src/stores/redb.rs:808-867`, C5 fix):** previously deleted the key blindly
+**Self-heal path (`src/stores/redb.rs:866-911`, C5 fix):** previously deleted the key blindly
 under the write transaction without re-reading. A valid `cache_set` that committed between the
 read and the write was silently deleted. The fix aligns the self-heal path with the expiry path:
 re-read the bytes under the write transaction; only delete if the bytes are still corrupt (same

--- a/specs/design/0034-prime-companion-body-before-lock.md
+++ b/specs/design/0034-prime-companion-body-before-lock.md
@@ -9,7 +9,7 @@ Calling `{fn}_prime_cache(args)` unconditionally runs the body and stores the re
 the cache lookup. It is used to warm the cache before the first call or to force a refresh.
 
 The generated prime body runs the function call before acquiring the cache lock
-(`cached_proc_macro/src/cached.rs:1209-1221`):
+(`cached_proc_macro/src/cached.rs:1218-1230`):
 
 ```
 // run the function first (no lock held), then cache the result
@@ -44,7 +44,7 @@ the `in_impl` static placement decision.
 
 ## Notes
 
-- `cached_proc_macro/src/cached.rs:1209-1265` contains the prime body generation and the
+- `cached_proc_macro/src/cached.rs:1218-1277` contains the prime body generation and the
   `in_impl` suppression logic.
-- The comment at line 1209 ("Run the function BEFORE taking the lock") captures the rationale
+- The comment at line 1218 ("Run the function BEFORE taking the lock") captures the rationale
   inline.

--- a/specs/design/0035-seeded-per-key-lock-bucket-hasher.md
+++ b/specs/design/0035-seeded-per-key-lock-bucket-hasher.md
@@ -6,7 +6,7 @@ Status: Implemented
 
 `sync_writes = "by_key"` on `#[cached]` serializes concurrent calls for the same cache key
 through a bucketed per-key lock. Each `by_key` static is wrapped in a `KeyedCache<C, B>` that
-holds a fixed-size array of bucket locks and a `RandomState` hasher (`src/lib.rs:773-807`):
+holds a fixed-size array of bucket locks and a `RandomState` hasher (`src/lib.rs:785-812`):
 
 ```rust
 pub struct KeyedCache<C, B> {
@@ -38,11 +38,11 @@ that it `Deref`s to the inner cache lock `C`, so a named `by_key` static (`FN_CA
 and hasher are private fields; callers cannot observe or influence bucket assignment.
 
 **`bucket_for` uses `BuildHasher::hash_one`.** This avoids constructing a `Hasher` manually and
-is the idiomatic way to hash a single value with a `BuildHasher` (`src/lib.rs:803-806`).
+is the idiomatic way to hash a single value with a `BuildHasher` (`src/lib.rs:807-811`).
 
 ## Notes
 
-- `src/lib.rs:773-807` contains the full `KeyedCache` implementation.
+- `src/lib.rs:785-812` contains the full `KeyedCache` implementation.
 - The CHANGELOG `[3.0.0-rc.4]` section notes: "`sync_writes = "by_key"` bucket selection seeds
   from a per-static `RandomState` instead of a fixed seed."
 - The number of buckets is controlled by `sync_writes_buckets` on `#[cached]` (default: the

--- a/specs/design/0036-in-impl-static-placement.md
+++ b/specs/design/0036-in-impl-static-placement.md
@@ -11,7 +11,7 @@ module namespace and accessible by the `{fn}_prime_cache` companion.
 When `in_impl = true` is set, the macro is applied to a method inside an `impl` block. In that
 case the cache static cannot be a module-level item because the generated code is emitted inside
 the impl, and `static` is not valid as an impl item. Instead, the static is emitted inside the
-generated function body (`cached_proc_macro/src/cached.rs:1223-1243`).
+generated function body (`cached_proc_macro/src/cached.rs:1237-1252`).
 
 A function-local static is valid Rust (item-in-fn), initialized once on first call (same
 semantics as a module static), and is only accessible from within that function body.
@@ -47,6 +47,6 @@ avoids surprises when a free function is renamed into a method.
 ## Notes
 
 - `cached_proc_macro/src/cached.rs:259-285` contains the receiver/`in_impl` validation.
-- `cached_proc_macro/src/cached.rs:1223-1243` contains the static placement branch.
-- `cached_proc_macro/src/cached.rs:1252-1253` contains the prime suppression under `in_impl`.
-- `cached_proc_macro/src/cached.rs:909-910` documents the visibility difference in a comment.
+- `cached_proc_macro/src/cached.rs:1237-1252` contains the static placement branch.
+- `cached_proc_macro/src/cached.rs:1261-1262` contains the prime suppression under `in_impl`.
+- `cached_proc_macro/src/cached.rs:918-921` documents the visibility difference in a comment.

--- a/specs/macro-cached.md
+++ b/specs/macro-cached.md
@@ -17,11 +17,13 @@ refresh-on-hit is `refresh =`, not `time_refresh =`.
 `cache_err = true` / `cache_none = true` (the pre-2.0 `result` / `option` attributes were
 removed). `size = N` is a hard rename error directing to `max_size = N`, per
 [design/0013-macro-store-attribute-placement.md](design/0013-macro-store-attribute-placement.md).
+`unbound` is also a removed attribute: using it emits a compile error pointing to `#[cached]`
+without `max_size`/`ttl`/`expires`, which already selects `UnboundCache`.
 
 ## CACHED-3
 
-Write-synchronization attributes: `sync_writes` (`false`/`"disabled"` default = no
-synchronization, `"by_key"` bucketed locks, `true`/`"default"` whole-cache lock),
+Write-synchronization attributes: `sync_writes` (`false`/`"false"`/`"disabled"` default = no
+synchronization, `"by_key"` bucketed locks, `true`/`"true"`/`"default"` whole-cache lock),
 `sync_writes_buckets` (default 64; a compile error unless `sync_writes = "by_key"`),
 `sync_lock` (`"rwlock"` default or `"mutex"`), `unsync_reads` (shared read lock for hits;
 `CachedRead` stores only). The `false` default and the earlier revert are recorded in

--- a/specs/macro-concurrent-cached.md
+++ b/specs/macro-concurrent-cached.md
@@ -6,20 +6,31 @@ in-memory stores by default, and the redis/redb backends when so configured.
 
 ## CONC-1
 
-Store selection follows the attributes: no extra attrs -> `ShardedUnboundCache`; `max_size` ->
-sharded LRU; `ttl_secs` / `ttl_millis` / `ttl` -> sharded TTL; `expires = true` -> sharded
-expiring; combinations pick the LRU+TTL / LRU+expiring variant. See
-[store-sharded.md](store-sharded.md).
+Store selection follows the attributes:
+
+| Attributes | Store |
+|---|---|
+| (none) | `ShardedUnboundCache` |
+| `max_size` | `ShardedLruCache` |
+| `ttl_secs` / `ttl_millis` / `ttl` | `ShardedTtlCache` |
+| `max_size` + TTL | `ShardedLruTtlCache` |
+| `expires = true` | `ShardedExpiringCache` |
+| `expires = true` + `max_size` | `ShardedExpiringLruCache` |
+
+See [store-sharded.md](store-sharded.md).
 
 ## CONC-2
 
 Shares the core attributes with `#[cached]` (`name`, `max_size`, `ttl_*`, `refresh`, `ty`,
 `create`, `key`, `convert`, `cache_err`, `cache_none`, `with_cached_flag`) but does not support
-`sync_writes` (the concurrent stores self-synchronize).
+`sync_writes` (the concurrent stores self-synchronize). Additional attributes:
+`force_refresh`, `in_impl`, `companions_vis`, `result_fallback`, `expires`, `shards` (default
+in-memory store only), `redis`, `disk`, `disk_dir`, `durable`, `cache_prefix_block`
+(redis/disk paths).
 
 ## CONC-3
 
-For disk/redis stores, `map_error` (unquoted closure `|e| MyErr(e)` or quoted string) converts
+For disk/redis stores, `map_error` (closure, e.g. `|e| MyErr(e)`) converts
 the store error into the function's error type. When omitted, a bare `?` is generated, which
 converts through `From` and so requires `E: From<StoreError>` (an explicit
 `.map_err(Into::into)` is deliberately not emitted: it is ambiguous when the target error has

--- a/specs/macro-once.md
+++ b/specs/macro-once.md
@@ -11,8 +11,9 @@ the `key` + `convert` pinning that `#[cached]` requires. See [macro-cached.md](m
 ## ONCE-2
 
 Attributes: `name`, `ttl_secs` / `ttl_millis` / `ttl`, `cache_err`, `cache_none`,
-`with_cached_flag`. `sync_writes` defaults to `false`. There is no `refresh =` attribute (a
-single-value cache has no per-key refresh-on-hit).
+`with_cached_flag`, `expires`, `force_refresh`, `in_impl`, `companions_vis`. `sync_writes`
+defaults to `false`. There is no `refresh =` attribute (a single-value cache has no per-key
+refresh-on-hit).
 
 ## ONCE-3
 

--- a/specs/store-expiring.md
+++ b/specs/store-expiring.md
@@ -7,7 +7,8 @@ pre-1.0 `ExpiringValueCache` (for `ExpiringLruCache`). Available without `time_s
 ## EXPIRE-1
 
 Values implement `Expires` (`is_expired()`); the store consults the value, not a store-wide TTL.
-`ExpiringCache` is the default store for `#[cached(expires = true)]`.
+`ExpiringCache` is the default store for `#[cached(expires = true)]`; `ExpiringLruCache` is
+selected when `max_size` is also specified.
 
 ## EXPIRE-2
 

--- a/specs/store-lru.md
+++ b/specs/store-lru.md
@@ -26,5 +26,6 @@ Implements `Cached`, `CachedPeek`, and `CachedIter`. Size/iter/evict semantics f
 [design/0002-size-iter-evict-semantics.md](design/0002-size-iter-evict-semantics.md).
 Inherent `retain(keep)` removes entries failing the predicate (firing `on_evict` and counting
 evictions); the expiry-aware LRU stores (`LruTtlCache`, `ExpiringLruCache`) share the contract
-but also remove expired entries regardless of the predicate. `set_max_size` /
-`try_set_max_size` resize a live cache.
+but also remove expired entries regardless of the predicate. `set_max_size(n) -> Option<usize>`
+resizes a live cache (returns the previous capacity, panics on zero). `try_set_max_size(n) ->
+Result<Option<usize>, SetMaxSizeError>` is the non-panicking variant.

--- a/specs/store-redb.md
+++ b/specs/store-redb.md
@@ -2,8 +2,8 @@
 
 `RedbCache` is a disk-backed concurrent store using `redb`, gated behind `redb_store`. It is
 self-synchronizing over a shared `&self` and builder-only: `builder(name)` takes the required
-cache name positionally; the on-disk directory (`disk_dir`) is optional with a system-cache-dir
-fallback.
+cache name positionally; the on-disk directory (`disk_dir`) is optional with a user cache dir fallback
+(`BaseDirs::cache_dir()`, e.g. `~/.cache`) and a further OS temp dir fallback.
 
 ## REDB-1
 

--- a/specs/store-sharded.md
+++ b/specs/store-sharded.md
@@ -32,7 +32,7 @@ See [traits-concurrent.md](traits-concurrent.md).
 
 ## SHARD-4
 
-`ShardedUnboundCache` does not track an evictions counter (it never evicts); see the declined
+`ShardedUnboundCache` does not track an evictions counter (it never evicts on its own); see the declined
 [design/0007-unbound-evictions-counter.md](design/0007-unbound-evictions-counter.md). Open
 directions: a read-optimized sharded LRU
 ([design/0010-read-optimized-sharded-lru.md](design/0010-read-optimized-sharded-lru.md)) and

--- a/specs/store-ttl.md
+++ b/specs/store-ttl.md
@@ -13,18 +13,20 @@ removes it. `TtlCache` and `LruTtlCache` refresh the stored value's timestamp on
 
 ## TTL-2
 
-Constructors: infallible `TtlCache::new(ttl)` and `LruTtlCache::new(max_size, ttl)`, plus the
-`::builder()` form for each. TTL is set as a `Duration`; the macros accept `ttl_secs`,
-`ttl_millis`, or `ttl = "<Duration expr>"`. See [macro-cached.md](macro-cached.md).
+Constructors: infallible `TtlCache::new(ttl)`, `LruTtlCache::new(max_size, ttl)`, and
+`TtlSortedCache::new(ttl)` (all panic on zero TTL), plus the `::builder()` form for each.
+TTL is set as a `Duration`; the macros accept `ttl_secs`, `ttl_millis`, or
+`ttl = "<Duration expr>"`. See [macro-cached.md](macro-cached.md).
 
 ## TTL-3
 
-These stores implement `CacheTtl` (`ttl()` / `set_ttl()` / `unset_ttl()`). `set_ttl(0)` and the
-per-entry expiry model follow
+These stores implement `CacheTtl` (`ttl()` / `set_ttl()` / `unset_ttl()` / `try_set_ttl()` /
+`refresh_on_hit()` / `set_refresh_on_hit()`). `set_ttl(0)` and the per-entry expiry model follow
 [design/0028-per-entry-expiry-and-set-ttl-zero.md](design/0028-per-entry-expiry-and-set-ttl-zero.md).
 
 ## TTL-4
 
-`TtlSortedCache` implements `CachedRead` (shared-ref reads / `unsync_reads`); `TimedEntry<V>` is
-`pub(crate)` and not part of the public surface. Size/iter/evict semantics follow
+`TtlSortedCache` implements `CachedRead` (shared-ref reads / `unsync_reads`), `CacheTtl`,
+`CachedIter`, `CachedPeek`, and `CloneCached`; `TimedEntry<V>` is `pub(crate)` and not part of
+the public surface. Size/iter/evict semantics follow
 [design/0002-size-iter-evict-semantics.md](design/0002-size-iter-evict-semantics.md).

--- a/specs/store-unbound.md
+++ b/specs/store-unbound.md
@@ -21,7 +21,7 @@ reads (`unsync_reads` in the macros) and iteration. See [traits-core.md](traits-
 
 ## UNBOUND-4
 
-Metrics track `hits`/`misses`; `evictions` is `None` (the store never evicts). See
+Metrics track `hits`/`misses`; `evictions` is `None` (the store never evicts on its own). See
 [metrics.md](metrics.md). Iteration and size/evict semantics follow
 [design/0002-size-iter-evict-semantics.md](design/0002-size-iter-evict-semantics.md); custom
 hasher support follows [design/0001-non-sharded-custom-hasher.md](design/0001-non-sharded-custom-hasher.md).

--- a/specs/traits-concurrent.md
+++ b/specs/traits-concurrent.md
@@ -18,7 +18,9 @@ and `ConcurrentCachedAsync<K, V>` extend it, per
 `cache_remove`, `cache_remove_entry`, `cache_delete`, `cache_clear`, `cache_reset`,
 `cache_reset_metrics`, `cache_get_or_set_with`, all returning
 `Result<_, Self::Error>`). `ConcurrentCachedAsync<K, V>` is its async counterpart.
-`ConcurrentCachedExt` provides the deduplicated method names.
+`ConcurrentCachedExt` provides deduplicated short-name methods (`get`, `set`, `remove`,
+`remove_entry`, `delete`, `clear`, `reset`, `get_or_set_with`); it does not forward
+`cache_reset_metrics`.
 
 ## CTRAIT-3
 

--- a/specs/traits-core.md
+++ b/specs/traits-core.md
@@ -7,11 +7,14 @@ These take `&mut self` (exclusive ownership), distinguishing them from the concu
 
 ## TRAIT-1
 
-`Cached<K, V>` is the core: `cache_get`, `cache_get_mut`, `cache_set`, `cache_get_or_set_with`
-(and `_mut` / `try_` variants), `cache_remove`, `cache_remove_entry`, `cache_delete`,
-`cache_clear`, `cache_reset`, `cache_size`, and the metric accessors (`cache_hits` /
-`cache_misses` / `cache_capacity` / `cache_evictions`). `CachedExt` is a blanket extension trait
-providing the deduplicated method names and `metrics()`, per
+`Cached<K, V>` is the core: `cache_get`, `cache_get_mut`, `cache_set`, `cache_try_set`,
+`cache_get_or_set_with` (and `_mut` / `try_` variants), `cache_remove`, `cache_remove_entry`,
+`cache_delete`, `cache_clear`, `cache_reset`, `cache_size`, and the metric accessors
+(`cache_hits` / `cache_misses` / `cache_capacity` / `cache_evictions`). `CachedExt` is a blanket
+extension trait providing deduplicated short-name methods (`get`, `get_mut`, `set`, `try_set`,
+`get_or_set_with`, `get_or_set_with_mut`, `try_get_or_set_with`, `try_get_or_set_with_mut`,
+`remove`, `remove_entry`, `delete`, `contains`, `clear`, `len`, `is_empty`, `hits`, `misses`,
+`metrics()`), per
 [design/0008-method-name-deduplication.md](design/0008-method-name-deduplication.md).
 
 ## TRAIT-2
@@ -32,7 +35,8 @@ A `CachedPeek` / `CachedRead` merge was considered and declined; they stay disti
 ## TRAIT-4
 
 `CacheEvict` provides `evict() -> usize` to sweep expired entries (firing `on_evict`); see
-[builders.md](builders.md). `Expires` is implemented by values in the expiring stores
-(`is_expired()`); see [store-expiring.md](store-expiring.md). Whether `Cached::get` should take
+[builders.md](builders.md). `Expires` is implemented by values in the expiring stores:
+`is_expired()` (required) and `expires_at() -> Option<Instant>` (provided default: `None`);
+see [store-expiring.md](store-expiring.md). Whether `Cached::get` should take
 `&self` is an open direction
 ([design/0009-cached-get-shared-receiver.md](design/0009-cached-get-shared-receiver.md)).

--- a/src/stores/sharded/expiring_lru.rs
+++ b/src/stores/sharded/expiring_lru.rs
@@ -284,7 +284,9 @@ where
             misses: Some(misses),
             evictions: Some(inner_evictions + self.inner.evictions.load(Ordering::Relaxed)),
             entry_count: Some(size),
-            capacity: Some(self.inner.total_capacity.load(Ordering::Relaxed)),
+            // Acquire, like `capacity()`: a caller that just resized on this thread sees
+            // the new total here too, not a stale value alongside a fresh `capacity()`.
+            capacity: Some(self.inner.total_capacity.load(Ordering::Acquire)),
         }
     }
 
@@ -404,6 +406,13 @@ where
     /// across shards while the resize is in progress. The new total reported by
     /// [`capacity`](Self::capacity) is published only after every shard has adopted
     /// its new per-shard cap.
+    ///
+    /// The same applies to **concurrent callers** of `set_max_size`: two overlapping
+    /// resizes interleave their per-shard writes, so individual shards can end up
+    /// with a mix of the two targets while `capacity()` reports whichever total was
+    /// published last. No entries are lost and there is no data race, but the
+    /// resulting bound is a blend of the two requests. Serialize resizes externally
+    /// (or re-issue the desired resize) if a single consistent target matters.
     ///
     /// When the 16-per-shard minimum floor applies (small `max_size` with multiple
     /// shards), `capacity()` after the call reflects the clamped total, which may

--- a/src/stores/sharded/lru.rs
+++ b/src/stores/sharded/lru.rs
@@ -262,7 +262,9 @@ where
             misses: Some(misses),
             evictions: Some(evictions),
             entry_count: Some(size),
-            capacity: Some(self.inner.total_capacity.load(Ordering::Relaxed)),
+            // Acquire, like `capacity()`: a caller that just resized on this thread sees
+            // the new total here too, not a stale value alongside a fresh `capacity()`.
+            capacity: Some(self.inner.total_capacity.load(Ordering::Acquire)),
         }
     }
 
@@ -384,6 +386,13 @@ where
     /// across shards while the resize is in progress. The new total reported by
     /// [`capacity`](Self::capacity) is published only after every shard has adopted
     /// its new per-shard cap.
+    ///
+    /// The same applies to **concurrent callers** of `set_max_size`: two overlapping
+    /// resizes interleave their per-shard writes, so individual shards can end up
+    /// with a mix of the two targets while `capacity()` reports whichever total was
+    /// published last. No entries are lost and there is no data race, but the
+    /// resulting bound is a blend of the two requests. Serialize resizes externally
+    /// (or re-issue the desired resize) if a single consistent target matters.
     ///
     /// When the 16-per-shard minimum floor applies (small `max_size` with multiple
     /// shards), `capacity()` after the call reflects the clamped total, which may

--- a/src/stores/sharded/lru_ttl.rs
+++ b/src/stores/sharded/lru_ttl.rs
@@ -348,7 +348,9 @@ where
                 lru_evictions + self.inner.non_capacity_evictions.load(Ordering::Relaxed),
             ),
             entry_count: Some(size),
-            capacity: Some(self.inner.total_capacity.load(Ordering::Relaxed)),
+            // Acquire, like `capacity()`: a caller that just resized on this thread sees
+            // the new total here too, not a stale value alongside a fresh `capacity()`.
+            capacity: Some(self.inner.total_capacity.load(Ordering::Acquire)),
         }
     }
 
@@ -469,6 +471,13 @@ where
     /// across shards while the resize is in progress. The new total reported by
     /// [`capacity`](Self::capacity) is published only after every shard has adopted
     /// its new per-shard cap.
+    ///
+    /// The same applies to **concurrent callers** of `set_max_size`: two overlapping
+    /// resizes interleave their per-shard writes, so individual shards can end up
+    /// with a mix of the two targets while `capacity()` reports whichever total was
+    /// published last. No entries are lost and there is no data race, but the
+    /// resulting bound is a blend of the two requests. Serialize resizes externally
+    /// (or re-issue the desired resize) if a single consistent target matters.
     ///
     /// When the 16-per-shard minimum floor applies (small `max_size` with multiple
     /// shards), `capacity()` after the call reflects the clamped total, which may

--- a/tests/v3_sharded_resize.rs
+++ b/tests/v3_sharded_resize.rs
@@ -15,7 +15,6 @@ use cached::{ConcurrentCacheBase, ConcurrentCached, SetMaxSizeError};
 // ---------------------------------------------------------------------------
 
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
 struct E {
     v: u32,
 }
@@ -29,7 +28,6 @@ impl cached::Expires for E {
 /// A value whose expiry is controlled per-instance, for the expiring_lru
 /// "shrink evicts LRU-order regardless of expiry" contract test.
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
 struct ExpVal {
     v: u32,
     expired: bool,
@@ -472,6 +470,73 @@ mod lru {
             "capacity must be eventually consistent with the final resize"
         );
     }
+
+    #[test]
+    fn concurrent_resizers_no_data_race_and_next_resize_restores_consistency() {
+        // Two threads resize concurrently. The documented contract: per-shard
+        // writes interleave (shards may briefly hold a mix of the two targets),
+        // there is no data race or lost entry, capacity() reports whichever
+        // total was published last, and a subsequent single-threaded resize
+        // restores one consistent target. The same resize code is shared by
+        // ShardedLruTtlCacheBase and ShardedExpiringLruCacheBase.
+        use std::thread;
+        let c = ShardedLruCacheBase::<u32, u32>::builder()
+            .shards(8)
+            .max_size(1024)
+            .build()
+            .unwrap();
+        for i in 0..64u32 {
+            ConcurrentCached::cache_set(&c, i, i).unwrap();
+        }
+
+        // Both targets are floor-free at 8 shards (512/8=64, 2048/8=256), so
+        // capacity() must land exactly on one of them.
+        let mut resizers = Vec::new();
+        for target in [512usize, 2048] {
+            let c = c.clone();
+            resizers.push(thread::spawn(move || {
+                for _ in 0..500 {
+                    let prev = c.set_max_size(target);
+                    assert!(prev.is_some(), "set_max_size always returns Some(prev)");
+                }
+            }));
+        }
+        for h in resizers {
+            h.join().expect("resizer thread must not panic");
+        }
+
+        let settled = c.capacity();
+        assert!(
+            settled == 512 || settled == 2048,
+            "capacity() must report one of the two published totals, got {settled}"
+        );
+        assert_eq!(
+            c.metrics().capacity,
+            Some(settled),
+            "metrics().capacity must agree with capacity() once resizers are done"
+        );
+        // No lost entries beyond LRU eviction: everything still readable or evicted,
+        // and the store keeps working.
+        ConcurrentCached::cache_set(&c, 1_000_000, 1).unwrap();
+        assert_eq!(
+            ConcurrentCached::cache_get(&c, &1_000_000).unwrap(),
+            Some(1)
+        );
+
+        // One more single-threaded resize resolves any mixed per-shard state.
+        let prev = c.set_max_size(1024);
+        assert_eq!(prev, Some(settled));
+        assert_eq!(c.capacity(), 1024);
+        // The bound holds after normalization: over-filling cannot exceed the total.
+        for i in 0..8192u32 {
+            ConcurrentCached::cache_set(&c, i, i).unwrap();
+        }
+        assert!(
+            c.len() <= 1024,
+            "entry count must respect the normalized capacity, got {}",
+            c.len()
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -766,8 +831,15 @@ mod expiring_lru {
         let prev = c.set_max_size(8);
         assert_eq!(prev, Some(4));
         assert_eq!(c.capacity(), 8);
-        assert!(ConcurrentCached::cache_get(&c, &1).unwrap().is_some());
-        assert!(ConcurrentCached::cache_get(&c, &2).unwrap().is_some());
+        // Round-trip the payload, not just presence.
+        assert_eq!(
+            ConcurrentCached::cache_get(&c, &1).unwrap().map(|e| e.v),
+            Some(10)
+        );
+        assert_eq!(
+            ConcurrentCached::cache_get(&c, &2).unwrap().map(|e| e.v),
+            Some(20)
+        );
     }
 
     #[test]
@@ -972,9 +1044,10 @@ mod expiring_lru {
         );
         // Survivors: key 3 (expired but LRU-recent) and key 4 (live). A cache_get on
         // key 3 is a miss because it is expired, but it was NOT dropped by the shrink.
-        assert!(
-            ConcurrentCached::cache_get(&c, &4).unwrap().is_some(),
-            "live MRU key 4 survives"
+        assert_eq!(
+            ConcurrentCached::cache_get(&c, &4).unwrap().map(|e| e.v),
+            Some(4),
+            "live MRU key 4 survives with its payload intact"
         );
         assert_eq!(
             c.len(),


### PR DESCRIPTION
- Load `metrics().capacity` with `Acquire` on `ShardedLruCacheBase` / `ShardedLruTtlCacheBase` / `ShardedExpiringLruCacheBase`, matching `capacity()`, so the two agree after a same-thread `set_max_size`
- Document concurrent-caller semantics of `set_max_size` on the three sharded LRU stores: overlapping resizes interleave per-shard writes (no data race or lost entries, but the resulting bound blends the two targets); add a two-resizer test that also covers restoring a consistent target with a follow-up resize
- Read the value payload in the sharded resize test helpers instead of suppressing `dead_code`
- Clear the `SLOW_LOOKUP` cache at the start of the `resilience` example's `by_key` demo so the `body_runs == 1` assertion holds on repeat invocation
- Sync specs with the shipped API: `map_error` accepts a closure only; `HasEvict`/`NoEvict` type-state applies to the two `LruTtl` builders (and the root re-exports are `time_stores`-gated); redb's `disk_dir` fallback is the user cache dir then the OS temp dir; add the missing `expires` rows to the `#[concurrent_cached]` store table and its attribute list; enumerate the `CachedExt` / `ConcurrentCachedExt` surfaces, `cache_try_set`, `Expires::expires_at`, `CacheTtl` refresh methods, `TtlSortedCache` constructors/traits, and `set_max_size` return types; note the MSRV is unconditional; update stale line refs across specs/design/