### PR TITLE
release: 3.0.0-rc.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [3.0.0-rc.8 / cached_proc_macro 3.0.0-rc.8 / cached_proc_macro_types 3.0.0-rc.8] - 2026-07-17
+
 ### Breaking Changes
 
 - `#[cached]` rejects an explicit `sync_writes_buckets` when `sync_writes` is not `"by_key"` with a pointed compile error. The value was previously accepted and silently ignored (buckets only exist on the `by_key` path); `#[once]` already rejected the same inert combination.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cached"
-version = "3.0.0-rc.7"
+version = "3.0.0-rc.8"
 authors = ["James Kominick <james@kominick.com>"]
 description = "Generic cache implementations and simplified function memoization"
 repository = "https://github.com/jaemk/cached"
@@ -76,12 +76,12 @@ redb_store = ["serde", "dep:redb", "dep:directories", "dep:blocking"]
 time_stores = []
 
 [dependencies.cached_proc_macro]
-version = "3.0.0-rc.7"
+version = "3.0.0-rc.8"
 path = "cached_proc_macro"
 optional = true
 
 [dependencies.cached_proc_macro_types]
-version = "3.0.0-rc.4"
+version = "3.0.0-rc.8"
 path = "cached_proc_macro_types"
 optional = true
 

--- a/cached_proc_macro/Cargo.toml
+++ b/cached_proc_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cached_proc_macro"
-version = "3.0.0-rc.7"
+version = "3.0.0-rc.8"
 authors = ["csos95 <csoscss@gmail.com>", "James Kominick <james@kominick.com>"]
 description = "Generic cache implementations and simplified function memoization"
 repository = "https://github.com/jaemk/cached"

--- a/cached_proc_macro_types/Cargo.toml
+++ b/cached_proc_macro_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cached_proc_macro_types"
-version = "3.0.0-rc.4"
+version = "3.0.0-rc.8"
 authors = ["James Kominick <james@kominick.com>"]
 description = "Types used by the cached proc-macro crate"
 repository = "https://github.com/jaemk/cached"


### PR DESCRIPTION
- Bump `cached`, `cached_proc_macro`, and `cached_proc_macro_types` to 3.0.0-rc.8
- Move unreleased changelog entries under the 3.0.0-rc.8 heading