### PR TITLE
feat: bound trait `Error` types, add `cache_contains`, `peek`/`reset` aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- `Cached::Error` and `ConcurrentCacheBase::Error` are now bounded by
+  `std::error::Error + Send + Sync + 'static`. Custom store implementations whose error
+  type does not implement `std::error::Error` (or is not `Send`/`Sync`/`'static`) must update
+  their `type Error`. All built-in stores (`Infallible`, `CacheSetError`, `RedisCacheError`,
+  `RedbCacheError`) already satisfy the bound. See the migration guide for detection and remediation.
+
+### Added
+
+- `CachedPeek::peek`: ergonomic alias for `cache_peek`.
+- `CloneCached::peek_with_expiry_status`: ergonomic alias for `cache_peek_with_expiry_status`.
+- `ConcurrentCloneCached::peek_with_expiry_status`: ergonomic alias for
+  `cache_peek_with_expiry_status` on the concurrent clone trait.
+- `CachedExt::reset`: ergonomic alias for `Cached::cache_reset`, mirroring the existing
+  `ConcurrentCachedExt::reset`.
+- `ConcurrentCached::cache_contains`: defaulted presence check returning `Result<bool, Self::Error>`.
+  The default calls `cache_get` (counts hits/misses, touches LRU recency, clones the value). The
+  built-in sharded stores override it with an efficient peek-based implementation (read lock, no
+  clone, no recency update, no hit/miss metrics). External stores use the default.
+- `ConcurrentCachedAsync::async_cache_contains`: async counterpart of `cache_contains`, same
+  default/override split.
+- `ConcurrentCachedExt::contains`: ergonomic alias for `cache_contains`.
+- `#[must_use]` on `ConcurrentCached::cache_remove` and `cache_remove_entry`, their
+  `ConcurrentCachedAsync` counterparts `async_cache_remove` / `async_cache_remove_entry`, and the
+  `ConcurrentCachedExt` aliases `remove` / `remove_entry`.
+- `#[must_use]` on `RedbCacheError::is_deserialization`, matching `RedisCacheError::is_deserialization`.
+- `#[cfg_attr(docsrs, doc(cfg(feature = "time_stores")))]` on the `ShardedTtlCache*` and
+  `ShardedLruTtlCache*` re-exports in `src/stores/sharded/mod.rs`.
+
+### Changed
+
+- `encode_ttl`/`decode_ttl` deduplicated from `src/stores/sharded/ttl.rs` and
+  `src/stores/sharded/lru_ttl.rs` into a single `pub(crate)` copy in
+  `src/stores/sharded/mod.rs`; both files now import from there. No behavior change.
+
+### Documentation
+
+- Prelude doc corrected: it re-exports both traits and the `CacheMetrics` struct, not traits only.
+- The `compile_fail` snippet for `cache_get_or_set_with` includes a leading comment making its
+  non-compiling intent clear in the generated README (where `compile_fail` renders as plain Rust).
+- `docs/migrations/2.0-to-3.0-human.md`: added section on `Return<T>` field privatization
+  (`r.value` / `r.was_cached` -> deref / `into_inner()` / `was_cached()`).
+- `docs/migrations/2.0-to-3.0.md` and `2.0-to-3.0-human.md`: added the `Cached::Error` and
+  `ConcurrentCacheBase::Error` bound as a breaking change entry.
+- `specs/traits-core.md` and `specs/traits-concurrent.md`: updated to record `Error` bounds,
+  `peek` aliases, `reset`, `cache_contains`/`async_cache_contains`/`contains`.
+
 ## [3.0.0-rc.8 / cached_proc_macro 3.0.0-rc.8 / cached_proc_macro_types 3.0.0-rc.8] - 2026-07-17
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@ no longer compiles. Use [`cache_get_or_set_with_mut`](crate::Cached::cache_get_o
 when you need a mutable reference.
 
 ```rust
+// This does NOT compile: cache_get_or_set_with returns &V, not &mut V.
 use cached::{Cached, UnboundCache};
 
 let mut cache: UnboundCache<u32, u32> = UnboundCache::builder().build().unwrap();

--- a/docs/migrations/2.0-to-3.0-human.md
+++ b/docs/migrations/2.0-to-3.0-human.md
@@ -302,6 +302,27 @@ the `redis_async_cache` feature is enabled (it was never constructible without i
 match on it, gate the arm with `#[cfg(feature = "redis_async_cache")]` or rely on the `_` arm
 the `#[non_exhaustive]` enum already requires.
 
+### `Return<T>` fields are now private
+
+The `value` and `was_cached` fields on `Return<T>` (from `cached_proc_macro_types`) went private.
+Code that accessed them directly produces `field value of struct Return is private` or
+`field was_cached of struct Return is private` compile errors.
+
+```rust
+// Before (2.x): direct field access
+let r: Return<String> = my_cached_fn();
+println!("{}", r.value);
+if r.was_cached { ... }
+```
+
+```rust
+// After (3.x): deref, into_inner(), and was_cached()
+let r: Return<String> = my_cached_fn();
+println!("{}", *r);             // deref coerces to &T
+println!("{}", r.into_inner()); // consumes r, returns T
+if r.was_cached() { ... }
+```
+
 ---
 
 ## Cargo.toml

--- a/docs/migrations/2.0-to-3.0.md
+++ b/docs/migrations/2.0-to-3.0.md
@@ -1506,6 +1506,31 @@ use cached::ConcurrentCacheTtl; // or `use cached::prelude::*;`
 cache.set_ttl(Duration::from_secs(30));
 ```
 
+### 71. `Cached::Error` and `ConcurrentCacheBase::Error` require `std::error::Error + Send + Sync + 'static`
+
+Both associated `Error` types now carry the bound
+`std::error::Error + Send + Sync + 'static`.
+
+Detection: `the trait bound MyError: std::error::Error is not satisfied` or similar `Send`/`Sync`
+errors when implementing `Cached` or `ConcurrentCacheBase` with a custom error type.
+
+Action: implement `std::error::Error` for your error type (and ensure it is `Send + Sync + 'static`):
+```rust
+#[derive(Debug)]
+struct MyStoreError(String);
+
+impl std::fmt::Display for MyStoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "store error: {}", self.0)
+    }
+}
+
+impl std::error::Error for MyStoreError {}
+```
+Using `thiserror::Error` derive satisfies the bound automatically.
+All built-in error types (`std::convert::Infallible`, `CacheSetError`, `RedisCacheError`,
+`RedbCacheError`) already satisfy the bound and require no changes.
+
 ## Required Cargo.toml change
 
 ```toml

--- a/specs/traits-concurrent.md
+++ b/specs/traits-concurrent.md
@@ -6,21 +6,24 @@ redis, and redb stores. Distinct from the `&mut self` single-owner family in
 
 ## CTRAIT-1
 
-`ConcurrentCacheBase` is the shared supertrait: it owns the associated `type Error`, the
-`cache_size` / `cache_is_empty` accessors, the metric accessors (`cache_hits` / `cache_misses` /
-`cache_capacity` / `cache_evictions`), and a provided `metrics()`. Both `ConcurrentCached<K, V>`
-and `ConcurrentCachedAsync<K, V>` extend it, per
-[design/0012-concurrent-metrics-trait.md](design/0012-concurrent-metrics-trait.md).
+`ConcurrentCacheBase` is the shared supertrait: it owns the associated `type Error` (bounded by
+`std::error::Error + Send + Sync + 'static`), the `cache_size` / `cache_is_empty` accessors, the
+metric accessors (`cache_hits` / `cache_misses` / `cache_capacity` / `cache_evictions`), and a
+provided `metrics()`. Both `ConcurrentCached<K, V>` and `ConcurrentCachedAsync<K, V>` extend it,
+per [design/0012-concurrent-metrics-trait.md](design/0012-concurrent-metrics-trait.md).
 
 ## CTRAIT-2
 
 `ConcurrentCached<K, V>` is the sync self-synchronizing API (`cache_get`, `cache_set`,
-`cache_remove`, `cache_remove_entry`, `cache_delete`, `cache_clear`, `cache_reset`,
-`cache_reset_metrics`, `cache_get_or_set_with`, all returning
-`Result<_, Self::Error>`). `ConcurrentCachedAsync<K, V>` is its async counterpart.
-`ConcurrentCachedExt` provides deduplicated short-name methods (`get`, `set`, `remove`,
-`remove_entry`, `delete`, `clear`, `reset`, `get_or_set_with`); it does not forward
-`cache_reset_metrics`.
+`cache_remove`, `cache_remove_entry`, `cache_delete`, `cache_contains`, `cache_clear`,
+`cache_reset`, `cache_reset_metrics`, `cache_get_or_set_with`, all returning
+`Result<_, Self::Error>`). `cache_contains` has a default that calls `cache_get` (counts
+hits/misses, clones the value); the built-in sharded stores override it with a peek-based
+implementation (read lock, no clone, no metrics). `ConcurrentCachedAsync<K, V>` is its async
+counterpart, adding `async_cache_contains`. `ConcurrentCachedExt` provides deduplicated short-name
+methods (`get`, `set`, `remove`, `remove_entry`, `delete`, `contains`, `clear`, `reset`,
+`get_or_set_with`); it does not forward `cache_reset_metrics` or `cache_contains` directly
+(use `contains` via the ext trait).
 
 ## CTRAIT-3
 

--- a/specs/traits-core.md
+++ b/specs/traits-core.md
@@ -10,27 +10,29 @@ These take `&mut self` (exclusive ownership), distinguishing them from the concu
 `Cached<K, V>` is the core: `cache_get`, `cache_get_mut`, `cache_set`, `cache_try_set`,
 `cache_get_or_set_with` (and `_mut` / `try_` variants), `cache_remove`, `cache_remove_entry`,
 `cache_delete`, `cache_clear`, `cache_reset`, `cache_size`, and the metric accessors
-(`cache_hits` / `cache_misses` / `cache_capacity` / `cache_evictions`). `CachedExt` is a blanket
-extension trait providing deduplicated short-name methods (`get`, `get_mut`, `set`, `try_set`,
-`get_or_set_with`, `get_or_set_with_mut`, `try_get_or_set_with`, `try_get_or_set_with_mut`,
-`remove`, `remove_entry`, `delete`, `contains`, `clear`, `len`, `is_empty`, `hits`, `misses`,
-`metrics()`), per
+(`cache_hits` / `cache_misses` / `cache_capacity` / `cache_evictions`). `Cached::Error` is bounded
+by `std::error::Error + Send + Sync + 'static` so generic callers can `?`-propagate or `.unwrap()`
+without extra where-clauses. `CachedExt` is a blanket extension trait providing deduplicated
+short-name methods (`get`, `get_mut`, `set`, `try_set`, `get_or_set_with`, `get_or_set_with_mut`,
+`try_get_or_set_with`, `try_get_or_set_with_mut`, `remove`, `remove_entry`, `delete`, `contains`,
+`clear`, `reset`, `len`, `is_empty`, `hits`, `misses`, `metrics()`), per
 [design/0008-method-name-deduplication.md](design/0008-method-name-deduplication.md).
 
 ## TRAIT-2
 
-`CachedPeek<K, V>` provides `cache_peek` (non-mutating, skips recency/TTL refresh and metrics).
-`CachedRead<K, V>: CachedPeek` adds `cache_get_read` for shared-ref reads (backs `unsync_reads`).
-A `CachedPeek` / `CachedRead` merge was considered and declined; they stay distinct on purpose
-(`CachedRead` is a compile-time capability marker), per
+`CachedPeek<K, V>` provides `cache_peek` (non-mutating, skips recency/TTL refresh and metrics)
+and a `peek` alias. `CachedRead<K, V>: CachedPeek` adds `cache_get_read` for shared-ref reads
+(backs `unsync_reads`). A `CachedPeek` / `CachedRead` merge was considered and declined; they stay
+distinct on purpose (`CachedRead` is a compile-time capability marker), per
 [design/0023-peek-read-trait-merge.md](design/0023-peek-read-trait-merge.md).
 
 ## TRAIT-3
 
 `CachedIter<K, V>` iterates entries (filtering expired ones without removing them).
-`CloneCached<K, V>` returns owned values with expiry status (`cache_get_with_expiry_status`,
-`cache_peek_with_expiry_status`). `CacheTtl` provides `ttl()` / `set_ttl()` / `unset_ttl()` /
-`try_set_ttl()` / `refresh_on_hit()` / `set_refresh_on_hit()` on single-owner timed stores.
+`CloneCached<K, V>` returns owned values with expiry status (`cache_get_with_expiry_status` /
+`get_with_expiry_status`, `cache_peek_with_expiry_status` / `peek_with_expiry_status`). `CacheTtl`
+provides `ttl()` / `set_ttl()` / `unset_ttl()` / `try_set_ttl()` / `refresh_on_hit()` /
+`set_refresh_on_hit()` on single-owner timed stores.
 
 ## TRAIT-4
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -455,6 +455,7 @@ no longer compiles. Use [`cache_get_or_set_with_mut`](crate::Cached::cache_get_o
 when you need a mutable reference.
 
 ```compile_fail
+// This does NOT compile: cache_get_or_set_with returns &V, not &mut V.
 use cached::{Cached, UnboundCache};
 
 let mut cache: UnboundCache<u32, u32> = UnboundCache::builder().build().unwrap();
@@ -825,8 +826,9 @@ impl<C, B> std::ops::Deref for KeyedCache<C, B> {
 /// especially handy for the `ConcurrentCached` family, whose methods (`cache_get`,
 /// `cache_set`, …) are trait methods and require the trait to be in scope to call.
 ///
-/// Only traits are re-exported here; concrete store types are intentionally omitted to
-/// avoid name clashes. Import those directly (e.g. `use cached::ShardedUnboundCache;`).
+/// Traits and the `CacheMetrics` snapshot struct are re-exported here; concrete store types
+/// are intentionally omitted to avoid name clashes. Import those directly
+/// (e.g. `use cached::ShardedUnboundCache;`).
 pub mod prelude {
     pub use crate::{
         CacheEvict, CacheMetrics, Cached, CachedExt, CachedIter, CachedPeek, CachedRead,
@@ -893,7 +895,12 @@ pub trait Cached<K, V> {
     /// Use [`std::convert::Infallible`] for stores where insertion can never fail.
     /// TTL-capable stores that may overflow `Instant` bounds use
     /// [`CacheSetError`].
-    type Error;
+    ///
+    /// The bound `std::error::Error + Send + Sync + 'static` lets generic code call
+    /// `.unwrap()` on `Result<_, Self::Error>`, propagate with `?` into
+    /// `Box<dyn std::error::Error>`, and send/share the error across threads without
+    /// additional where-clauses at every use site.
+    type Error: std::error::Error + Send + Sync + 'static;
 
     // ── Core required methods (stores implement these) ────────────────────
 
@@ -1220,6 +1227,10 @@ pub trait CachedExt<K, V>: Cached<K, V> {
     /// [`cache_clear`](Cached::cache_clear).
     fn clear(&mut self);
 
+    /// Remove all entries and reset metrics to zero. Delegates to
+    /// [`cache_reset`](Cached::cache_reset).
+    fn reset(&mut self);
+
     /// Return the number of entries currently in the cache. Delegates to
     /// [`cache_size`](Cached::cache_size).
     ///
@@ -1331,6 +1342,10 @@ impl<K, V, T: Cached<K, V>> CachedExt<K, V> for T {
 
     fn clear(&mut self) {
         self.cache_clear()
+    }
+
+    fn reset(&mut self) {
+        self.cache_reset()
     }
 
     fn len(&self) -> usize {
@@ -1462,6 +1477,15 @@ pub trait CachedPeek<K, V> {
     where
         K: std::borrow::Borrow<Q>,
         Q: std::hash::Hash + Eq + ?Sized;
+
+    /// Ergonomic alias for [`cache_peek`](Self::cache_peek).
+    fn peek<Q>(&self, k: &Q) -> Option<&V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
+        self.cache_peek(k)
+    }
 }
 
 /// Shared-reference cache lookup for stores that can preserve normal read semantics without an
@@ -1556,6 +1580,16 @@ pub trait CloneCached<K, V> {
         K: std::borrow::Borrow<Q>,
         Q: std::hash::Hash + Eq + ?Sized,
         V: Clone;
+
+    /// Ergonomic alias for [`cache_peek_with_expiry_status`](Self::cache_peek_with_expiry_status).
+    fn peek_with_expiry_status<Q>(&self, key: &Q) -> (Option<V>, bool)
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+        V: Clone,
+    {
+        self.cache_peek_with_expiry_status(key)
+    }
 }
 
 /// Concurrent analogue of [`CloneCached`] for the internally-synchronized sharded stores.
@@ -1631,6 +1665,11 @@ pub trait ConcurrentCloneCached<K, V> {
     /// This is used on the `force_refresh` bypass path of `#[concurrent_cached(result_fallback = true)]`
     /// to capture the stale fallback value without touching counters or recency.
     fn cache_peek_with_expiry_status(&self, key: &K) -> (Option<V>, bool);
+
+    /// Ergonomic alias for [`cache_peek_with_expiry_status`](Self::cache_peek_with_expiry_status).
+    fn peek_with_expiry_status(&self, key: &K) -> (Option<V>, bool) {
+        self.cache_peek_with_expiry_status(key)
+    }
 }
 
 /// TTL management for single-owner time-bounded cache stores.
@@ -1811,7 +1850,12 @@ pub trait CachedGetOrSetAsync<K, V> {
 /// `type Error` and any `cache_size`/metric overrides live.
 pub trait ConcurrentCacheBase {
     /// The error type returned by fallible cache operations.
-    type Error;
+    ///
+    /// The bound `std::error::Error + Send + Sync + 'static` lets generic code call
+    /// `.unwrap()` on `Result<_, Self::Error>`, propagate with `?` into
+    /// `Box<dyn std::error::Error>`, and send/share the error across threads without
+    /// additional where-clauses at every use site.
+    type Error: std::error::Error + Send + Sync + 'static;
 
     /// Report the number of entries currently held by the store, if the store can
     /// determine it cheaply.
@@ -2076,6 +2120,7 @@ pub trait ConcurrentCached<K, V>: ConcurrentCacheBase {
     /// # Errors
     ///
     /// Should return `Self::Error` if the operation fails
+    #[must_use = "cache_remove returns the previous value; ignoring it discards the displaced entry"]
     fn cache_remove(&self, k: &K) -> Result<Option<V>, Self::Error>;
 
     /// Remove a cached entry, returning the stored key and value whenever an entry
@@ -2131,6 +2176,7 @@ pub trait ConcurrentCached<K, V>: ConcurrentCacheBase {
     /// // Returns None only when the key was never present.
     /// assert_eq!(cache.remove_entry(&"missing".to_string()), None);
     /// ```
+    #[must_use = "cache_remove_entry returns the previous entry; ignoring it discards the displaced key and value"]
     fn cache_remove_entry(&self, k: &K) -> Result<Option<(K, V)>, Self::Error>;
 
     /// Delete a cached value without returning or decoding the stored value.
@@ -2146,6 +2192,27 @@ pub trait ConcurrentCached<K, V>: ConcurrentCacheBase {
     /// Should return `Self::Error` if the operation fails
     fn cache_delete(&self, k: &K) -> Result<bool, Self::Error> {
         self.cache_remove_entry(k).map(|removed| removed.is_some())
+    }
+
+    /// Return `true` if the cache contains a live value for the given key.
+    ///
+    /// The default implementation calls [`cache_get`](ConcurrentCached::cache_get), which
+    /// **counts a hit or miss, touches LRU recency on sharded LRU stores, and clones the value**.
+    /// The built-in sharded in-memory stores override this with an efficient peek-based
+    /// implementation that does not clone the value, update recency, or record hit/miss metrics.
+    /// External stores (`RedisCache`, `AsyncRedisCache`, `RedbCache`) use the default.
+    ///
+    /// The `where Self: Sized` bound keeps this generic method out of the vtable.
+    ///
+    /// # Errors
+    ///
+    /// Should return `Self::Error` if the operation fails.
+    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
+    where
+        Self: Sized,
+        V: Clone,
+    {
+        self.cache_get(k).map(|v| v.is_some())
     }
 
     /// Remove all cached entries while preserving capacity allocation and metrics.
@@ -2254,10 +2321,12 @@ pub trait ConcurrentCachedExt<K, V>: ConcurrentCached<K, V> {
 
     /// Remove a cached value and return it. Delegates to
     /// [`cache_remove`](ConcurrentCached::cache_remove).
+    #[must_use = "remove returns the previous value; ignoring it discards the displaced entry"]
     fn remove(&self, k: &K) -> Result<Option<V>, Self::Error>;
 
     /// Remove a cached entry and return the stored key and value. Delegates to
     /// [`cache_remove_entry`](ConcurrentCached::cache_remove_entry).
+    #[must_use = "remove_entry returns the previous entry; ignoring it discards the displaced key and value"]
     fn remove_entry(&self, k: &K) -> Result<Option<(K, V)>, Self::Error>;
 
     /// Delete a cached value without returning it. Delegates to
@@ -2271,6 +2340,12 @@ pub trait ConcurrentCachedExt<K, V>: ConcurrentCached<K, V> {
     /// Remove all entries and reset the cache to its initial state. Delegates to
     /// [`cache_reset`](ConcurrentCached::cache_reset).
     fn reset(&self) -> Result<(), Self::Error>;
+
+    /// Return `true` if the cache contains a live value for the given key. Delegates to
+    /// [`cache_contains`](ConcurrentCached::cache_contains).
+    fn contains(&self, k: &K) -> Result<bool, Self::Error>
+    where
+        V: Clone;
 
     /// Return the cached value for `k`, or compute and store `f()`. Delegates to
     /// [`cache_get_or_set_with`](ConcurrentCached::cache_get_or_set_with).
@@ -2306,6 +2381,13 @@ impl<K, V, T: ConcurrentCached<K, V>> ConcurrentCachedExt<K, V> for T {
 
     fn reset(&self) -> Result<(), Self::Error> {
         self.cache_reset()
+    }
+
+    fn contains(&self, k: &K) -> Result<bool, Self::Error>
+    where
+        V: Clone,
+    {
+        self.cache_contains(k)
     }
 
     fn get_or_set_with<F: FnOnce() -> V>(&self, k: K, f: F) -> Result<V, Self::Error>
@@ -2374,6 +2456,7 @@ pub trait ConcurrentCachedAsync<K, V>: ConcurrentCacheBase {
     ) -> impl Future<Output = Result<Option<V>, Self::Error>> + Send;
 
     /// Remove a cached value, returning it if it was both present and still live.
+    #[must_use = "async_cache_remove returns the previous value; ignoring it discards the displaced entry"]
     #[doc(alias = "async_remove")]
     #[doc(alias = "cache_remove")]
     fn async_cache_remove(
@@ -2383,6 +2466,7 @@ pub trait ConcurrentCachedAsync<K, V>: ConcurrentCacheBase {
 
     /// Remove a cached entry, returning the stored key and value whenever an entry
     /// was physically deleted — including entries that were present but already expired.
+    #[must_use = "async_cache_remove_entry returns the previous entry; ignoring it discards the displaced key and value"]
     #[doc(alias = "async_remove_entry")]
     #[doc(alias = "cache_remove_entry")]
     fn async_cache_remove_entry(
@@ -2401,6 +2485,28 @@ pub trait ConcurrentCachedAsync<K, V>: ConcurrentCacheBase {
         K: Sync,
     {
         async move { self.async_cache_remove_entry(k).await.map(|r| r.is_some()) }
+    }
+
+    /// Return `true` if the cache contains a live value for the given key.
+    ///
+    /// The default implementation calls
+    /// [`async_cache_get`](ConcurrentCachedAsync::async_cache_get), which
+    /// **counts a hit or miss, touches LRU recency on sharded LRU stores, and clones the value**.
+    /// The built-in sharded in-memory stores override this with an efficient peek-based
+    /// implementation that does not clone the value, update recency, or record hit/miss metrics.
+    /// External stores (`AsyncRedisCache`, `RedbCache`) use the default.
+    ///
+    /// # Errors
+    ///
+    /// Should return `Self::Error` if the operation fails.
+    #[doc(alias = "cache_contains")]
+    fn async_cache_contains(&self, k: &K) -> impl Future<Output = Result<bool, Self::Error>> + Send
+    where
+        Self: Sized + Sync,
+        K: Sync,
+        V: Clone + Send,
+    {
+        async move { self.async_cache_get(k).await.map(|v| v.is_some()) }
     }
 
     /// Remove all cached entries while preserving capacity allocation and metrics.

--- a/src/stores/redb.rs
+++ b/src/stores/redb.rs
@@ -767,6 +767,7 @@ impl RedbCacheError {
         }
     }
     /// Returns `true` if this error is a deserialization failure.
+    #[must_use]
     pub fn is_deserialization(&self) -> bool {
         matches!(self, Self::CacheDeserialization { .. })
     }

--- a/src/stores/sharded/expiring.rs
+++ b/src/stores/sharded/expiring.rs
@@ -12,6 +12,8 @@ use std::collections::HashMap;
 #[cfg(feature = "async_core")]
 use crate::ConcurrentCachedAsync;
 use crate::{CacheMetrics, ConcurrentCacheBase, ConcurrentCached, ConcurrentCloneCached, Expires};
+#[cfg(feature = "async_core")]
+use core::future::Future;
 
 use super::{
     CachePadded, DefaultShardHasher, Shard, ShardHasher, checked_shard_count, shard_index,
@@ -550,6 +552,17 @@ where
         self.inner.evictions.store(0, Ordering::Relaxed);
         Ok(())
     }
+
+    /// Efficient peek-based contains: acquires a read lock, does not clone the value,
+    /// and does not record hit/miss metrics. Returns `true` only for live (not expired) entries.
+    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
+    where
+        Self: Sized,
+        V: Clone,
+    {
+        let shard = self.shard_of(k);
+        Ok(shard.lock.read().get(k).is_some_and(|v| !v.is_expired()))
+    }
 }
 
 #[cfg(feature = "async_core")]
@@ -585,6 +598,18 @@ where
 
     async fn async_cache_reset_metrics(&self) -> Result<(), Self::Error> {
         ConcurrentCached::cache_reset_metrics(self)
+    }
+
+    /// Efficient peek-based contains: does not clone the value, does not record hit/miss metrics,
+    /// and returns `true` only for live (not expired) entries.
+    fn async_cache_contains(&self, k: &K) -> impl Future<Output = Result<bool, Self::Error>> + Send
+    where
+        Self: Sized + Sync,
+        K: Sync,
+        V: Clone + Send,
+    {
+        let result = ConcurrentCached::cache_contains(self, k);
+        async move { result }
     }
 }
 

--- a/src/stores/sharded/expiring_lru.rs
+++ b/src/stores/sharded/expiring_lru.rs
@@ -8,6 +8,8 @@ use crate::{
     CacheMetrics, CachedIter, CachedPeek, ConcurrentCacheBase, ConcurrentCached,
     ConcurrentCloneCached, Expires,
 };
+#[cfg(feature = "async_core")]
+use core::future::Future;
 
 use super::{
     CachePadded, DefaultShardHasher, Shard, ShardHasher, checked_shard_count,
@@ -663,6 +665,23 @@ where
         self.inner.evictions.store(0, Ordering::Relaxed);
         Ok(())
     }
+
+    /// Efficient peek-based contains: acquires a read lock, does not clone the value, does not
+    /// update LRU recency, and does not record hit/miss metrics. Returns `true` only for live
+    /// (not expired) entries.
+    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
+    where
+        Self: Sized,
+        V: Clone,
+    {
+        use crate::CachedPeek;
+        let shard = self.shard_of(k);
+        Ok(shard
+            .lock
+            .read()
+            .cache_peek(k)
+            .is_some_and(|v| !v.is_expired()))
+    }
 }
 
 #[cfg(feature = "async_core")]
@@ -698,6 +717,18 @@ where
 
     async fn async_cache_reset_metrics(&self) -> Result<(), Self::Error> {
         ConcurrentCached::cache_reset_metrics(self)
+    }
+
+    /// Efficient peek-based contains: does not clone the value, does not update LRU recency,
+    /// does not record hit/miss metrics, and returns `true` only for live (not expired) entries.
+    fn async_cache_contains(&self, k: &K) -> impl Future<Output = Result<bool, Self::Error>> + Send
+    where
+        Self: Sized + Sync,
+        K: Sync,
+        V: Clone + Send,
+    {
+        let result = ConcurrentCached::cache_contains(self, k);
+        async move { result }
     }
 }
 

--- a/src/stores/sharded/lru.rs
+++ b/src/stores/sharded/lru.rs
@@ -5,6 +5,8 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 #[cfg(feature = "async_core")]
 use crate::ConcurrentCachedAsync;
 use crate::{CacheMetrics, CachedIter, ConcurrentCacheBase, ConcurrentCached};
+#[cfg(feature = "async_core")]
+use core::future::Future;
 
 use super::{
     CachePadded, DefaultShardHasher, Shard, ShardHasher, checked_shard_count,
@@ -559,6 +561,18 @@ where
         }
         Ok(())
     }
+
+    /// Efficient peek-based contains: acquires a read lock, does not clone the value,
+    /// does not update LRU recency, and does not record hit/miss metrics.
+    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
+    where
+        Self: Sized,
+        V: Clone,
+    {
+        use crate::CachedPeek;
+        let shard = self.shard_of(k);
+        Ok(shard.lock.read().cache_peek(k).is_some())
+    }
 }
 
 #[cfg(feature = "async_core")]
@@ -594,6 +608,18 @@ where
 
     async fn async_cache_reset_metrics(&self) -> Result<(), Self::Error> {
         ConcurrentCached::cache_reset_metrics(self)
+    }
+
+    /// Efficient peek-based contains: does not clone the value, does not update LRU
+    /// recency, and does not record hit/miss metrics.
+    fn async_cache_contains(&self, k: &K) -> impl Future<Output = Result<bool, Self::Error>> + Send
+    where
+        Self: Sized + Sync,
+        K: Sync,
+        V: Clone + Send,
+    {
+        let result = ConcurrentCached::cache_contains(self, k);
+        async move { result }
     }
 }
 

--- a/src/stores/sharded/lru_ttl.rs
+++ b/src/stores/sharded/lru_ttl.rs
@@ -3,24 +3,6 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 
-/// Encode a TTL into the `ttl_nanos` atomic. A zero duration encodes as `0`
-/// (expiry disabled / no expiry).
-#[inline]
-fn encode_ttl(ttl: Duration) -> u64 {
-    ttl.as_nanos().min(u64::MAX as u128) as u64
-}
-
-/// Decode the `ttl_nanos` atomic into an optional TTL. `0` means expiry is
-/// disabled (entries never expire), so it decodes to `None`.
-#[inline]
-fn decode_ttl(nanos: u64) -> Option<Duration> {
-    if nanos == 0 {
-        None
-    } else {
-        Some(Duration::from_nanos(nanos))
-    }
-}
-
 #[cfg(feature = "async_core")]
 use crate::ConcurrentCachedAsync;
 use crate::time::{Duration, Instant};
@@ -28,10 +10,12 @@ use crate::{
     CacheMetrics, ConcurrentCacheBase, ConcurrentCacheEvict, ConcurrentCacheTtl, ConcurrentCached,
     ConcurrentCloneCached,
 };
+#[cfg(feature = "async_core")]
+use core::future::Future;
 
 use super::{
-    CachePadded, DefaultShardHasher, Shard, ShardHasher, checked_shard_count,
-    per_shard_cap_from_total, shard_index,
+    CachePadded, DefaultShardHasher, Shard, ShardHasher, checked_shard_count, decode_ttl,
+    encode_ttl, per_shard_cap_from_total, shard_index,
 };
 use crate::stores::{BuildError, HasEvict, LruCache, NoEvict, TimedEntry};
 use crate::{Cached, CachedIter, CachedPeek};
@@ -814,6 +798,21 @@ where
             .store(0, Ordering::Relaxed);
         Ok(())
     }
+
+    /// Efficient peek-based contains: acquires a read lock, does not clone the value, does not
+    /// update LRU recency, and does not record hit/miss metrics. Returns `true` only for live
+    /// (not expired) entries.
+    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
+    where
+        Self: Sized,
+        V: Clone,
+    {
+        let shard = self.shard_of(k);
+        let guard = shard.lock.read();
+        Ok(guard
+            .cache_peek(k)
+            .is_some_and(|entry| entry.expires_at.is_none_or(|t| Instant::now() < t)))
+    }
 }
 
 #[cfg(feature = "async_core")]
@@ -849,6 +848,18 @@ where
 
     async fn async_cache_reset_metrics(&self) -> Result<(), Self::Error> {
         ConcurrentCached::cache_reset_metrics(self)
+    }
+
+    /// Efficient peek-based contains: does not clone the value, does not update LRU recency,
+    /// does not record hit/miss metrics, and returns `true` only for live (not expired) entries.
+    fn async_cache_contains(&self, k: &K) -> impl Future<Output = Result<bool, Self::Error>> + Send
+    where
+        Self: Sized + Sync,
+        K: Sync,
+        V: Clone + Send,
+    {
+        let result = ConcurrentCached::cache_contains(self, k);
+        async move { result }
     }
 }
 

--- a/src/stores/sharded/mod.rs
+++ b/src/stores/sharded/mod.rs
@@ -106,6 +106,26 @@ pub(crate) fn shard_index(hash: u64, mask: usize) -> usize {
     (hash >> 32) as usize & mask
 }
 
+/// Encode a TTL into a nanosecond atomic. A zero duration encodes as `0`
+/// (expiry disabled / no expiry).
+#[cfg(feature = "time_stores")]
+#[inline]
+pub(crate) fn encode_ttl(ttl: crate::time::Duration) -> u64 {
+    ttl.as_nanos().min(u64::MAX as u128) as u64
+}
+
+/// Decode the nanosecond atomic into an optional TTL. `0` means expiry is
+/// disabled (entries never expire), so it decodes to `None`.
+#[cfg(feature = "time_stores")]
+#[inline]
+pub(crate) fn decode_ttl(nanos: u64) -> Option<crate::time::Duration> {
+    if nanos == 0 {
+        None
+    } else {
+        Some(crate::time::Duration::from_nanos(nanos))
+    }
+}
+
 /// Trait for types that deterministically map a key to a `u64` shard hash.
 ///
 /// No `K: Hash` bound on the trait itself — custom impls can partition by
@@ -218,9 +238,11 @@ pub use lru::{ShardedLruCache, ShardedLruCacheBase, ShardedLruCacheBuilder};
 pub use unbound::{ShardedUnboundCache, ShardedUnboundCacheBase, ShardedUnboundCacheBuilder};
 
 #[cfg(feature = "time_stores")]
+#[cfg_attr(docsrs, doc(cfg(feature = "time_stores")))]
 pub use ttl::{ShardedTtlCache, ShardedTtlCacheBase, ShardedTtlCacheBuilder};
 
 #[cfg(feature = "time_stores")]
+#[cfg_attr(docsrs, doc(cfg(feature = "time_stores")))]
 pub use lru_ttl::{ShardedLruTtlCache, ShardedLruTtlCacheBase, ShardedLruTtlCacheBuilder};
 
 #[cfg(test)]

--- a/src/stores/sharded/ttl.rs
+++ b/src/stores/sharded/ttl.rs
@@ -2,24 +2,6 @@ use std::hash::Hash;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
-/// Encode a TTL into the `ttl_nanos` atomic. A zero duration encodes as `0`
-/// (expiry disabled / no expiry).
-#[inline]
-fn encode_ttl(ttl: Duration) -> u64 {
-    ttl.as_nanos().min(u64::MAX as u128) as u64
-}
-
-/// Decode the `ttl_nanos` atomic into an optional TTL. `0` means expiry is
-/// disabled (entries never expire), so it decodes to `None`.
-#[inline]
-fn decode_ttl(nanos: u64) -> Option<Duration> {
-    if nanos == 0 {
-        None
-    } else {
-        Some(Duration::from_nanos(nanos))
-    }
-}
-
 #[cfg(feature = "ahash")]
 use ahash::RandomState;
 #[cfg(not(feature = "ahash"))]
@@ -34,9 +16,12 @@ use crate::{
     CacheMetrics, ConcurrentCacheBase, ConcurrentCacheEvict, ConcurrentCacheTtl, ConcurrentCached,
     ConcurrentCloneCached,
 };
+#[cfg(feature = "async_core")]
+use core::future::Future;
 
 use super::{
-    CachePadded, DefaultShardHasher, Shard, ShardHasher, checked_shard_count, shard_index,
+    CachePadded, DefaultShardHasher, Shard, ShardHasher, checked_shard_count, decode_ttl,
+    encode_ttl, shard_index,
 };
 use crate::stores::{BuildError, TimedEntry};
 
@@ -685,6 +670,18 @@ where
         self.inner.evictions.store(0, Ordering::Relaxed);
         Ok(())
     }
+
+    /// Efficient peek-based contains: acquires a read lock, does not clone the value,
+    /// and does not record hit/miss metrics. Returns `true` only for live (not expired) entries.
+    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
+    where
+        Self: Sized,
+        V: Clone,
+    {
+        let shard = self.shard_of(k);
+        let guard = shard.lock.read();
+        Ok(guard.get(k).is_some_and(|entry| !self.is_expired(entry)))
+    }
 }
 
 #[cfg(feature = "async_core")]
@@ -720,6 +717,18 @@ where
 
     async fn async_cache_reset_metrics(&self) -> Result<(), Self::Error> {
         ConcurrentCached::cache_reset_metrics(self)
+    }
+
+    /// Efficient peek-based contains: does not clone the value, does not record hit/miss
+    /// metrics, and returns `true` only for live (not expired) entries.
+    fn async_cache_contains(&self, k: &K) -> impl Future<Output = Result<bool, Self::Error>> + Send
+    where
+        Self: Sized + Sync,
+        K: Sync,
+        V: Clone + Send,
+    {
+        let result = ConcurrentCached::cache_contains(self, k);
+        async move { result }
     }
 }
 

--- a/src/stores/sharded/unbound.rs
+++ b/src/stores/sharded/unbound.rs
@@ -12,6 +12,8 @@ use std::collections::HashMap;
 #[cfg(feature = "async_core")]
 use crate::ConcurrentCachedAsync;
 use crate::{CacheMetrics, ConcurrentCacheBase, ConcurrentCached};
+#[cfg(feature = "async_core")]
+use core::future::Future;
 
 use super::{
     CachePadded, DefaultShardHasher, Shard, ShardHasher, checked_shard_count, shard_index,
@@ -424,6 +426,17 @@ where
         }
         Ok(())
     }
+
+    /// Efficient peek-based contains: acquires a read lock, does not clone the value,
+    /// and does not record hit/miss metrics.
+    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
+    where
+        Self: Sized,
+        V: Clone,
+    {
+        let shard = self.shard_of(k);
+        Ok(shard.lock.read().contains_key(k))
+    }
 }
 
 #[cfg(feature = "async_core")]
@@ -459,6 +472,18 @@ where
 
     async fn async_cache_reset_metrics(&self) -> Result<(), Self::Error> {
         ConcurrentCached::cache_reset_metrics(self)
+    }
+
+    /// Efficient peek-based contains: does not clone the value and does not record
+    /// hit/miss metrics.
+    fn async_cache_contains(&self, k: &K) -> impl Future<Output = Result<bool, Self::Error>> + Send
+    where
+        Self: Sized + Sync,
+        K: Sync,
+        V: Clone + Send,
+    {
+        let result = ConcurrentCached::cache_contains(self, k);
+        async move { result }
     }
 }
 

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -8814,7 +8814,10 @@ fn clone_cached_peek_with_expiry_status_alias_reports_expired() {
     // Expired entry: alias must report the stale value AND expired == true.
     let (val, expired) = cache.peek_with_expiry_status(&"k".to_string());
     assert_eq!(val, Some(5u32), "peek must return the stale value");
-    assert!(expired, "peek_with_expiry_status must flag the entry expired");
+    assert!(
+        expired,
+        "peek_with_expiry_status must flag the entry expired"
+    );
 }
 
 #[cfg(feature = "time_stores")]
@@ -8834,7 +8837,10 @@ fn concurrent_clone_cached_peek_with_expiry_status_alias_reports_expired() {
 
     let (val, expired) = cache.peek_with_expiry_status(&"k".to_string());
     assert_eq!(val, Some(5u32), "peek must return the stale value");
-    assert!(expired, "peek_with_expiry_status must flag the entry expired");
+    assert!(
+        expired,
+        "peek_with_expiry_status must flag the entry expired"
+    );
 }
 
 // ── Certification gap-fill: ConcurrentCachedExt::contains alias on an expiring ─

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -8213,3 +8213,649 @@ mod len_iter_evict_contract_sharded_expiring {
         );
     }
 }
+
+// ── Item 1: Cached::Error bound ──────────────────────────────────────────────
+
+/// A generic function over Cached that ?-propagates Cached::Error.
+/// Compiles only if Error: std::error::Error + Send + Sync + 'static.
+#[allow(dead_code)]
+fn cached_error_propagate<K, V, C>(
+    cache: &mut C,
+    k: K,
+    v: V,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    K: std::hash::Hash + Eq,
+    C: cached::Cached<K, V>,
+{
+    // ? works only if Self::Error: Into<Box<dyn std::error::Error>>,
+    // which requires std::error::Error + Send + Sync + 'static.
+    cache.cache_try_set(k, v)?;
+    Ok(())
+}
+
+/// A generic function that ?-propagates Cached::Error into Box<dyn std::error::Error>.
+/// Compiles only if Error: std::error::Error + Send + Sync + 'static.
+#[allow(dead_code)]
+fn cached_error_question_mark<K, V, C>(
+    cache: &mut C,
+    k: K,
+    v: V,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    K: std::hash::Hash + Eq,
+    C: cached::Cached<K, V>,
+{
+    cache.cache_try_set(k, v)?;
+    Ok(())
+}
+
+/// A generic function over ConcurrentCached that calls .unwrap() and ?-propagates errors.
+/// Compiles only if ConcurrentCacheBase::Error satisfies the bound.
+#[allow(dead_code)]
+fn concurrent_error_question_mark<K, V, C>(
+    cache: &C,
+    k: K,
+    v: V,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    K: std::hash::Hash + Eq + Clone,
+    V: Clone,
+    C: cached::ConcurrentCached<K, V>,
+{
+    cache.cache_set(k, v)?;
+    Ok(())
+}
+
+#[test]
+fn cached_error_bound_allows_unwrap_and_question_mark() {
+    // Calls the generic functions with a concrete store; proves the bound is satisfied at runtime.
+    let mut cache = UnboundCache::<String, u32>::builder().build().unwrap();
+    cached_error_question_mark(&mut cache, "k".to_string(), 1).unwrap();
+
+    let sharded = cached::ShardedUnboundCache::<String, u32>::builder()
+        .build()
+        .unwrap();
+    concurrent_error_question_mark(&sharded, "k".to_string(), 1).unwrap();
+}
+
+// ── Item 2: peek short aliases ────────────────────────────────────────────────
+
+#[test]
+fn cached_peek_alias_works_via_prelude() {
+    use cached::UnboundCache;
+    use cached::prelude::*;
+    let mut cache = UnboundCache::<String, u32>::builder().build().unwrap();
+    cache.set("key".to_string(), 42u32);
+    // peek alias delegates to cache_peek; does not require mutable access.
+    assert_eq!(cache.peek("key"), Some(&42u32));
+    assert_eq!(cache.peek("missing"), None);
+}
+
+#[cfg(feature = "time_stores")]
+#[test]
+fn clone_cached_peek_with_expiry_status_alias_works() {
+    use cached::TtlCache;
+    use cached::prelude::*;
+    use cached::time::Duration;
+    let mut cache = TtlCache::<String, u32>::builder()
+        .ttl(Duration::from_secs(60))
+        .build()
+        .unwrap();
+    cache.set("k".to_string(), 1u32);
+    // peek_with_expiry_status alias delegates to cache_peek_with_expiry_status.
+    let (val, expired) = cache.peek_with_expiry_status(&"k".to_string());
+    assert_eq!(val, Some(1u32));
+    assert!(!expired);
+    let (val2, expired2) = cache.peek_with_expiry_status(&"missing".to_string());
+    assert_eq!(val2, None);
+    assert!(!expired2);
+}
+
+#[cfg(feature = "time_stores")]
+#[test]
+fn concurrent_clone_cached_peek_with_expiry_status_alias_works() {
+    use cached::ShardedTtlCache;
+    use cached::prelude::*;
+    use cached::time::Duration;
+    let cache = ShardedTtlCache::<String, u32>::builder()
+        .ttl(Duration::from_secs(60))
+        .build()
+        .unwrap();
+    cache.set("k".to_string(), 1u32);
+    // peek_with_expiry_status alias on ConcurrentCloneCached.
+    let (val, expired) = cache.peek_with_expiry_status(&"k".to_string());
+    assert_eq!(val, Some(1u32));
+    assert!(!expired);
+}
+
+// ── Item 3a: CachedExt::reset alias ──────────────────────────────────────────
+
+#[test]
+fn cached_ext_reset_clears_entries_and_metrics() {
+    use cached::UnboundCache;
+    use cached::prelude::*;
+    let mut cache = UnboundCache::<String, u32>::builder().build().unwrap();
+    cache.set("k".to_string(), 1u32);
+    cache.get("k");
+    assert_eq!(cache.len(), 1);
+    assert_eq!(cache.hits(), Some(1));
+
+    cache.reset();
+
+    assert_eq!(cache.len(), 0, "reset() must clear entries");
+    assert_eq!(cache.hits(), Some(0), "reset() must zero metrics");
+}
+
+// ── Item 3b: ConcurrentCachedExt::contains + recency / hit-count contracts ───
+
+#[test]
+fn concurrent_contains_sharded_lru_no_recency_change() {
+    use cached::{ConcurrentCacheBase, ConcurrentCachedExt, ShardedLruCache};
+    // Build a 3-slot LRU: insert A, B, C in order so A is LRU.
+    let cache = ShardedLruCache::<u32, u32>::builder()
+        .max_size(3)
+        .shards(1) // single shard for deterministic eviction order
+        .build()
+        .unwrap();
+    cache.set(1u32, 10u32);
+    cache.set(2u32, 20u32);
+    cache.set(3u32, 30u32);
+
+    // Before contains: 1 is LRU (inserted first). Snapshot hits.
+    let hits_before = ConcurrentCacheBase::cache_hits(&cache).unwrap_or(0);
+    let misses_before = ConcurrentCacheBase::cache_misses(&cache).unwrap_or(0);
+
+    // contains() must not change recency of key 1.
+    let present = ConcurrentCachedExt::contains(&cache, &1u32).unwrap();
+    assert!(present, "key 1 is present");
+
+    let hits_after = ConcurrentCacheBase::cache_hits(&cache).unwrap_or(0);
+    let misses_after = ConcurrentCacheBase::cache_misses(&cache).unwrap_or(0);
+
+    assert_eq!(
+        hits_after, hits_before,
+        "contains() must not increment hit counter"
+    );
+    assert_eq!(
+        misses_after, misses_before,
+        "contains() must not increment miss counter"
+    );
+
+    // Insert a 4th key; if contains() had promoted key 1 to MRU, key 2 would be evicted.
+    // Without promotion, key 1 (LRU) is evicted.
+    cache.set(4u32, 40u32);
+
+    // Key 1 should have been evicted (it was LRU and contains() must not have changed that).
+    let k1_present = ConcurrentCachedExt::contains(&cache, &1u32).unwrap();
+    assert!(
+        !k1_present,
+        "key 1 must be evicted (LRU) -- contains() must not update recency"
+    );
+
+    // Keys 2, 3, 4 must still be present.
+    assert!(ConcurrentCachedExt::contains(&cache, &2u32).unwrap());
+    assert!(ConcurrentCachedExt::contains(&cache, &3u32).unwrap());
+    assert!(ConcurrentCachedExt::contains(&cache, &4u32).unwrap());
+}
+
+#[test]
+fn concurrent_contains_returns_false_for_absent_key() {
+    use cached::{ConcurrentCachedExt, ShardedUnboundCache};
+    let cache = ShardedUnboundCache::<String, u32>::builder()
+        .build()
+        .unwrap();
+    cache.set("present".to_string(), 1u32);
+    assert!(ConcurrentCachedExt::contains(&cache, &"present".to_string()).unwrap());
+    assert!(!ConcurrentCachedExt::contains(&cache, &"absent".to_string()).unwrap());
+}
+
+/// Generic trait usage: contains() on any ConcurrentCached without extra where-clauses.
+#[allow(dead_code)]
+fn generic_concurrent_contains<K, V, C>(cache: &C, k: &K) -> bool
+where
+    K: std::hash::Hash + Eq + Clone,
+    V: Clone,
+    C: cached::ConcurrentCached<K, V>,
+{
+    cache.cache_contains(k).unwrap_or(false)
+}
+
+#[test]
+fn concurrent_contains_generic_usage_compiles_and_works() {
+    use cached::ShardedUnboundCache;
+    let cache = ShardedUnboundCache::<String, u32>::builder()
+        .build()
+        .unwrap();
+    cache.set("x".to_string(), 99u32);
+    assert!(generic_concurrent_contains(&cache, &"x".to_string()));
+    assert!(!generic_concurrent_contains(&cache, &"y".to_string()));
+}
+
+// ── Certification gap-fills: sync cache_contains expiry-awareness on the ─────
+//    TTL-family and per-value-expiry sharded overrides. The overrides in
+//    ttl.rs / lru_ttl.rs / expiring.rs / expiring_lru.rs must return `false`
+//    for a present-but-expired entry (peek-based, not cache_get-based), and
+//    must not touch hit/miss metrics on any of the six stores.
+
+/// A per-value `Expires` value with a settable flag, for the expiring sharded stores.
+#[derive(Clone)]
+struct ContainsExpirable {
+    expired: bool,
+}
+
+impl cached::Expires for ContainsExpirable {
+    fn is_expired(&self) -> bool {
+        self.expired
+    }
+}
+
+#[cfg(feature = "time_stores")]
+#[test]
+fn sharded_ttl_cache_contains_is_expiry_aware_and_metric_neutral() {
+    use cached::time::Duration;
+    use cached::{ConcurrentCacheBase, ConcurrentCached, ShardedTtlCache};
+
+    let cache = ShardedTtlCache::<u32, u32>::builder()
+        .ttl(Duration::from_millis(20))
+        .build()
+        .unwrap();
+    cache.set(1, 10);
+
+    // Live entry: contains == true, no hit/miss recorded.
+    let hits_before = ConcurrentCacheBase::cache_hits(&cache).unwrap_or(0);
+    let misses_before = ConcurrentCacheBase::cache_misses(&cache).unwrap_or(0);
+    assert!(
+        ConcurrentCached::cache_contains(&cache, &1).unwrap(),
+        "live TTL entry must be contained"
+    );
+    assert!(
+        !ConcurrentCached::cache_contains(&cache, &99).unwrap(),
+        "absent key must not be contained"
+    );
+    assert_eq!(
+        ConcurrentCacheBase::cache_hits(&cache).unwrap_or(0),
+        hits_before,
+        "cache_contains must not record a hit"
+    );
+    assert_eq!(
+        ConcurrentCacheBase::cache_misses(&cache).unwrap_or(0),
+        misses_before,
+        "cache_contains must not record a miss"
+    );
+
+    // Expired entry (still physically present, unswept): contains == false.
+    std::thread::sleep(std::time::Duration::from_millis(40));
+    assert_eq!(cache.len(), 1, "expired entry is still stored (unswept)");
+    assert!(
+        !ConcurrentCached::cache_contains(&cache, &1).unwrap(),
+        "expired TTL entry must NOT be contained"
+    );
+    // The false result came from the peek override, not cache_get eviction.
+    assert_eq!(
+        cache.len(),
+        1,
+        "cache_contains must not evict the expired entry"
+    );
+}
+
+#[cfg(feature = "time_stores")]
+#[test]
+fn sharded_lru_ttl_cache_contains_is_expiry_aware() {
+    use cached::time::Duration;
+    use cached::{ConcurrentCached, ShardedLruTtlCache};
+
+    let cache = ShardedLruTtlCache::<u32, u32>::builder()
+        .max_size(10)
+        .ttl(Duration::from_millis(20))
+        .build()
+        .unwrap();
+    cache.set(1, 10);
+    assert!(ConcurrentCached::cache_contains(&cache, &1).unwrap());
+    assert!(!ConcurrentCached::cache_contains(&cache, &99).unwrap());
+
+    std::thread::sleep(std::time::Duration::from_millis(40));
+    assert!(
+        !ConcurrentCached::cache_contains(&cache, &1).unwrap(),
+        "expired LRU+TTL entry must NOT be contained"
+    );
+}
+
+#[test]
+fn sharded_expiring_cache_contains_is_expiry_aware() {
+    use cached::{ConcurrentCached, ShardedExpiringCache};
+
+    let cache = ShardedExpiringCache::<u32, ContainsExpirable>::builder()
+        .build()
+        .unwrap();
+    cache.set(1, ContainsExpirable { expired: false });
+    cache.set(2, ContainsExpirable { expired: true });
+
+    assert!(
+        ConcurrentCached::cache_contains(&cache, &1).unwrap(),
+        "live per-value entry must be contained"
+    );
+    assert!(
+        !ConcurrentCached::cache_contains(&cache, &2).unwrap(),
+        "expired per-value entry must NOT be contained"
+    );
+    assert!(
+        !ConcurrentCached::cache_contains(&cache, &99).unwrap(),
+        "absent key must not be contained"
+    );
+    // Neither call should have evicted the expired entry.
+    assert_eq!(cache.len(), 2, "cache_contains must not evict entries");
+}
+
+#[test]
+fn sharded_expiring_lru_cache_contains_is_expiry_aware() {
+    use cached::{ConcurrentCached, ShardedExpiringLruCache};
+
+    let cache = ShardedExpiringLruCache::<u32, ContainsExpirable>::builder()
+        .max_size(10)
+        .build()
+        .unwrap();
+    cache.set(1, ContainsExpirable { expired: false });
+    cache.set(2, ContainsExpirable { expired: true });
+
+    assert!(ConcurrentCached::cache_contains(&cache, &1).unwrap());
+    assert!(
+        !ConcurrentCached::cache_contains(&cache, &2).unwrap(),
+        "expired per-value LRU entry must NOT be contained"
+    );
+    assert!(!ConcurrentCached::cache_contains(&cache, &99).unwrap());
+    assert_eq!(cache.len(), 2, "cache_contains must not evict entries");
+}
+
+// ── Certification gap-fills: async_cache_contains overrides. The implementor ─
+//    only tested the sync path. These exercise the async overrides on a
+//    non-TTL LRU store and TTL/expiring stores: absent -> false, live -> true,
+//    expired -> false, and no hit/miss metric or recency change.
+
+#[cfg(feature = "async")]
+#[tokio::test]
+async fn async_contains_sharded_lru_no_recency_or_metric_change() {
+    use cached::{ConcurrentCacheBase, ConcurrentCachedAsync, ShardedLruCache};
+
+    // Single shard, 3 slots: 1 is LRU after inserting 1,2,3.
+    let cache = ShardedLruCache::<u32, u32>::builder()
+        .max_size(3)
+        .shards(1)
+        .build()
+        .unwrap();
+    ConcurrentCachedAsync::async_cache_set(&cache, 1, 10)
+        .await
+        .unwrap();
+    ConcurrentCachedAsync::async_cache_set(&cache, 2, 20)
+        .await
+        .unwrap();
+    ConcurrentCachedAsync::async_cache_set(&cache, 3, 30)
+        .await
+        .unwrap();
+
+    let hits_before = ConcurrentCacheBase::cache_hits(&cache).unwrap_or(0);
+    let misses_before = ConcurrentCacheBase::cache_misses(&cache).unwrap_or(0);
+
+    assert!(
+        ConcurrentCachedAsync::async_cache_contains(&cache, &1)
+            .await
+            .unwrap(),
+        "live key present"
+    );
+    assert!(
+        !ConcurrentCachedAsync::async_cache_contains(&cache, &99)
+            .await
+            .unwrap(),
+        "absent key -> false"
+    );
+
+    assert_eq!(
+        ConcurrentCacheBase::cache_hits(&cache).unwrap_or(0),
+        hits_before,
+        "async_cache_contains must not record a hit"
+    );
+    assert_eq!(
+        ConcurrentCacheBase::cache_misses(&cache).unwrap_or(0),
+        misses_before,
+        "async_cache_contains must not record a miss"
+    );
+
+    // If contains() had promoted key 1 to MRU, inserting a 4th key would evict
+    // key 2 instead of key 1. Without promotion, key 1 (LRU) is evicted.
+    ConcurrentCachedAsync::async_cache_set(&cache, 4, 40)
+        .await
+        .unwrap();
+    assert!(
+        !ConcurrentCachedAsync::async_cache_contains(&cache, &1)
+            .await
+            .unwrap(),
+        "key 1 must be evicted (LRU): async_cache_contains must not update recency"
+    );
+    assert!(
+        ConcurrentCachedAsync::async_cache_contains(&cache, &2)
+            .await
+            .unwrap()
+    );
+    assert!(
+        ConcurrentCachedAsync::async_cache_contains(&cache, &3)
+            .await
+            .unwrap()
+    );
+    assert!(
+        ConcurrentCachedAsync::async_cache_contains(&cache, &4)
+            .await
+            .unwrap()
+    );
+}
+
+#[cfg(all(feature = "async", feature = "time_stores"))]
+#[tokio::test]
+async fn async_contains_sharded_ttl_is_expiry_aware() {
+    use cached::time::Duration;
+    use cached::{ConcurrentCachedAsync, ShardedTtlCache};
+
+    let cache = ShardedTtlCache::<u32, u32>::builder()
+        .ttl(Duration::from_millis(20))
+        .build()
+        .unwrap();
+    ConcurrentCachedAsync::async_cache_set(&cache, 1, 10)
+        .await
+        .unwrap();
+
+    assert!(
+        ConcurrentCachedAsync::async_cache_contains(&cache, &1)
+            .await
+            .unwrap(),
+        "live TTL entry -> true"
+    );
+    assert!(
+        !ConcurrentCachedAsync::async_cache_contains(&cache, &99)
+            .await
+            .unwrap(),
+        "absent key -> false"
+    );
+
+    std::thread::sleep(std::time::Duration::from_millis(40));
+    assert!(
+        !ConcurrentCachedAsync::async_cache_contains(&cache, &1)
+            .await
+            .unwrap(),
+        "expired TTL entry -> false"
+    );
+    assert_eq!(
+        cache.len(),
+        1,
+        "async_cache_contains must not evict the expired entry"
+    );
+}
+
+#[cfg(feature = "async")]
+#[tokio::test]
+async fn async_contains_sharded_expiring_is_expiry_aware() {
+    use cached::{ConcurrentCachedAsync, ShardedExpiringCache};
+
+    let cache = ShardedExpiringCache::<u32, ContainsExpirable>::builder()
+        .build()
+        .unwrap();
+    ConcurrentCachedAsync::async_cache_set(&cache, 1, ContainsExpirable { expired: false })
+        .await
+        .unwrap();
+    ConcurrentCachedAsync::async_cache_set(&cache, 2, ContainsExpirable { expired: true })
+        .await
+        .unwrap();
+
+    assert!(
+        ConcurrentCachedAsync::async_cache_contains(&cache, &1)
+            .await
+            .unwrap(),
+        "live per-value entry -> true"
+    );
+    assert!(
+        !ConcurrentCachedAsync::async_cache_contains(&cache, &2)
+            .await
+            .unwrap(),
+        "expired per-value entry -> false"
+    );
+    assert!(
+        !ConcurrentCachedAsync::async_cache_contains(&cache, &99)
+            .await
+            .unwrap(),
+        "absent key -> false"
+    );
+}
+
+// ── Certification gap-fill: the DEFAULT cache_contains path (via cache_get) on ─
+//    a store WITHOUT an override. RedbCache uses the trait default, so this
+//    exercises `cache_get(k).map(|v| v.is_some())`. Documented side effects
+//    (hit counting) are acceptable here; we assert only the correct result and
+//    the documented expiry behavior (cache_get skips expired -> contains false).
+
+#[cfg(feature = "redb_store")]
+#[test]
+fn redb_default_cache_contains_returns_correct_results() {
+    use cached::time::Duration;
+    use cached::{ConcurrentCached, RedbCache};
+
+    let cache = RedbCache::<String, u32>::builder("redb_default_contains_correctness")
+        .ttl(Duration::from_secs(30))
+        .build()
+        .expect("build redb cache");
+    // Start clean so a prior run's on-disk state cannot skew results.
+    ConcurrentCached::cache_clear(&cache).expect("clear");
+
+    assert!(
+        !ConcurrentCached::cache_contains(&cache, &"k".to_string()).expect("contains absent"),
+        "absent key must not be contained (default path)"
+    );
+
+    ConcurrentCached::cache_set(&cache, "k".to_string(), 7).expect("set");
+    assert!(
+        ConcurrentCached::cache_contains(&cache, &"k".to_string()).expect("contains present"),
+        "present key must be contained via the default cache_get-based path"
+    );
+
+    // Also reachable through the ext-trait alias.
+    use cached::ConcurrentCachedExt;
+    assert!(ConcurrentCachedExt::contains(&cache, &"k".to_string()).expect("ext contains"));
+    assert!(!ConcurrentCachedExt::contains(&cache, &"missing".to_string()).expect("ext contains"));
+
+    ConcurrentCached::cache_clear(&cache).expect("clean up");
+}
+
+#[cfg(feature = "redb_store")]
+#[test]
+fn redb_default_cache_contains_is_expiry_aware() {
+    use cached::time::Duration;
+    use cached::{ConcurrentCached, RedbCache};
+
+    // Very short TTL: after it lapses, cache_get returns None for the entry,
+    // so the default cache_contains must report false.
+    let cache = RedbCache::<String, u32>::builder("redb_default_contains_expiry")
+        .ttl(Duration::from_millis(50))
+        .build()
+        .expect("build redb cache");
+    ConcurrentCached::cache_clear(&cache).expect("clear");
+
+    ConcurrentCached::cache_set(&cache, "k".to_string(), 1).expect("set");
+    assert!(
+        ConcurrentCached::cache_contains(&cache, &"k".to_string()).expect("live contains"),
+        "freshly-set redb entry must be contained"
+    );
+
+    std::thread::sleep(std::time::Duration::from_millis(80));
+    assert!(
+        !ConcurrentCached::cache_contains(&cache, &"k".to_string()).expect("expired contains"),
+        "expired redb entry must NOT be contained (default path follows cache_get)"
+    );
+
+    ConcurrentCached::cache_clear(&cache).expect("clean up");
+}
+
+// ── Certification gap-fill: peek_with_expiry_status aliases on EXPIRED entries. ─
+//    The dev tests only cover the live path. On an expired-but-present entry the
+//    alias must forward the (Some(stale_value), true) tuple from the underlying
+//    cache_peek_with_expiry_status without refreshing or mutating.
+
+#[cfg(feature = "time_stores")]
+#[test]
+fn clone_cached_peek_with_expiry_status_alias_reports_expired() {
+    use cached::TtlCache;
+    use cached::prelude::*;
+    use cached::time::Duration;
+
+    let mut cache = TtlCache::<String, u32>::builder()
+        .ttl(Duration::from_millis(20))
+        .build()
+        .unwrap();
+    cache.set("k".to_string(), 5u32);
+
+    std::thread::sleep(std::time::Duration::from_millis(40));
+
+    // Expired entry: alias must report the stale value AND expired == true.
+    let (val, expired) = cache.peek_with_expiry_status(&"k".to_string());
+    assert_eq!(val, Some(5u32), "peek must return the stale value");
+    assert!(expired, "peek_with_expiry_status must flag the entry expired");
+}
+
+#[cfg(feature = "time_stores")]
+#[test]
+fn concurrent_clone_cached_peek_with_expiry_status_alias_reports_expired() {
+    use cached::ShardedTtlCache;
+    use cached::prelude::*;
+    use cached::time::Duration;
+
+    let cache = ShardedTtlCache::<String, u32>::builder()
+        .ttl(Duration::from_millis(20))
+        .build()
+        .unwrap();
+    cache.set("k".to_string(), 5u32);
+
+    std::thread::sleep(std::time::Duration::from_millis(40));
+
+    let (val, expired) = cache.peek_with_expiry_status(&"k".to_string());
+    assert_eq!(val, Some(5u32), "peek must return the stale value");
+    assert!(expired, "peek_with_expiry_status must flag the entry expired");
+}
+
+// ── Certification gap-fill: ConcurrentCachedExt::contains alias on an expiring ─
+//    store must be expiry-aware too (delegates to the peek-based override).
+
+#[test]
+fn concurrent_contains_ext_alias_expiry_aware_on_expiring_store() {
+    use cached::{ConcurrentCachedExt, ShardedExpiringCache};
+
+    let cache = ShardedExpiringCache::<u32, ContainsExpirable>::builder()
+        .build()
+        .unwrap();
+    cache.set(1, ContainsExpirable { expired: false });
+    cache.set(2, ContainsExpirable { expired: true });
+
+    assert!(
+        ConcurrentCachedExt::contains(&cache, &1).unwrap(),
+        "live entry contained via ext alias"
+    );
+    assert!(
+        !ConcurrentCachedExt::contains(&cache, &2).unwrap(),
+        "expired entry not contained via ext alias"
+    );
+}


### PR DESCRIPTION
- Bound `Cached::Error` and `ConcurrentCacheBase::Error` with `std::error::Error + Send + Sync + 'static` so generic code can unwrap, log, and `?`-propagate store errors. Breaking for custom store impls; all built-in error types already satisfy the bound. Migration guides, changelog, and specs updated.
- Add `ConcurrentCached::cache_contains` and `ConcurrentCachedAsync::async_cache_contains` (defaulted via `cache_get`) with peek-based overrides on all sharded stores (read lock, no clone, no recency update, no hit/miss metrics), plus `ConcurrentCachedExt::contains`
- Add `CachedPeek::peek`, `CloneCached::peek_with_expiry_status`, `ConcurrentCloneCached::peek_with_expiry_status`, and `CachedExt::reset` aliases
- Add `#[must_use]` to the concurrent `cache_remove`/`cache_remove_entry` family and `RedbCacheError::is_deserialization`
- Add docs.rs cfg badges to the sharded `time_stores` re-exports
- Dedupe sharded `encode_ttl`/`decode_ttl` into `sharded/mod.rs`
- Document `Return` field privatization in the human migration guide, fix the prelude doc (`CacheMetrics` is re-exported), and mark the `cache_get_or_set_with` `compile_fail` snippet as non-compiling in the generated README
- Tests: error-bound generic usage, alias coverage, `contains` expiry-awareness and recency/metric neutrality on sync and async paths, redb default-impl path
