### PR TITLE
feat: require unbounded `cache_contains`, peek-based `contains` parity, remove inherent `TtlSortedCache::set_ttl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@
   type does not implement `std::error::Error` (or is not `Send`/`Sync`/`'static`) must update
   their `type Error`. All built-in stores (`Infallible`, `CacheSetError`, `RedisCacheError`,
   `RedbCacheError`) already satisfy the bound. See the migration guide for detection and remediation.
+- `ConcurrentCached::cache_contains` and `ConcurrentCachedAsync::async_cache_contains` are now
+  required methods, no longer defaulted, and no longer carry a `V: Clone` (async: `V: Clone + Send`)
+  bound. External implementors of `ConcurrentCached` / `ConcurrentCachedAsync` must add these
+  methods; the previous defaulted version only ever shipped in 3.0.0 rcs. Rationale: the `V: Clone`
+  bound blocked `contains` for non-Clone value types and could not be relaxed after 3.0.0 without
+  another breaking change. `ConcurrentCachedExt::contains` also drops its `V: Clone` bound.
+- `TtlSortedCache::set_ttl` inherent method removed. Runtime TTL controls are now only on the
+  traits: `CacheTtl` for single-owner stores, `ConcurrentCacheTtl` for concurrent stores. Migration:
+  `use cached::CacheTtl;` and the same `cache.set_ttl(d)` call compiles with identical semantics.
+- `CachedExt::contains` now delegates to `Cached::cache_contains` (new, defaulted; built-ins
+  override with a peek-based implementation) instead of `cache_get`. As a result `contains` no
+  longer counts a hit/miss, promotes LRU recency, or refreshes TTL on refresh-on-hit stores, and
+  reports expired entries as absent. This only affects the rc surface; the trait-level default of
+  `Cached::cache_contains` remains get-based for third-party stores that do not override it.
 
 ### Added
 
@@ -18,13 +32,23 @@
   `cache_peek_with_expiry_status` on the concurrent clone trait.
 - `CachedExt::reset`: ergonomic alias for `Cached::cache_reset`, mirroring the existing
   `ConcurrentCachedExt::reset`.
-- `ConcurrentCached::cache_contains`: defaulted presence check returning `Result<bool, Self::Error>`.
-  The default calls `cache_get` (counts hits/misses, touches LRU recency, clones the value). The
-  built-in sharded stores override it with an efficient peek-based implementation (read lock, no
-  clone, no recency update, no hit/miss metrics). External stores use the default.
-- `ConcurrentCachedAsync::async_cache_contains`: async counterpart of `cache_contains`, same
-  default/override split.
-- `ConcurrentCachedExt::contains`: ergonomic alias for `cache_contains`.
+- `Cached::cache_contains<Q>(&mut self, k: &Q) -> bool`: defaulted presence check on the core
+  single-owner trait (default get-based; built-in stores override with a peek-based implementation).
+  `CachedExt::contains` delegates to it, giving `contains` both spellings on both trait families.
+- `ConcurrentCached::cache_contains`: required presence check returning `Result<bool, Self::Error>`,
+  no `V: Clone` bound. The built-in sharded stores use a peek-based implementation (read lock, no
+  clone, no recency update, no hit/miss metrics); `RedisCache` / `AsyncRedisCache` / `RedbCache`
+  use a get-based implementation. External implementors of `ConcurrentCached` must add this method.
+- `ConcurrentCachedAsync::async_cache_contains`: required async counterpart of `cache_contains`,
+  no `V: Clone + Send` bound; same impl split as the sync method. External implementors of
+  `ConcurrentCachedAsync` must add this method.
+- `ConcurrentCachedExt::contains`: ergonomic alias for `cache_contains`, no `V: Clone` bound.
+- Inherent `contains(&self, &K) -> bool` on all six sharded stores: peek-based, infallible,
+  takes call-site priority over `ConcurrentCachedExt::contains` (consistent with the other
+  inherent shims like `get`/`set`/`reset`).
+- `ExpiringLruCache::iter_order` / `key_order` / `value_order`: recency-order introspection
+  matching `LruCache` (plain `(K, V)` / `K` / `V` shapes; expired entries excluded), completing
+  the LRU-family parity started with `retain`.
 - `#[must_use]` on `ConcurrentCached::cache_remove` and `cache_remove_entry`, their
   `ConcurrentCachedAsync` counterparts `async_cache_remove` / `async_cache_remove_entry`, and the
   `ConcurrentCachedExt` aliases `remove` / `remove_entry`.
@@ -49,6 +73,14 @@
   `ConcurrentCacheBase::Error` bound as a breaking change entry.
 - `specs/traits-core.md` and `specs/traits-concurrent.md`: updated to record `Error` bounds,
   `peek` aliases, `reset`, `cache_contains`/`async_cache_contains`/`contains`.
+- `docs/migrations/2.0-to-3.0.md` and `2.0-to-3.0-human.md`: added entries for required
+  `cache_contains`/`async_cache_contains`, `TtlSortedCache::set_ttl` inherent removal, and the
+  single-owner `contains` semantic change.
+- `specs/traits-core.md`: added `Cached::cache_contains` defaulted method and updated
+  `CachedExt::contains` delegation.
+- `specs/traits-concurrent.md`: updated `cache_contains`/`async_cache_contains` to required,
+  unbounded; updated ext alias and IO store impls.
+- `specs/store-sharded.md`: added inherent `contains` to the sharded store inherent-shim list.
 
 ## [3.0.0-rc.8 / cached_proc_macro 3.0.0-rc.8 / cached_proc_macro_types 3.0.0-rc.8] - 2026-07-17
 

--- a/docs/migrations/2.0-to-3.0-human.md
+++ b/docs/migrations/2.0-to-3.0-human.md
@@ -323,6 +323,40 @@ println!("{}", r.into_inner()); // consumes r, returns T
 if r.was_cached() { ... }
 ```
 
+### `cache_contains` / `async_cache_contains` are now required on the concurrent traits
+
+If you have a custom `impl ConcurrentCached` or `impl ConcurrentCachedAsync` for your own store,
+you must add these methods. The `V: Clone` bound that was on the defaulted rc versions is gone.
+
+```rust
+fn cache_contains(&self, k: &K) -> Result<bool, Self::Error> {
+    self.cache_get(k).map(|v| v.is_some())
+}
+
+async fn async_cache_contains(&self, k: &K) -> Result<bool, Self::Error> {
+    self.async_cache_get(k).await.map(|v| v.is_some())
+}
+```
+
+If you only use the built-in sharded, redis, or redb stores, no change is needed.
+
+### `TtlSortedCache::set_ttl` inherent method removed
+
+Call `set_ttl` through the `CacheTtl` trait (same as `TtlCache` and `LruTtlCache`):
+
+```rust
+use cached::CacheTtl; // or `use cached::prelude::*;`
+cache.set_ttl(Duration::from_secs(30));
+```
+
+### `contains` on single-owner stores is now peek-based (rc-only behavior change)
+
+`CachedExt::contains` delegates to `Cached::cache_contains`, which the built-in stores implement
+with a side-effect-free peek. Previously it called `cache_get`, which counted a hit/miss, promoted
+LRU recency, and refreshed TTL on refresh-on-hit stores. The new implementation does none of those
+things and reports expired entries as absent. No code change is required; this is a behavioral
+note for callers who relied on the side effects of the old `contains`.
+
 ---
 
 ## Cargo.toml

--- a/docs/migrations/2.0-to-3.0.md
+++ b/docs/migrations/2.0-to-3.0.md
@@ -1531,6 +1531,75 @@ Using `thiserror::Error` derive satisfies the bound automatically.
 All built-in error types (`std::convert::Infallible`, `CacheSetError`, `RedisCacheError`,
 `RedbCacheError`) already satisfy the bound and require no changes.
 
+### 72. `ConcurrentCached::cache_contains` and `async_cache_contains` are now required; `V: Clone` bound removed
+
+`cache_contains` on `ConcurrentCached` and `async_cache_contains` on `ConcurrentCachedAsync` are
+now required methods. The previous defaulted versions (shipped only in 3.0.0 rcs) carried a
+`V: Clone` (async: `V: Clone + Send`) bound; the required methods drop that bound entirely.
+`ConcurrentCachedExt::contains` also drops its `V: Clone` bound.
+
+Built-in stores: the six sharded stores keep their peek-based implementations (read lock, no
+clone, no metrics); `RedisCache`, `AsyncRedisCache`, and `RedbCache` gain explicit get-based
+implementations.
+
+Detection: grep your code for `impl ConcurrentCached` and `impl ConcurrentCachedAsync` on your
+own store types. Any such impl now fails with `E0046` ("not all trait items implemented, missing:
+`cache_contains`") if the method is absent.
+
+Action: add both methods to each impl. A get-based body is the simplest correct implementation:
+
+```rust
+impl ConcurrentCached<String, u32> for MyStore {
+    // ...existing methods...
+    fn cache_contains(&self, k: &String) -> Result<bool, Self::Error> {
+        self.cache_get(k).map(|v| v.is_some())
+    }
+}
+
+impl ConcurrentCachedAsync<String, u32> for MyStore {
+    // ...existing methods...
+    async fn async_cache_contains(&self, k: &String) -> Result<bool, Self::Error> {
+        self.async_cache_get(k).await.map(|v| v.is_some())
+    }
+}
+```
+
+### 73. `TtlSortedCache::set_ttl` inherent method removed; use `CacheTtl`
+
+The inherent `set_ttl` method on `TtlSortedCache` is removed. Runtime TTL controls are now only
+on the traits: `CacheTtl` for single-owner stores, `ConcurrentCacheTtl` for concurrent stores.
+This matches the pattern established for `TtlCache` / `LruTtlCache` (see #20) and for the
+sharded TTL stores (see #70).
+
+Detection: grep for `\.set_ttl(` on a `TtlSortedCache` value where `use cached::CacheTtl` (or
+`use cached::prelude::*`) is not already in scope. A `no method named set_ttl found for struct
+TtlSortedCache` error surfaces at the call site.
+
+Action: import the trait. The call is otherwise unchanged:
+
+```rust
+use cached::CacheTtl; // or `use cached::prelude::*;`
+// Before (inherent, no import needed)
+cache.set_ttl(Duration::from_secs(30));
+// After (same call, trait must be in scope)
+cache.set_ttl(Duration::from_secs(30));
+```
+
+Note: `unset_ttl`, `ttl`, `refresh_on_hit`, and `set_refresh_on_hit` were already trait-only on
+`TtlSortedCache`; only `set_ttl` had an inherent duplicate that is now removed.
+
+### Single-owner `contains` semantic change (rc surface only; no code change required)
+
+`CachedExt::contains` now delegates to `Cached::cache_contains` (a new defaulted method on
+`Cached`; built-in stores override it with a peek-based implementation) instead of delegating to
+`cache_get`. As a result, `contains` on the built-in single-owner stores no longer counts a
+hit/miss, promotes LRU recency, or refreshes the TTL on refresh-on-hit stores. Expired entries
+are now reported as absent (`false`) rather than triggering eviction and returning a miss.
+
+No code change is required. The trait-level default of `Cached::cache_contains` remains
+get-based, so a custom `impl Cached` that does not override `cache_contains` keeps the previous
+side-effecting behavior.
+
 ## Required Cargo.toml change
 
 ```toml

--- a/specs/store-sharded.md
+++ b/specs/store-sharded.md
@@ -26,7 +26,10 @@ Sharded stores implement the concurrent trait family: `ConcurrentCacheBase`,
 TTL variants; `ConcurrentCacheEvict` and `ConcurrentCloneCached` on the four expiry-capable
 variants (TTL and expiring). The runtime TTL controls (`ttl`/`set_ttl`/`unset_ttl`/
 `refresh_on_hit`/`set_refresh_on_hit`) exist only on `ConcurrentCacheTtl`, not as inherent
-methods. Metrics are exposed through the trait per
+methods. Each of the six concrete sharded types also exposes inherent shims that return unwrapped
+values and take call-site priority over the `ConcurrentCachedExt` aliases: `get`, `set`, `remove`,
+`remove_entry`, `delete`, `reset`, and `contains` (`contains` is peek-based, infallible, `&self`).
+Metrics are exposed through the trait per
 [design/0012-concurrent-metrics-trait.md](design/0012-concurrent-metrics-trait.md).
 See [traits-concurrent.md](traits-concurrent.md).
 

--- a/specs/traits-concurrent.md
+++ b/specs/traits-concurrent.md
@@ -17,13 +17,17 @@ per [design/0012-concurrent-metrics-trait.md](design/0012-concurrent-metrics-tra
 `ConcurrentCached<K, V>` is the sync self-synchronizing API (`cache_get`, `cache_set`,
 `cache_remove`, `cache_remove_entry`, `cache_delete`, `cache_contains`, `cache_clear`,
 `cache_reset`, `cache_reset_metrics`, `cache_get_or_set_with`, all returning
-`Result<_, Self::Error>`). `cache_contains` has a default that calls `cache_get` (counts
-hits/misses, clones the value); the built-in sharded stores override it with a peek-based
-implementation (read lock, no clone, no metrics). `ConcurrentCachedAsync<K, V>` is its async
-counterpart, adding `async_cache_contains`. `ConcurrentCachedExt` provides deduplicated short-name
-methods (`get`, `set`, `remove`, `remove_entry`, `delete`, `contains`, `clear`, `reset`,
-`get_or_set_with`); it does not forward `cache_reset_metrics` or `cache_contains` directly
-(use `contains` via the ext trait).
+`Result<_, Self::Error>`). `cache_contains` is a required method with no `V: Clone` bound; the
+built-in sharded stores implement it with a peek-based read (read lock, no clone, no metrics);
+`RedisCache`, `AsyncRedisCache`, and `RedbCache` use a get-based implementation. External
+implementors of `ConcurrentCached` must provide `cache_contains`. `ConcurrentCachedAsync<K, V>`
+is its async counterpart; `async_cache_contains` is likewise required with no `V: Clone + Send`
+bound. `ConcurrentCachedExt` provides deduplicated short-name methods (`get`, `set`, `remove`,
+`remove_entry`, `delete`, `contains` (no `V: Clone` bound), `clear`, `reset`, `get_or_set_with`);
+it does not forward `cache_reset_metrics` directly (use `contains` via the ext trait). The six
+sharded concrete types also expose an inherent `contains(&self, &K) -> bool` that takes call-site
+priority over the ext-trait alias, consistent with the other inherent shims (`get`, `set`,
+`reset`).
 
 ## CTRAIT-3
 

--- a/specs/traits-core.md
+++ b/specs/traits-core.md
@@ -9,13 +9,15 @@ These take `&mut self` (exclusive ownership), distinguishing them from the concu
 
 `Cached<K, V>` is the core: `cache_get`, `cache_get_mut`, `cache_set`, `cache_try_set`,
 `cache_get_or_set_with` (and `_mut` / `try_` variants), `cache_remove`, `cache_remove_entry`,
-`cache_delete`, `cache_clear`, `cache_reset`, `cache_size`, and the metric accessors
-(`cache_hits` / `cache_misses` / `cache_capacity` / `cache_evictions`). `Cached::Error` is bounded
-by `std::error::Error + Send + Sync + 'static` so generic callers can `?`-propagate or `.unwrap()`
-without extra where-clauses. `CachedExt` is a blanket extension trait providing deduplicated
-short-name methods (`get`, `get_mut`, `set`, `try_set`, `get_or_set_with`, `get_or_set_with_mut`,
-`try_get_or_set_with`, `try_get_or_set_with_mut`, `remove`, `remove_entry`, `delete`, `contains`,
-`clear`, `reset`, `len`, `is_empty`, `hits`, `misses`, `metrics()`), per
+`cache_delete`, `cache_clear`, `cache_reset`, `cache_size`, `cache_contains` (defaulted; built-ins
+override with a peek-based implementation; the trait-level default is get-based for third-party
+stores), and the metric accessors (`cache_hits` / `cache_misses` / `cache_capacity` /
+`cache_evictions`). `Cached::Error` is bounded by `std::error::Error + Send + Sync + 'static` so
+generic callers can `?`-propagate or `.unwrap()` without extra where-clauses. `CachedExt` is a
+blanket extension trait providing deduplicated short-name methods (`get`, `get_mut`, `set`,
+`try_set`, `get_or_set_with`, `get_or_set_with_mut`, `try_get_or_set_with`,
+`try_get_or_set_with_mut`, `remove`, `remove_entry`, `delete`, `contains` (delegates to
+`cache_contains`), `clear`, `reset`, `len`, `is_empty`, `hits`, `misses`, `metrics()`), per
 [design/0008-method-name-deduplication.md](design/0008-method-name-deduplication.md).
 
 ## TRAIT-2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1072,6 +1072,21 @@ pub trait Cached<K, V> {
     /// Reset hit/miss counters.
     fn cache_reset_metrics(&mut self) {}
 
+    /// Return `true` if the key is present (and unexpired), `false` otherwise.
+    ///
+    /// The default delegates to [`cache_get`](Cached::cache_get) and therefore counts a hit or
+    /// miss and may update recency/expiry state. All built-in single-owner stores override it
+    /// peek-based: no hit/miss metrics, no LRU promotion, no TTL refresh, and expired entries
+    /// report `false`. For a non-mutating borrow-returning lookup, use
+    /// [`CachedPeek::cache_peek`].
+    fn cache_contains<Q>(&mut self, k: &Q) -> bool
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
+        self.cache_get(k).is_some()
+    }
+
     /// Return the number of times a cached value was successfully retrieved.
     #[must_use]
     fn cache_hits(&self) -> Option<u64> {
@@ -1214,10 +1229,13 @@ pub trait CachedExt<K, V>: Cached<K, V> {
         Q: std::hash::Hash + Eq + ?Sized;
 
     /// Return `true` if the cache contains a value for the given key.
+    /// Delegates to [`cache_contains`](Cached::cache_contains).
     ///
-    /// Requires `&mut self` because some stores update recency, expiration
-    /// timestamps, or metrics during reads. For a non-mutating presence check
-    /// use [`CachedPeek::cache_peek`] if the store implements it.
+    /// The receiver stays `&mut self` because a third-party store's implementation
+    /// may mutate, but the built-in stores' overrides are peek-based and do not
+    /// mutate observable state (no hit/miss count, no recency update, no TTL
+    /// refresh). For a non-mutating borrow-returning lookup use
+    /// [`CachedPeek::cache_peek`] if the store implements it.
     fn contains<Q>(&mut self, k: &Q) -> bool
     where
         K: std::borrow::Borrow<Q>,
@@ -1337,7 +1355,7 @@ impl<K, V, T: Cached<K, V>> CachedExt<K, V> for T {
         K: std::borrow::Borrow<Q>,
         Q: std::hash::Hash + Eq + ?Sized,
     {
-        self.cache_get(k).is_some()
+        self.cache_contains(k)
     }
 
     fn clear(&mut self) {
@@ -2064,6 +2082,9 @@ pub trait ConcurrentCacheTtl {
 ///         self.0.lock().unwrap().clear();
 ///         Ok(())
 ///     }
+///     fn cache_contains(&self, k: &String) -> Result<bool, Self::Error> {
+///         Ok(self.0.lock().unwrap().contains_key(k))
+///     }
 /// }
 ///
 /// let store = MyStore(Mutex::new(HashMap::new()));
@@ -2196,11 +2217,10 @@ pub trait ConcurrentCached<K, V>: ConcurrentCacheBase {
 
     /// Return `true` if the cache contains a live value for the given key.
     ///
-    /// The default implementation calls [`cache_get`](ConcurrentCached::cache_get), which
-    /// **counts a hit or miss, touches LRU recency on sharded LRU stores, and clones the value**.
-    /// The built-in sharded in-memory stores override this with an efficient peek-based
-    /// implementation that does not clone the value, update recency, or record hit/miss metrics.
-    /// External stores (`RedisCache`, `AsyncRedisCache`, `RedbCache`) use the default.
+    /// The built-in sharded in-memory stores implement this peek-based: they take a read lock
+    /// and check for presence without cloning the value, updating LRU recency, or recording
+    /// hit/miss metrics. The IO stores (`RedisCache`, `AsyncRedisCache`, `RedbCache`) implement
+    /// it get-based: they fetch the entry and check whether it is present.
     ///
     /// The `where Self: Sized` bound keeps this generic method out of the vtable.
     ///
@@ -2209,11 +2229,7 @@ pub trait ConcurrentCached<K, V>: ConcurrentCacheBase {
     /// Should return `Self::Error` if the operation fails.
     fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
     where
-        Self: Sized,
-        V: Clone,
-    {
-        self.cache_get(k).map(|v| v.is_some())
-    }
+        Self: Sized;
 
     /// Remove all cached entries while preserving capacity allocation and metrics.
     ///
@@ -2343,9 +2359,7 @@ pub trait ConcurrentCachedExt<K, V>: ConcurrentCached<K, V> {
 
     /// Return `true` if the cache contains a live value for the given key. Delegates to
     /// [`cache_contains`](ConcurrentCached::cache_contains).
-    fn contains(&self, k: &K) -> Result<bool, Self::Error>
-    where
-        V: Clone;
+    fn contains(&self, k: &K) -> Result<bool, Self::Error>;
 
     /// Return the cached value for `k`, or compute and store `f()`. Delegates to
     /// [`cache_get_or_set_with`](ConcurrentCached::cache_get_or_set_with).
@@ -2383,10 +2397,7 @@ impl<K, V, T: ConcurrentCached<K, V>> ConcurrentCachedExt<K, V> for T {
         self.cache_reset()
     }
 
-    fn contains(&self, k: &K) -> Result<bool, Self::Error>
-    where
-        V: Clone,
-    {
+    fn contains(&self, k: &K) -> Result<bool, Self::Error> {
         self.cache_contains(k)
     }
 
@@ -2489,12 +2500,10 @@ pub trait ConcurrentCachedAsync<K, V>: ConcurrentCacheBase {
 
     /// Return `true` if the cache contains a live value for the given key.
     ///
-    /// The default implementation calls
-    /// [`async_cache_get`](ConcurrentCachedAsync::async_cache_get), which
-    /// **counts a hit or miss, touches LRU recency on sharded LRU stores, and clones the value**.
-    /// The built-in sharded in-memory stores override this with an efficient peek-based
-    /// implementation that does not clone the value, update recency, or record hit/miss metrics.
-    /// External stores (`AsyncRedisCache`, `RedbCache`) use the default.
+    /// The built-in sharded in-memory stores implement this peek-based: they take a read lock
+    /// and check for presence without cloning the value, updating LRU recency, or recording
+    /// hit/miss metrics. The IO stores (`AsyncRedisCache`, `RedbCache`) implement it get-based:
+    /// they fetch the entry and check whether it is present.
     ///
     /// # Errors
     ///
@@ -2503,11 +2512,7 @@ pub trait ConcurrentCachedAsync<K, V>: ConcurrentCacheBase {
     fn async_cache_contains(&self, k: &K) -> impl Future<Output = Result<bool, Self::Error>> + Send
     where
         Self: Sized + Sync,
-        K: Sync,
-        V: Clone + Send,
-    {
-        async move { self.async_cache_get(k).await.map(|v| v.is_some()) }
-    }
+        K: Sync;
 
     /// Remove all cached entries while preserving capacity allocation and metrics.
     ///

--- a/src/stores/expiring.rs
+++ b/src/stores/expiring.rs
@@ -510,6 +510,18 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> Cached<K, V> for ExpiringCache<K,
         self.evictions.store(0, Ordering::Relaxed);
         self.store.cache_reset_metrics();
     }
+
+    /// Check whether the cache contains a live (non-expired) entry for `k`.
+    ///
+    /// Delegates to [`CachedPeek::cache_peek`], so it records no hit/miss
+    /// metrics and reports absent/expired entries as `false`.
+    fn cache_contains<Q>(&mut self, k: &Q) -> bool
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
+        crate::CachedPeek::cache_peek(self, k).is_some()
+    }
 }
 
 impl<K: Hash + Eq, V: Expires, S: BuildHasher> CachedIter<K, V> for ExpiringCache<K, V, S> {

--- a/src/stores/expiring_lru.rs
+++ b/src/stores/expiring_lru.rs
@@ -413,6 +413,61 @@ impl<K: Clone + Hash + Eq, V: Expires, S: BuildHasher> ExpiringLruCache<K, V, S>
             }
         }
     }
+
+    /// Return all live entries in current LRU order (most-recently-used first)
+    /// as a `Vec` of `(K, V)` pairs. Expired entries are excluded.
+    #[must_use]
+    pub fn iter_order(&self) -> Vec<(K, V)>
+    where
+        K: Clone,
+        V: Clone,
+    {
+        self.store
+            .iter_order()
+            .into_iter()
+            .filter(|(_, v)| !v.is_expired())
+            .collect()
+    }
+
+    /// Return a `Vec` of keys in the current order from most to least recently
+    /// used. Expired entries are excluded.
+    #[must_use]
+    pub fn key_order(&self) -> Vec<K>
+    where
+        K: Clone,
+    {
+        self.store
+            .order
+            .iter()
+            .filter_map(|(k, v)| {
+                if v.is_expired() {
+                    None
+                } else {
+                    Some(k.clone())
+                }
+            })
+            .collect()
+    }
+
+    /// Return a `Vec` of values in the current order from most to least recently
+    /// used. Expired entries are excluded.
+    #[must_use]
+    pub fn value_order(&self) -> Vec<V>
+    where
+        V: Clone,
+    {
+        self.store
+            .order
+            .iter()
+            .filter_map(|(_, v)| {
+                if v.is_expired() {
+                    None
+                } else {
+                    Some(v.clone())
+                }
+            })
+            .collect()
+    }
 }
 
 // https://docs.rs/cached/latest/cached/trait.Cached.html
@@ -616,6 +671,19 @@ impl<K: Hash + Eq + Clone, V: Expires, S: BuildHasher> Cached<K, V> for Expiring
         self.misses.store(0, Ordering::Relaxed);
         self.evictions.store(0, Ordering::Relaxed);
         self.store.cache_reset_metrics();
+    }
+
+    /// Check whether the cache contains a live (non-expired) entry for `k`.
+    ///
+    /// Delegates to [`CachedPeek::cache_peek`], so it records no hit/miss
+    /// metrics, performs no recency promotion, and reports absent/expired
+    /// entries as `false`.
+    fn cache_contains<Q>(&mut self, k: &Q) -> bool
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
+        crate::CachedPeek::cache_peek(self, k).is_some()
     }
 }
 

--- a/src/stores/lru.rs
+++ b/src/stores/lru.rs
@@ -878,6 +878,19 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruCache<K, V, S>
     fn cache_capacity(&self) -> Option<usize> {
         Some(self.capacity)
     }
+
+    /// Check whether the cache contains a live entry for `k`.
+    ///
+    /// Delegates to [`CachedPeek::cache_peek`], so it records no hit/miss
+    /// metrics, performs no recency promotion, and reports absent/expired
+    /// entries as `false`.
+    fn cache_contains<Q>(&mut self, k: &Q) -> bool
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
+        crate::CachedPeek::cache_peek(self, k).is_some()
+    }
 }
 
 impl<K: Hash + Eq + Clone, V, S: BuildHasher> CachedIter<K, V> for LruCache<K, V, S> {

--- a/src/stores/lru_ttl.rs
+++ b/src/stores/lru_ttl.rs
@@ -858,6 +858,19 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
     fn cache_capacity(&self) -> Option<usize> {
         Some(self.size)
     }
+
+    /// Check whether the cache contains a live (non-expired) entry for `k`.
+    ///
+    /// Delegates to [`CachedPeek::cache_peek`], so it records no hit/miss
+    /// metrics, performs no recency promotion or TTL refresh, and reports
+    /// absent/expired entries as `false`.
+    fn cache_contains<Q>(&mut self, k: &Q) -> bool
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
+        crate::CachedPeek::cache_peek(self, k).is_some()
+    }
 }
 
 impl<K: Hash + Eq + Clone, V, S: BuildHasher> CachedIter<K, V> for LruTtlCache<K, V, S> {

--- a/src/stores/redb.rs
+++ b/src/stores/redb.rs
@@ -1410,6 +1410,17 @@ where
     fn cache_reset(&self) -> Result<(), RedbCacheError> {
         disk_cache_clear(&self.connection, self.durable)
     }
+
+    /// Returns `true` if the cache contains a non-expired entry for `key`.
+    ///
+    /// Delegates to [`cache_get`](ConcurrentCached::cache_get): the value is
+    /// fetched and deserialized to determine presence.
+    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
+    where
+        Self: Sized,
+    {
+        self.cache_get(k).map(|v| v.is_some())
+    }
 }
 
 impl<K, V> crate::SerializeCached<K, V> for RedbCache<K, V>
@@ -1516,6 +1527,18 @@ where
         let connection = self.connection.clone();
         let durable = self.durable;
         blocking::unblock(move || disk_cache_clear(&connection, durable)).await
+    }
+
+    /// Returns `true` if the cache contains a non-expired entry for `key`.
+    ///
+    /// Delegates to [`async_cache_get`](crate::ConcurrentCachedAsync::async_cache_get)
+    /// via a background thread (same pattern as all other async methods here).
+    async fn async_cache_contains(&self, k: &K) -> Result<bool, RedbCacheError>
+    where
+        Self: Sized + Sync,
+        K: Sync,
+    {
+        self.async_cache_get(k).await.map(|v| v.is_some())
     }
 }
 

--- a/src/stores/redis.rs
+++ b/src/stores/redis.rs
@@ -1712,6 +1712,18 @@ where
     fn cache_reset(&self) -> Result<(), RedisCacheError> {
         self.cache_clear()
     }
+
+    /// Returns `true` if the cache contains a non-expired entry for `key`.
+    ///
+    /// This delegates to [`cache_get`](ConcurrentCached::cache_get): the value is
+    /// fetched and deserialized to determine presence. There is no separate Redis
+    /// EXISTS round-trip in this implementation.
+    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
+    where
+        Self: Sized,
+    {
+        self.cache_get(k).map(|v| v.is_some())
+    }
 }
 
 impl<K, V> crate::SerializeCached<K, V> for RedisCache<K, V>
@@ -2675,6 +2687,19 @@ mod async_redis {
         /// the entries (matching `RedbCache`, which also overrides both).
         async fn async_cache_reset(&self) -> Result<(), Self::Error> {
             self.async_cache_clear().await
+        }
+
+        /// Returns `true` if the cache contains a non-expired entry for `key`.
+        ///
+        /// Delegates to [`async_cache_get`](ConcurrentCachedAsync::async_cache_get):
+        /// the value is fetched and deserialized to determine presence. There is no
+        /// separate Redis EXISTS round-trip in this implementation.
+        async fn async_cache_contains(&self, k: &K) -> Result<bool, Self::Error>
+        where
+            Self: Sized + Sync,
+            K: Sync,
+        {
+            self.async_cache_get(k).await.map(|v| v.is_some())
         }
     }
 

--- a/src/stores/sharded/expiring.rs
+++ b/src/stores/sharded/expiring.rs
@@ -241,6 +241,11 @@ where
     pub fn reset(&self) {
         ConcurrentCached::cache_reset(self).unwrap()
     }
+
+    /// Return true if a live (not expired) value is stored for `k`. Peek-based: no recency update, no hit/miss metrics.
+    pub fn contains(&self, k: &K) -> bool {
+        ConcurrentCached::cache_contains(self, k).unwrap()
+    }
 }
 
 impl<K, V, H: ShardHasher<K>> ShardedExpiringCacheBase<K, V, H>
@@ -558,7 +563,6 @@ where
     fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
     where
         Self: Sized,
-        V: Clone,
     {
         let shard = self.shard_of(k);
         Ok(shard.lock.read().get(k).is_some_and(|v| !v.is_expired()))
@@ -606,7 +610,6 @@ where
     where
         Self: Sized + Sync,
         K: Sync,
-        V: Clone + Send,
     {
         let result = ConcurrentCached::cache_contains(self, k);
         async move { result }

--- a/src/stores/sharded/expiring_lru.rs
+++ b/src/stores/sharded/expiring_lru.rs
@@ -244,6 +244,11 @@ where
     pub fn reset(&self) {
         ConcurrentCached::cache_reset(self).unwrap()
     }
+
+    /// Return true if a live (not expired) value is stored for `k`. Peek-based: no recency update, no hit/miss metrics.
+    pub fn contains(&self, k: &K) -> bool {
+        ConcurrentCached::cache_contains(self, k).unwrap()
+    }
 }
 
 impl<K, V, H: ShardHasher<K>> ShardedExpiringLruCacheBase<K, V, H>
@@ -672,7 +677,6 @@ where
     fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
     where
         Self: Sized,
-        V: Clone,
     {
         use crate::CachedPeek;
         let shard = self.shard_of(k);
@@ -725,7 +729,6 @@ where
     where
         Self: Sized + Sync,
         K: Sync,
-        V: Clone + Send,
     {
         let result = ConcurrentCached::cache_contains(self, k);
         async move { result }

--- a/src/stores/sharded/lru.rs
+++ b/src/stores/sharded/lru.rs
@@ -228,6 +228,11 @@ where
     pub fn reset(&self) {
         ConcurrentCached::cache_reset(self).unwrap()
     }
+
+    /// Return true if a live value is stored for `k`. Peek-based: no recency update, no hit/miss metrics.
+    pub fn contains(&self, k: &K) -> bool {
+        ConcurrentCached::cache_contains(self, k).unwrap()
+    }
 }
 
 impl<K, V, H: ShardHasher<K>> ShardedLruCacheBase<K, V, H>
@@ -567,7 +572,6 @@ where
     fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
     where
         Self: Sized,
-        V: Clone,
     {
         use crate::CachedPeek;
         let shard = self.shard_of(k);
@@ -616,7 +620,6 @@ where
     where
         Self: Sized + Sync,
         K: Sync,
-        V: Clone + Send,
     {
         let result = ConcurrentCached::cache_contains(self, k);
         async move { result }

--- a/src/stores/sharded/lru_ttl.rs
+++ b/src/stores/sharded/lru_ttl.rs
@@ -296,6 +296,11 @@ where
     pub fn reset(&self) {
         ConcurrentCached::cache_reset(self).unwrap()
     }
+
+    /// Return true if a live (not expired) value is stored for `k`. Peek-based: no recency update, no hit/miss metrics.
+    pub fn contains(&self, k: &K) -> bool {
+        ConcurrentCached::cache_contains(self, k).unwrap()
+    }
 }
 
 impl<K, V, H: ShardHasher<K>> ShardedLruTtlCacheBase<K, V, H>
@@ -805,7 +810,6 @@ where
     fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
     where
         Self: Sized,
-        V: Clone,
     {
         let shard = self.shard_of(k);
         let guard = shard.lock.read();
@@ -856,7 +860,6 @@ where
     where
         Self: Sized + Sync,
         K: Sync,
-        V: Clone + Send,
     {
         let result = ConcurrentCached::cache_contains(self, k);
         async move { result }

--- a/src/stores/sharded/ttl.rs
+++ b/src/stores/sharded/ttl.rs
@@ -282,6 +282,11 @@ where
     pub fn reset(&self) {
         ConcurrentCached::cache_reset(self).unwrap()
     }
+
+    /// Return true if a live (not expired) value is stored for `k`. Peek-based: no recency update, no hit/miss metrics.
+    pub fn contains(&self, k: &K) -> bool {
+        ConcurrentCached::cache_contains(self, k).unwrap()
+    }
 }
 
 impl<K, V, H: ShardHasher<K>> ShardedTtlCacheBase<K, V, H>
@@ -676,7 +681,6 @@ where
     fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
     where
         Self: Sized,
-        V: Clone,
     {
         let shard = self.shard_of(k);
         let guard = shard.lock.read();
@@ -725,7 +729,6 @@ where
     where
         Self: Sized + Sync,
         K: Sync,
-        V: Clone + Send,
     {
         let result = ConcurrentCached::cache_contains(self, k);
         async move { result }

--- a/src/stores/sharded/unbound.rs
+++ b/src/stores/sharded/unbound.rs
@@ -240,6 +240,11 @@ where
     pub fn reset(&self) {
         ConcurrentCached::cache_reset(self).unwrap()
     }
+
+    /// Return true if a live value is stored for `k`. Peek-based: no recency update, no hit/miss metrics.
+    pub fn contains(&self, k: &K) -> bool {
+        ConcurrentCached::cache_contains(self, k).unwrap()
+    }
 }
 
 impl<K, V, H: ShardHasher<K>> ShardedUnboundCacheBase<K, V, H>
@@ -432,7 +437,6 @@ where
     fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
     where
         Self: Sized,
-        V: Clone,
     {
         let shard = self.shard_of(k);
         Ok(shard.lock.read().contains_key(k))
@@ -480,7 +484,6 @@ where
     where
         Self: Sized + Sync,
         K: Sync,
-        V: Clone + Send,
     {
         let result = ConcurrentCached::cache_contains(self, k);
         async move { result }

--- a/src/stores/ttl.rs
+++ b/src/stores/ttl.rs
@@ -616,6 +616,19 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for TtlCache<K, V, S> {
     fn cache_evictions(&self) -> Option<u64> {
         Some(self.evictions.load(Ordering::Relaxed))
     }
+
+    /// Check whether the cache contains a live (non-expired) entry for `k`.
+    ///
+    /// Delegates to [`CachedPeek::cache_peek`], so it records no hit/miss
+    /// metrics, performs no TTL refresh, and reports absent/expired entries
+    /// as `false`.
+    fn cache_contains<Q>(&mut self, k: &Q) -> bool
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
+        crate::CachedPeek::cache_peek(self, k).is_some()
+    }
 }
 
 impl<K: Hash + Eq, V, S: BuildHasher> CachedIter<K, V> for TtlCache<K, V, S> {

--- a/src/stores/ttl_sorted.rs
+++ b/src/stores/ttl_sorted.rs
@@ -538,19 +538,6 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> TtlSortedCache<K, V, S> {
         self.map.reserve(more);
     }
 
-    /// Set the default ttl and return the previous value.
-    ///
-    /// Returns the previous TTL, or `None` if expiry was already disabled (the previous
-    /// TTL was zero). This matches [`CacheTtl::set_ttl`](crate::CacheTtl::set_ttl) and the
-    /// `set_ttl` of every other timed store (`TtlCache`, `LruTtlCache`), so a zero
-    /// previous value is reported uniformly as `None` regardless of which store a generic
-    /// caller is using.
-    pub fn set_ttl(&mut self, ttl: Duration) -> Option<Duration> {
-        let old = self.ttl;
-        self.ttl = ttl;
-        if old.is_zero() { None } else { Some(old) }
-    }
-
     /// Evict values that have expired.
     /// Returns number of dropped items.
     #[must_use]
@@ -1061,6 +1048,18 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> Cached<K, V> for TtlSortedCa
     fn cache_capacity(&self) -> Option<usize> {
         self.size_limit
     }
+
+    /// Returns `true` if the key is present and its entry has not expired.
+    ///
+    /// Uses `cache_peek` internally: no hit/miss counters are updated and no
+    /// recency or TTL refresh occurs. Expired entries report `false`.
+    fn cache_contains<Q>(&mut self, k: &Q) -> bool
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
+        crate::CachedPeek::cache_peek(self, k).is_some()
+    }
 }
 
 impl<K: Hash + Eq + Ord, V, S: BuildHasher> CachedIter<K, V> for TtlSortedCache<K, V, S> {
@@ -1274,7 +1273,7 @@ impl<K: std::hash::Hash + Eq + Ord + Clone, V, S: BuildHasher> CacheEvict
 mod test {
     use crate::stores::TtlSortedCache;
     use crate::time::Duration;
-    use crate::{Cached, CachedExt, CachedRead};
+    use crate::{CacheTtl, Cached, CachedExt, CachedRead};
     use std::cmp::Ordering as CmpOrdering;
     use std::hash::{Hash, Hasher};
     use std::sync::Arc;

--- a/src/stores/unbound.rs
+++ b/src/stores/unbound.rs
@@ -322,6 +322,19 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for UnboundCache<K, V, S> {
     fn cache_misses(&self) -> Option<u64> {
         Some(self.misses.load())
     }
+
+    /// Check whether the cache contains a live entry for `k`.
+    ///
+    /// Delegates to [`CachedPeek::cache_peek`], so it records no hit/miss
+    /// metrics, performs no recency promotion, and reports absent/expired
+    /// entries as `false`.
+    fn cache_contains<Q>(&mut self, k: &Q) -> bool
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
+        crate::CachedPeek::cache_peek(self, k).is_some()
+    }
 }
 
 impl<K: Hash + Eq, V, S: BuildHasher> CachedIter<K, V> for UnboundCache<K, V, S> {

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -4453,6 +4453,12 @@ mod concurrent_cached_return_named_error {
         fn cache_remove_entry(&self, k: &String) -> Result<Option<(String, String)>, Self::Error> {
             Ok(self.0.lock().unwrap().remove_entry(k))
         }
+        fn cache_contains(&self, k: &String) -> Result<bool, Self::Error>
+        where
+            Self: Sized,
+        {
+            Ok(self.cache_get(k)?.is_some())
+        }
         fn cache_clear(&self) -> Result<(), Self::Error> {
             self.0.lock().unwrap().clear();
             Ok(())
@@ -7214,6 +7220,12 @@ mod generic_where_tests {
         fn cache_remove_entry(&self, k: &String) -> Result<Option<(String, String)>, Self::Error> {
             Ok(self.inner.lock().unwrap().remove_entry(k))
         }
+        fn cache_contains(&self, k: &String) -> Result<bool, Self::Error>
+        where
+            Self: Sized,
+        {
+            Ok(self.cache_get(k)?.is_some())
+        }
         fn cache_clear(&self) -> Result<(), Self::Error> {
             self.inner.lock().unwrap().clear();
             Ok(())
@@ -8216,24 +8228,6 @@ mod len_iter_evict_contract_sharded_expiring {
 
 // ── Item 1: Cached::Error bound ──────────────────────────────────────────────
 
-/// A generic function over Cached that ?-propagates Cached::Error.
-/// Compiles only if Error: std::error::Error + Send + Sync + 'static.
-#[allow(dead_code)]
-fn cached_error_propagate<K, V, C>(
-    cache: &mut C,
-    k: K,
-    v: V,
-) -> Result<(), Box<dyn std::error::Error>>
-where
-    K: std::hash::Hash + Eq,
-    C: cached::Cached<K, V>,
-{
-    // ? works only if Self::Error: Into<Box<dyn std::error::Error>>,
-    // which requires std::error::Error + Send + Sync + 'static.
-    cache.cache_try_set(k, v)?;
-    Ok(())
-}
-
 /// A generic function that ?-propagates Cached::Error into Box<dyn std::error::Error>.
 /// Compiles only if Error: std::error::Error + Send + Sync + 'static.
 #[allow(dead_code)]
@@ -8411,7 +8405,6 @@ fn concurrent_contains_returns_false_for_absent_key() {
 }
 
 /// Generic trait usage: contains() on any ConcurrentCached without extra where-clauses.
-#[allow(dead_code)]
 fn generic_concurrent_contains<K, V, C>(cache: &C, k: &K) -> bool
 where
     K: std::hash::Hash + Eq + Clone,
@@ -8863,5 +8856,780 @@ fn concurrent_contains_ext_alias_expiry_aware_on_expiring_store() {
     assert!(
         !ConcurrentCachedExt::contains(&cache, &2).unwrap(),
         "expired entry not contained via ext alias"
+    );
+}
+
+// ── Task 2: single-owner peek-based cache_contains semantics ──────────────────
+
+/// LruCache: cache_contains is peek-based -- no hit/miss increment, no recency promotion.
+#[test]
+fn lru_cache_contains_no_metrics_and_no_recency_promotion() {
+    use cached::{Cached, CachedExt, LruCache};
+
+    let mut cache = LruCache::<u32, u32>::builder().max_size(3).build().unwrap();
+
+    cache.cache_set(1, 10);
+    cache.cache_set(2, 20);
+
+    // Promote key 1 to MRU via a real get so order is [1, 2].
+    cache.cache_get(&1);
+
+    // Snapshot metrics and key order after the promoting get.
+    let hits_before = cache.cache_hits().unwrap_or(0);
+    let misses_before = cache.cache_misses().unwrap_or(0);
+    let order_before = cache.key_order();
+
+    // contains on a present key must return true without altering metrics or order.
+    assert!(
+        cache.cache_contains(&1),
+        "present key must be reported contained"
+    );
+    assert!(
+        cache.cache_contains(&2),
+        "present key 2 must be reported contained"
+    );
+    // contains on an absent key must return false.
+    assert!(
+        !cache.cache_contains(&99),
+        "absent key must not be reported contained"
+    );
+
+    // Metrics unchanged.
+    assert_eq!(
+        cache.cache_hits().unwrap_or(0),
+        hits_before,
+        "cache_contains must not increment hit counter"
+    );
+    assert_eq!(
+        cache.cache_misses().unwrap_or(0),
+        misses_before,
+        "cache_contains must not increment miss counter"
+    );
+
+    // Recency order unchanged -- contains must not promote key 2 to MRU.
+    assert_eq!(
+        cache.key_order(),
+        order_before,
+        "cache_contains must not change key recency order"
+    );
+
+    // Also verify the CachedExt alias delegates correctly.
+    assert!(
+        CachedExt::contains(&mut cache, &1),
+        "CachedExt::contains must agree for present key"
+    );
+    assert!(
+        !CachedExt::contains(&mut cache, &99),
+        "CachedExt::contains must agree for absent key"
+    );
+}
+
+/// TtlCache with refresh_on_hit: cache_contains must NOT refresh the TTL.
+/// After the TTL elapses, contains returns false.  An expired-but-unswept
+/// entry still counts in len() but reports contains == false.
+#[cfg(feature = "time_stores")]
+#[test]
+fn ttl_cache_contains_does_not_refresh_ttl() {
+    use cached::time::Duration;
+    use cached::{Cached, TtlCache};
+
+    let mut cache = TtlCache::<u32, u32>::builder()
+        .ttl(Duration::from_millis(40))
+        .refresh_on_hit(true)
+        .build()
+        .unwrap();
+
+    cache.cache_set(1, 10);
+
+    // Immediately after set: live, so contains == true.
+    assert!(
+        cache.cache_contains(&1),
+        "freshly-set TTL entry must be contained"
+    );
+
+    // Sleep past the TTL.  If cache_contains had refreshed the TTL, the entry
+    // would still be live; it must not, so the entry must be expired.
+    std::thread::sleep(std::time::Duration::from_millis(80));
+
+    // Expired-but-unswept entry: len still counts it, but contains == false.
+    assert_eq!(
+        cache.cache_size(),
+        1,
+        "expired-but-unswept entry must still count in len"
+    );
+    assert!(
+        !cache.cache_contains(&1),
+        "expired TTL entry must NOT be reported contained (no TTL refresh via contains)"
+    );
+}
+
+/// Default (get-based) cache_contains path: a store that does NOT override
+/// cache_contains uses the trait default, which delegates to cache_get.
+/// This means a hit count increase is expected -- that is the documented
+/// side-effect of the default path.
+#[test]
+fn cached_trait_default_cache_contains_delegates_to_cache_get() {
+    use cached::Cached;
+    use std::collections::HashMap;
+
+    // Minimal custom `Cached` store with no cache_contains override.
+    struct MapCache {
+        map: HashMap<u32, u32>,
+        hits: u64,
+        misses: u64,
+    }
+
+    impl MapCache {
+        fn new() -> Self {
+            Self {
+                map: HashMap::new(),
+                hits: 0,
+                misses: 0,
+            }
+        }
+    }
+
+    impl Cached<u32, u32> for MapCache {
+        type Error = std::convert::Infallible;
+
+        fn cache_get<Q>(&mut self, k: &Q) -> Option<&u32>
+        where
+            u32: std::borrow::Borrow<Q>,
+            Q: std::hash::Hash + Eq + ?Sized,
+        {
+            match self.map.get(k) {
+                Some(v) => {
+                    self.hits += 1;
+                    Some(v)
+                }
+                None => {
+                    self.misses += 1;
+                    None
+                }
+            }
+        }
+
+        fn cache_get_mut<Q>(&mut self, k: &Q) -> Option<&mut u32>
+        where
+            u32: std::borrow::Borrow<Q>,
+            Q: std::hash::Hash + Eq + ?Sized,
+        {
+            self.map.get_mut(k)
+        }
+
+        fn cache_set(&mut self, k: u32, v: u32) -> Option<u32> {
+            self.map.insert(k, v)
+        }
+
+        fn cache_remove<Q>(&mut self, k: &Q) -> Option<u32>
+        where
+            u32: std::borrow::Borrow<Q>,
+            Q: std::hash::Hash + Eq + ?Sized,
+        {
+            self.map.remove(k)
+        }
+
+        fn cache_remove_entry<Q>(&mut self, k: &Q) -> Option<(u32, u32)>
+        where
+            u32: std::borrow::Borrow<Q>,
+            Q: std::hash::Hash + Eq + ?Sized,
+        {
+            self.map.remove_entry(k)
+        }
+
+        fn cache_get_or_set_with_mut<F: FnOnce() -> u32>(&mut self, key: u32, f: F) -> &mut u32 {
+            self.map.entry(key).or_insert_with(f)
+        }
+
+        fn cache_try_get_or_set_with_mut<F: FnOnce() -> Result<u32, E>, E>(
+            &mut self,
+            key: u32,
+            f: F,
+        ) -> Result<&mut u32, E> {
+            use std::collections::hash_map::Entry;
+            match self.map.entry(key) {
+                Entry::Occupied(o) => Ok(o.into_mut()),
+                Entry::Vacant(v) => Ok(v.insert(f()?)),
+            }
+        }
+
+        fn cache_clear(&mut self) {
+            self.map.clear();
+        }
+
+        fn cache_reset(&mut self) {
+            self.map.clear();
+            self.hits = 0;
+            self.misses = 0;
+        }
+
+        fn cache_size(&self) -> usize {
+            self.map.len()
+        }
+
+        fn cache_hits(&self) -> Option<u64> {
+            Some(self.hits)
+        }
+
+        fn cache_misses(&self) -> Option<u64> {
+            Some(self.misses)
+        }
+    }
+
+    let mut cache = MapCache::new();
+    cache.cache_set(42, 100);
+
+    let hits_before = cache.cache_hits().unwrap();
+
+    // The default cache_contains delegates to cache_get, so it increases hits.
+    assert!(
+        cache.cache_contains(&42),
+        "present key must be reported contained via default path"
+    );
+    assert!(
+        !cache.cache_contains(&99),
+        "absent key must not be reported contained via default path"
+    );
+
+    // Default path goes through cache_get, so hit count increased for the hit.
+    assert_eq!(
+        cache.cache_hits().unwrap(),
+        hits_before + 1,
+        "default cache_contains delegates to cache_get, incrementing hit count"
+    );
+}
+
+// ── Task 3: async_cache_contains for ShardedLruTtlCache and ShardedExpiringLruCache ──
+
+#[cfg(all(feature = "async", feature = "time_stores"))]
+#[tokio::test]
+async fn async_contains_sharded_lru_ttl_cache_is_expiry_aware() {
+    use cached::time::Duration;
+    use cached::{ConcurrentCachedAsync, ShardedLruTtlCache};
+
+    let cache = ShardedLruTtlCache::<u32, u32>::builder()
+        .max_size(10)
+        .ttl(Duration::from_millis(30))
+        .build()
+        .unwrap();
+
+    ConcurrentCachedAsync::async_cache_set(&cache, 1, 10)
+        .await
+        .unwrap();
+
+    // Live entry -> true, absent key -> false.
+    assert!(
+        ConcurrentCachedAsync::async_cache_contains(&cache, &1)
+            .await
+            .unwrap(),
+        "live LRU+TTL entry must be reported contained"
+    );
+    assert!(
+        !ConcurrentCachedAsync::async_cache_contains(&cache, &99)
+            .await
+            .unwrap(),
+        "absent key must not be reported contained"
+    );
+
+    // Sleep past the TTL -- expired entry must report false.
+    std::thread::sleep(std::time::Duration::from_millis(70));
+    assert!(
+        !ConcurrentCachedAsync::async_cache_contains(&cache, &1)
+            .await
+            .unwrap(),
+        "expired LRU+TTL entry must NOT be reported contained"
+    );
+}
+
+#[cfg(feature = "async")]
+#[tokio::test]
+async fn async_contains_sharded_expiring_lru_cache_is_expiry_aware() {
+    use cached::{ConcurrentCachedAsync, Expires, ShardedExpiringLruCache};
+
+    #[derive(Clone)]
+    struct ExpItem {
+        expired: bool,
+    }
+    impl Expires for ExpItem {
+        fn is_expired(&self) -> bool {
+            self.expired
+        }
+    }
+
+    let cache = ShardedExpiringLruCache::<u32, ExpItem>::builder()
+        .max_size(10)
+        .build()
+        .unwrap();
+
+    ConcurrentCachedAsync::async_cache_set(&cache, 1, ExpItem { expired: false })
+        .await
+        .unwrap();
+    ConcurrentCachedAsync::async_cache_set(&cache, 2, ExpItem { expired: true })
+        .await
+        .unwrap();
+
+    // Live per-value entry -> true.
+    assert!(
+        ConcurrentCachedAsync::async_cache_contains(&cache, &1)
+            .await
+            .unwrap(),
+        "live per-value LRU entry must be reported contained"
+    );
+    // Expired per-value entry -> false.
+    assert!(
+        !ConcurrentCachedAsync::async_cache_contains(&cache, &2)
+            .await
+            .unwrap(),
+        "expired per-value LRU entry must NOT be reported contained"
+    );
+    // Absent key -> false.
+    assert!(
+        !ConcurrentCachedAsync::async_cache_contains(&cache, &99)
+            .await
+            .unwrap(),
+        "absent key must not be reported contained"
+    );
+    // async_cache_contains must not evict the expired entry.
+    assert_eq!(
+        cache.len(),
+        2,
+        "async_cache_contains must not evict entries"
+    );
+}
+
+// ── Certification gap-fills: single-owner stores not yet directly covered ─────
+
+/// UnboundCache: cache_contains is peek-based -- no hit/miss increment, no expiry.
+/// Also exercises the Borrow pattern: K=String, Q=str.
+#[test]
+fn unbound_cache_contains_no_metrics_and_borrow_key() {
+    use cached::{Cached, CachedExt, UnboundCache};
+
+    let mut cache = UnboundCache::<String, u32>::new();
+    cache.cache_set("hello".to_string(), 1);
+    cache.cache_set("world".to_string(), 2);
+
+    let hits_before = cache.cache_hits().unwrap_or(0);
+    let misses_before = cache.cache_misses().unwrap_or(0);
+
+    // Borrowed-key lookup: Q=str, K=String -- exercises the Borrow<Q> path.
+    assert!(
+        cache.cache_contains("hello"),
+        "present key must be reported contained via borrowed &str"
+    );
+    assert!(
+        cache.cache_contains("world"),
+        "present key 'world' must be reported contained"
+    );
+    // Absent key must return false.
+    assert!(
+        !cache.cache_contains("absent"),
+        "absent key must not be reported contained"
+    );
+
+    // Peek-based: no hit or miss increments.
+    assert_eq!(
+        cache.cache_hits().unwrap_or(0),
+        hits_before,
+        "cache_contains must not increment hit counter on UnboundCache"
+    );
+    assert_eq!(
+        cache.cache_misses().unwrap_or(0),
+        misses_before,
+        "cache_contains must not increment miss counter on UnboundCache"
+    );
+
+    // CachedExt::contains delegates to cache_contains.
+    assert!(
+        CachedExt::contains(&mut cache, "hello"),
+        "CachedExt::contains must agree for present key on UnboundCache"
+    );
+    assert!(
+        !CachedExt::contains(&mut cache, "absent"),
+        "CachedExt::contains must agree for absent key on UnboundCache"
+    );
+}
+
+/// LruTtlCache: cache_contains is peek-based -- expired entries report false, no TTL
+/// refresh, no hit/miss increment, no recency promotion.
+#[cfg(feature = "time_stores")]
+#[test]
+fn lru_ttl_cache_contains_is_expiry_aware_and_metric_neutral() {
+    use cached::time::Duration;
+    use cached::{Cached, LruTtlCache};
+
+    let mut cache = LruTtlCache::<u32, u32>::builder()
+        .max_size(4)
+        .ttl(Duration::from_millis(40))
+        .build()
+        .unwrap();
+
+    cache.cache_set(1, 10);
+    cache.cache_set(2, 20);
+
+    let hits_before = cache.cache_hits().unwrap_or(0);
+    let misses_before = cache.cache_misses().unwrap_or(0);
+
+    // Live entries.
+    assert!(
+        cache.cache_contains(&1),
+        "live LruTtl entry must be reported contained"
+    );
+    assert!(
+        cache.cache_contains(&2),
+        "live LruTtl entry 2 must be reported contained"
+    );
+    // Absent key.
+    assert!(
+        !cache.cache_contains(&99),
+        "absent key must not be reported contained"
+    );
+
+    // Metrics unchanged.
+    assert_eq!(
+        cache.cache_hits().unwrap_or(0),
+        hits_before,
+        "cache_contains must not increment hit counter on LruTtlCache"
+    );
+    assert_eq!(
+        cache.cache_misses().unwrap_or(0),
+        misses_before,
+        "cache_contains must not increment miss counter on LruTtlCache"
+    );
+
+    // Sleep past TTL -- expired entry must report false.
+    std::thread::sleep(std::time::Duration::from_millis(80));
+    assert!(
+        !cache.cache_contains(&1),
+        "expired LruTtl entry must NOT be reported contained"
+    );
+    assert!(
+        !cache.cache_contains(&2),
+        "expired LruTtl entry 2 must NOT be reported contained"
+    );
+}
+
+/// TtlSortedCache: cache_contains is peek-based -- expired entries report false, no
+/// hit/miss increment.
+#[cfg(feature = "time_stores")]
+#[test]
+fn ttl_sorted_cache_contains_is_expiry_aware_and_metric_neutral() {
+    use cached::time::Duration;
+    use cached::{Cached, TtlSortedCache};
+
+    let mut cache = TtlSortedCache::<u32, u32>::builder()
+        .ttl(Duration::from_millis(40))
+        .build()
+        .unwrap();
+
+    cache.cache_set(7, 70);
+
+    let hits_before = cache.cache_hits().unwrap_or(0);
+    let misses_before = cache.cache_misses().unwrap_or(0);
+
+    // Live entry.
+    assert!(
+        cache.cache_contains(&7),
+        "live TtlSorted entry must be reported contained"
+    );
+    // Absent key.
+    assert!(
+        !cache.cache_contains(&99),
+        "absent key must not be reported contained by TtlSortedCache"
+    );
+
+    // Metrics unchanged.
+    assert_eq!(
+        cache.cache_hits().unwrap_or(0),
+        hits_before,
+        "cache_contains must not increment hit counter on TtlSortedCache"
+    );
+    assert_eq!(
+        cache.cache_misses().unwrap_or(0),
+        misses_before,
+        "cache_contains must not increment miss counter on TtlSortedCache"
+    );
+
+    // Sleep past TTL -- expired entry must report false.
+    std::thread::sleep(std::time::Duration::from_millis(80));
+    assert!(
+        !cache.cache_contains(&7),
+        "expired TtlSorted entry must NOT be reported contained"
+    );
+}
+
+/// ExpiringCache: cache_contains is peek-based -- expired (per-value) entries report
+/// false, no hit/miss increment.
+#[test]
+fn expiring_cache_contains_is_expiry_aware_and_metric_neutral() {
+    use cached::{Cached, Expires, ExpiringCache};
+
+    #[derive(Clone)]
+    struct Val {
+        expired: bool,
+    }
+    impl Expires for Val {
+        fn is_expired(&self) -> bool {
+            self.expired
+        }
+    }
+
+    let mut cache = ExpiringCache::<u32, Val>::new();
+    cache.cache_set(1, Val { expired: false });
+    cache.cache_set(2, Val { expired: true });
+
+    let hits_before = cache.cache_hits().unwrap_or(0);
+    let misses_before = cache.cache_misses().unwrap_or(0);
+
+    // Live entry.
+    assert!(
+        cache.cache_contains(&1),
+        "live ExpiringCache entry must be reported contained"
+    );
+    // Per-value expired entry: must report false without evicting.
+    assert!(
+        !cache.cache_contains(&2),
+        "expired ExpiringCache entry must NOT be reported contained"
+    );
+    // Absent key.
+    assert!(
+        !cache.cache_contains(&99),
+        "absent key must not be reported contained by ExpiringCache"
+    );
+
+    // Metrics unchanged (peek-based).
+    assert_eq!(
+        cache.cache_hits().unwrap_or(0),
+        hits_before,
+        "cache_contains must not increment hit counter on ExpiringCache"
+    );
+    assert_eq!(
+        cache.cache_misses().unwrap_or(0),
+        misses_before,
+        "cache_contains must not increment miss counter on ExpiringCache"
+    );
+
+    // Both entries still physically present -- no eviction from contains.
+    assert_eq!(
+        cache.cache_size(),
+        2,
+        "cache_contains must not evict entries from ExpiringCache"
+    );
+}
+
+/// ExpiringLruCache: cache_contains is peek-based -- expired entries report false, no
+/// hit/miss increment, no recency promotion.
+#[test]
+fn expiring_lru_cache_contains_is_expiry_aware_metric_neutral_and_no_recency() {
+    use cached::{Cached, CachedExt, Expires, ExpiringLruCache};
+
+    #[derive(Clone)]
+    struct Val {
+        expired: bool,
+    }
+    impl Expires for Val {
+        fn is_expired(&self) -> bool {
+            self.expired
+        }
+    }
+
+    // max_size=3 so we can test recency: insert 1, 2 (live), 3 (expired).
+    let mut cache = ExpiringLruCache::<u32, Val>::new(3);
+    cache.cache_set(1, Val { expired: false });
+    cache.cache_set(2, Val { expired: false });
+    // Promote key 1 to MRU so order is [1, 2] (1 most recent).
+    cache.cache_get(&1);
+
+    let hits_before = cache.cache_hits().unwrap_or(0);
+    let misses_before = cache.cache_misses().unwrap_or(0);
+    let size_before = cache.cache_size();
+
+    // Live entry: true.
+    assert!(
+        cache.cache_contains(&1),
+        "live ExpiringLru entry must be reported contained"
+    );
+    // Also live.
+    assert!(
+        cache.cache_contains(&2),
+        "live ExpiringLru entry 2 must be reported contained"
+    );
+    // Absent key: false.
+    assert!(
+        !cache.cache_contains(&99),
+        "absent key must not be reported contained by ExpiringLruCache"
+    );
+
+    // Metrics unchanged (peek-based).
+    assert_eq!(
+        cache.cache_hits().unwrap_or(0),
+        hits_before,
+        "cache_contains must not increment hit counter on ExpiringLruCache"
+    );
+    assert_eq!(
+        cache.cache_misses().unwrap_or(0),
+        misses_before,
+        "cache_contains must not increment miss counter on ExpiringLruCache"
+    );
+
+    // No entry evicted (cache_size unchanged).
+    assert_eq!(
+        cache.cache_size(),
+        size_before,
+        "cache_contains must not evict entries from ExpiringLruCache"
+    );
+
+    // Recency check: if cache_contains(&2) had promoted key 2 to MRU, inserting a new
+    // key would evict key 1 (which was MRU). Since contains must not change recency,
+    // key 2 must be evicted instead (it was LRU at time of contains).
+    cache.cache_set(3, Val { expired: false });
+    // After one promoting get (key 1) and no recency change from contains, the LRU
+    // order is: key 2 is least recent, key 1 is most recent.
+    // Inserting key 3 evicts key 2.
+    assert!(
+        cache.cache_contains(&1),
+        "key 1 must still be present (was MRU, must not have been evicted)"
+    );
+    assert!(
+        cache.cache_contains(&3),
+        "newly inserted key 3 must be present"
+    );
+
+    // CachedExt alias check.
+    assert!(
+        CachedExt::contains(&mut cache, &1),
+        "CachedExt::contains must agree for present key on ExpiringLruCache"
+    );
+}
+
+/// Default cache_contains path counts a miss for absent keys (via cache_get).
+/// The implementor's test verifies hits increase but does not check miss count.
+#[test]
+fn cached_trait_default_cache_contains_absent_key_counts_miss() {
+    use cached::Cached;
+    use std::collections::HashMap;
+
+    // Same minimal MapCache as above -- copy kept local to this test.
+    struct MapCache2 {
+        map: HashMap<u32, u32>,
+        hits: u64,
+        misses: u64,
+    }
+    impl MapCache2 {
+        fn new() -> Self {
+            Self {
+                map: HashMap::new(),
+                hits: 0,
+                misses: 0,
+            }
+        }
+    }
+    impl Cached<u32, u32> for MapCache2 {
+        type Error = std::convert::Infallible;
+
+        fn cache_get<Q>(&mut self, k: &Q) -> Option<&u32>
+        where
+            u32: std::borrow::Borrow<Q>,
+            Q: std::hash::Hash + Eq + ?Sized,
+        {
+            match self.map.get(k) {
+                Some(v) => {
+                    self.hits += 1;
+                    Some(v)
+                }
+                None => {
+                    self.misses += 1;
+                    None
+                }
+            }
+        }
+
+        fn cache_get_mut<Q>(&mut self, k: &Q) -> Option<&mut u32>
+        where
+            u32: std::borrow::Borrow<Q>,
+            Q: std::hash::Hash + Eq + ?Sized,
+        {
+            self.map.get_mut(k)
+        }
+
+        fn cache_set(&mut self, k: u32, v: u32) -> Option<u32> {
+            self.map.insert(k, v)
+        }
+
+        fn cache_remove<Q>(&mut self, k: &Q) -> Option<u32>
+        where
+            u32: std::borrow::Borrow<Q>,
+            Q: std::hash::Hash + Eq + ?Sized,
+        {
+            self.map.remove(k)
+        }
+
+        fn cache_remove_entry<Q>(&mut self, k: &Q) -> Option<(u32, u32)>
+        where
+            u32: std::borrow::Borrow<Q>,
+            Q: std::hash::Hash + Eq + ?Sized,
+        {
+            self.map.remove_entry(k)
+        }
+
+        fn cache_get_or_set_with_mut<F: FnOnce() -> u32>(&mut self, key: u32, f: F) -> &mut u32 {
+            self.map.entry(key).or_insert_with(f)
+        }
+
+        fn cache_try_get_or_set_with_mut<F: FnOnce() -> Result<u32, E>, E>(
+            &mut self,
+            key: u32,
+            f: F,
+        ) -> Result<&mut u32, E> {
+            use std::collections::hash_map::Entry;
+            match self.map.entry(key) {
+                Entry::Occupied(o) => Ok(o.into_mut()),
+                Entry::Vacant(v) => Ok(v.insert(f()?)),
+            }
+        }
+
+        fn cache_clear(&mut self) {
+            self.map.clear();
+        }
+
+        fn cache_reset(&mut self) {
+            self.map.clear();
+            self.hits = 0;
+            self.misses = 0;
+        }
+
+        fn cache_size(&self) -> usize {
+            self.map.len()
+        }
+
+        fn cache_hits(&self) -> Option<u64> {
+            Some(self.hits)
+        }
+
+        fn cache_misses(&self) -> Option<u64> {
+            Some(self.misses)
+        }
+    }
+
+    let mut cache = MapCache2::new();
+    cache.cache_set(1, 10);
+
+    let misses_before = cache.cache_misses().unwrap();
+
+    // Hit path: cache_contains on a present key -- must NOT count a miss.
+    assert!(cache.cache_contains(&1));
+    assert_eq!(
+        cache.cache_misses().unwrap(),
+        misses_before,
+        "default cache_contains on a present key must not count a miss"
+    );
+
+    // Miss path: cache_contains on an absent key -- default delegates to cache_get
+    // which counts a miss in this store.
+    assert!(!cache.cache_contains(&99));
+    assert_eq!(
+        cache.cache_misses().unwrap(),
+        misses_before + 1,
+        "default cache_contains on an absent key delegates to cache_get, counting a miss"
     );
 }

--- a/tests/serialize_set_dispatch.rs
+++ b/tests/serialize_set_dispatch.rs
@@ -92,6 +92,13 @@ mod stores {
         fn cache_reset(&self) -> Result<(), Infallible> {
             self.cache_clear()
         }
+
+        fn cache_contains(&self, k: &u32) -> Result<bool, Infallible>
+        where
+            Self: Sized,
+        {
+            self.cache_get(k).map(|v| v.is_some())
+        }
     }
 
     impl SerializeCached<u32, Counted> for SerStore {
@@ -157,6 +164,13 @@ mod stores {
 
         fn cache_reset(&self) -> Result<(), Infallible> {
             self.cache_clear()
+        }
+
+        fn cache_contains(&self, k: &u32) -> Result<bool, Infallible>
+        where
+            Self: Sized,
+        {
+            self.cache_get(k).map(|v| v.is_some())
         }
     }
 
@@ -391,6 +405,21 @@ mod async_serialize_store {
             self.map.lock().unwrap().clear();
             async move { Ok(()) }
         }
+
+        fn async_cache_contains(
+            &self,
+            k: &u32,
+        ) -> impl std::future::Future<Output = Result<bool, Infallible>> + Send
+        where
+            Self: Sized + Sync,
+            u32: Sync,
+        {
+            let result = {
+                let map = self.map.lock().unwrap();
+                map.get(k).is_some()
+            };
+            async move { Ok(result) }
+        }
     }
 
     impl SerializeCachedAsync<u32, AsyncVal> for AsyncSerStore {
@@ -496,6 +525,21 @@ mod async_serialize_store {
         {
             self.map.lock().unwrap().clear();
             async move { Ok(()) }
+        }
+
+        fn async_cache_contains(
+            &self,
+            k: &u32,
+        ) -> impl std::future::Future<Output = Result<bool, Infallible>> + Send
+        where
+            Self: Sized + Sync,
+            u32: Sync,
+        {
+            let result = {
+                let map = self.map.lock().unwrap();
+                map.get(k).is_some()
+            };
+            async move { Ok(result) }
         }
     }
 

--- a/tests/v3_async_setref_notsync_dispatch.rs
+++ b/tests/v3_async_setref_notsync_dispatch.rs
@@ -154,6 +154,21 @@ impl ConcurrentCachedAsync<u32, NotSyncVal> for NotSyncStore {
         self.map.lock().unwrap().clear();
         async move { Ok(()) }
     }
+
+    fn async_cache_contains(
+        &self,
+        k: &u32,
+    ) -> impl std::future::Future<Output = Result<bool, Infallible>> + Send
+    where
+        Self: Sized + Sync,
+        u32: Sync,
+    {
+        let result = {
+            let map = self.map.lock().unwrap();
+            map.get(k).is_some()
+        };
+        async move { Ok(result) }
+    }
 }
 
 impl SerializeCachedAsync<u32, NotSyncVal> for NotSyncStore {

--- a/tests/v3_contains_parity.rs
+++ b/tests/v3_contains_parity.rs
@@ -1,0 +1,652 @@
+//! Tests for the bound-drop on `ConcurrentCached::cache_contains` and the inherent
+//! `contains` on sharded stores.
+//!
+//! Three behavioral paths are pinned:
+//! 1. Generic code over `C: ConcurrentCached<K, V>` can call `cache_contains` with no
+//!    `V: Clone` bound -- compile proof that the bound was dropped.
+//! 2. An external implementor with a NON-Clone value type can implement
+//!    `ConcurrentCached` / `ConcurrentCachedAsync` and use `cache_contains` /
+//!    `async_cache_contains` correctly.
+//! 3. Inherent sharded `contains` resolves to `bool` (not `Result<bool, _>`) and
+//!    agrees with `cache_contains`, including TTL expiry semantics.
+
+// ── 1. Generic helper: no V: Clone bound ─────────────────────────────────────
+
+use cached::{ConcurrentCached, ShardedLruCache, ShardedUnboundCache};
+
+/// Compile-proof that `cache_contains` does not require `V: Clone`.
+///
+/// If a `V: Clone` bound crept back onto `ConcurrentCached::cache_contains`,
+/// calling this function with `V = String` would still compile (String is Clone),
+/// but calling it with a non-Clone value would not -- and the custom-store test
+/// below (section 2) calls the equivalent path with `V = NoClone`. The type
+/// annotation on the return makes the bound check explicit at this call site.
+fn has<K, V, C: ConcurrentCached<K, V>>(c: &C, k: &K) -> bool {
+    // No V: Clone bound anywhere in this signature or body.
+    c.cache_contains(k).ok().unwrap_or(false)
+}
+
+#[test]
+fn generic_has_compiles_and_returns_correct_result() {
+    let cache: ShardedUnboundCache<u32, String> =
+        ShardedUnboundCache::builder().build().expect("build");
+
+    // Key 1 absent -- has must return false.
+    assert!(!has(&cache, &1u32));
+
+    cache.cache_set(1, "hello".to_string()).unwrap();
+
+    // Key 1 present -- has must return true.
+    assert!(has(&cache, &1u32));
+
+    // Key 2 never inserted -- still false.
+    assert!(!has(&cache, &2u32));
+
+    cache.cache_remove(&1).unwrap();
+    // After removal, absent again.
+    assert!(!has(&cache, &1u32));
+}
+
+// ── 2. Custom store with NON-Clone value type ─────────────────────────────────
+
+/// A value type that deliberately does NOT implement `Clone`.
+/// Implementing `cache_contains` on a store holding `NoClone` values proves that
+/// the required method works without any `V: Clone` in scope.
+struct NoClone(#[allow(dead_code)] u32);
+
+// Intentionally NOT `impl Clone for NoClone`.
+
+mod custom_store {
+    //! Minimal `ConcurrentCached` / `ConcurrentCachedAsync` implementation
+    //! for a non-Clone value type.
+
+    use super::NoClone;
+    use cached::{ConcurrentCacheBase, ConcurrentCached};
+    use parking_lot::Mutex;
+    use std::collections::HashMap;
+    use std::convert::Infallible;
+
+    // A tiny hand-written concurrent store backed by a Mutex<HashMap>.
+    pub struct NoCloneStore {
+        inner: Mutex<HashMap<u32, NoClone>>,
+    }
+
+    impl NoCloneStore {
+        pub fn new() -> Self {
+            Self {
+                inner: Mutex::new(HashMap::new()),
+            }
+        }
+    }
+
+    impl ConcurrentCacheBase for NoCloneStore {
+        type Error = Infallible;
+    }
+
+    impl ConcurrentCached<u32, NoClone> for NoCloneStore {
+        fn cache_get(&self, k: &u32) -> Result<Option<NoClone>, Self::Error> {
+            // Move the value out (remove) to return an owned copy -- semantics
+            // don't matter for this test; we only need a correct `cache_contains`.
+            Ok(self.inner.lock().remove(k))
+        }
+
+        fn cache_set(&self, k: u32, v: NoClone) -> Result<Option<NoClone>, Self::Error> {
+            Ok(self.inner.lock().insert(k, v))
+        }
+
+        fn cache_remove(&self, k: &u32) -> Result<Option<NoClone>, Self::Error> {
+            Ok(self.inner.lock().remove(k))
+        }
+
+        fn cache_remove_entry(&self, k: &u32) -> Result<Option<(u32, NoClone)>, Self::Error> {
+            Ok(self.inner.lock().remove_entry(k))
+        }
+
+        fn cache_delete(&self, k: &u32) -> Result<bool, Self::Error> {
+            Ok(self.inner.lock().remove(k).is_some())
+        }
+
+        /// Peek-based check: does NOT require V: Clone.
+        fn cache_contains(&self, k: &u32) -> Result<bool, Self::Error>
+        where
+            Self: Sized,
+        {
+            Ok(self.inner.lock().contains_key(k))
+        }
+
+        fn cache_clear(&self) -> Result<(), Self::Error> {
+            self.inner.lock().clear();
+            Ok(())
+        }
+
+        fn cache_reset(&self) -> Result<(), Self::Error> {
+            self.cache_clear()
+        }
+    }
+
+    #[test]
+    fn cache_contains_true_after_set_no_clone_bound() {
+        let store = NoCloneStore::new();
+
+        // Key absent initially.
+        assert!(!store.cache_contains(&10).unwrap());
+
+        store.cache_set(10, NoClone(42)).unwrap();
+
+        // Key present -- cache_contains must return true without needing V: Clone.
+        assert!(store.cache_contains(&10).unwrap());
+    }
+
+    #[test]
+    fn cache_contains_false_after_removal() {
+        let store = NoCloneStore::new();
+        store.cache_set(7, NoClone(1)).unwrap();
+        assert!(store.cache_contains(&7).unwrap());
+
+        store.cache_remove(&7).unwrap();
+        assert!(!store.cache_contains(&7).unwrap());
+    }
+}
+
+// ── 2b. Async custom store with NON-Clone value type ─────────────────────────
+
+#[cfg(feature = "async_core")]
+mod custom_store_async {
+    use super::NoClone;
+    use cached::{ConcurrentCacheBase, ConcurrentCached, ConcurrentCachedAsync};
+    use parking_lot::Mutex;
+    use std::collections::HashMap;
+    use std::convert::Infallible;
+
+    pub struct NoCloneAsyncStore {
+        inner: Mutex<HashMap<u32, NoClone>>,
+    }
+
+    impl NoCloneAsyncStore {
+        pub fn new() -> Self {
+            Self {
+                inner: Mutex::new(HashMap::new()),
+            }
+        }
+    }
+
+    impl ConcurrentCacheBase for NoCloneAsyncStore {
+        type Error = Infallible;
+    }
+
+    // Keep the sync impl as well so we can delegate from the async one.
+    impl ConcurrentCached<u32, NoClone> for NoCloneAsyncStore {
+        fn cache_get(&self, k: &u32) -> Result<Option<NoClone>, Self::Error> {
+            Ok(self.inner.lock().remove(k))
+        }
+        fn cache_set(&self, k: u32, v: NoClone) -> Result<Option<NoClone>, Self::Error> {
+            Ok(self.inner.lock().insert(k, v))
+        }
+        fn cache_remove(&self, k: &u32) -> Result<Option<NoClone>, Self::Error> {
+            Ok(self.inner.lock().remove(k))
+        }
+        fn cache_remove_entry(&self, k: &u32) -> Result<Option<(u32, NoClone)>, Self::Error> {
+            Ok(self.inner.lock().remove_entry(k))
+        }
+        fn cache_delete(&self, k: &u32) -> Result<bool, Self::Error> {
+            Ok(self.inner.lock().remove(k).is_some())
+        }
+        fn cache_contains(&self, k: &u32) -> Result<bool, Self::Error>
+        where
+            Self: Sized,
+        {
+            Ok(self.inner.lock().contains_key(k))
+        }
+        fn cache_clear(&self) -> Result<(), Self::Error> {
+            self.inner.lock().clear();
+            Ok(())
+        }
+        fn cache_reset(&self) -> Result<(), Self::Error> {
+            self.cache_clear()
+        }
+    }
+
+    impl ConcurrentCachedAsync<u32, NoClone> for NoCloneAsyncStore {
+        fn async_cache_get(
+            &self,
+            k: &u32,
+        ) -> impl std::future::Future<Output = Result<Option<NoClone>, Self::Error>> + Send
+        {
+            let v = self.inner.lock().remove(k);
+            async move { Ok(v) }
+        }
+
+        fn async_cache_set(
+            &self,
+            k: u32,
+            v: NoClone,
+        ) -> impl std::future::Future<Output = Result<Option<NoClone>, Self::Error>> + Send
+        {
+            let prev = self.inner.lock().insert(k, v);
+            async move { Ok(prev) }
+        }
+
+        fn async_cache_remove(
+            &self,
+            k: &u32,
+        ) -> impl std::future::Future<Output = Result<Option<NoClone>, Self::Error>> + Send
+        {
+            let v = self.inner.lock().remove(k);
+            async move { Ok(v) }
+        }
+
+        fn async_cache_remove_entry(
+            &self,
+            k: &u32,
+        ) -> impl std::future::Future<Output = Result<Option<(u32, NoClone)>, Self::Error>> + Send
+        {
+            let v = self.inner.lock().remove_entry(k);
+            async move { Ok(v) }
+        }
+
+        fn async_cache_contains(
+            &self,
+            k: &u32,
+        ) -> impl std::future::Future<Output = Result<bool, Self::Error>> + Send
+        where
+            Self: Sized + Sync,
+            u32: Sync,
+        {
+            let present = self.inner.lock().contains_key(k);
+            async move { Ok(present) }
+        }
+
+        fn async_cache_clear(
+            &self,
+        ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send
+        where
+            Self: Sync,
+        {
+            self.inner.lock().clear();
+            async move { Ok(()) }
+        }
+
+        fn async_cache_reset(
+            &self,
+        ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send
+        where
+            Self: Sync,
+        {
+            self.inner.lock().clear();
+            async move { Ok(()) }
+        }
+    }
+
+    #[tokio::test]
+    async fn async_cache_contains_true_after_set_no_clone_bound() {
+        let store = NoCloneAsyncStore::new();
+
+        // Absent initially.
+        assert!(!store.async_cache_contains(&10u32).await.unwrap());
+
+        store.async_cache_set(10, NoClone(42)).await.unwrap();
+
+        // Present after set -- no V: Clone needed.
+        assert!(store.async_cache_contains(&10u32).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn async_cache_contains_false_after_removal() {
+        let store = NoCloneAsyncStore::new();
+        store.async_cache_set(7, NoClone(1)).await.unwrap();
+        assert!(store.async_cache_contains(&7u32).await.unwrap());
+
+        store.async_cache_remove(&7).await.unwrap();
+        assert!(!store.async_cache_contains(&7u32).await.unwrap());
+    }
+}
+
+// ── 3. Inherent sharded `contains` returns plain bool ────────────────────────
+
+/// The inherent `ShardedLruCache::contains` takes priority over the
+/// `ConcurrentCachedExt::contains` (which returns `Result<bool, _>`).
+/// The type annotation on `b` is the assertion: if the wrong method resolved,
+/// the annotation would be `Result<bool, Infallible>` and this would fail to compile.
+#[test]
+fn sharded_lru_inherent_contains_returns_bool() {
+    let cache: ShardedLruCache<u32, String> = ShardedLruCache::builder()
+        .max_size(16)
+        .build()
+        .expect("build ShardedLruCache");
+
+    cache.cache_set(1, "a".to_string()).unwrap();
+
+    // Type annotation asserts the inherent method (-> bool) resolved, not the ext trait (-> Result).
+    let b: bool = cache.contains(&1);
+    assert!(b, "contains must return true after cache_set");
+
+    let absent: bool = cache.contains(&999);
+    assert!(!absent, "contains must return false for an absent key");
+
+    // Inherent method agrees with trait method.
+    assert_eq!(
+        cache.contains(&1),
+        cache.cache_contains(&1).unwrap(),
+        "inherent contains must agree with trait cache_contains"
+    );
+}
+
+/// Same check for `ShardedUnboundCache`.
+#[test]
+fn sharded_unbound_inherent_contains_returns_bool() {
+    let cache: ShardedUnboundCache<u32, String> =
+        ShardedUnboundCache::builder().build().expect("build");
+
+    cache.cache_set(42, "x".to_string()).unwrap();
+
+    let b: bool = cache.contains(&42);
+    assert!(b);
+
+    let absent: bool = cache.contains(&0);
+    assert!(!absent);
+
+    assert_eq!(cache.contains(&42), cache.cache_contains(&42).unwrap());
+}
+
+/// `ShardedTtlCache::contains` returns `bool`, respects TTL expiry,
+/// and agrees with `cache_contains`.
+#[cfg(feature = "time_stores")]
+mod ttl_contains {
+    use cached::{ConcurrentCached, ShardedTtlCache};
+    use std::time::Duration;
+
+    #[test]
+    fn sharded_ttl_inherent_contains_returns_bool_and_expires() {
+        let cache: ShardedTtlCache<u32, String> = ShardedTtlCache::builder()
+            .ttl(Duration::from_millis(50))
+            .build()
+            .expect("build ShardedTtlCache");
+
+        cache.cache_set(1, "hello".to_string()).unwrap();
+
+        // Immediately after insertion the key must be present.
+        let before: bool = cache.contains(&1);
+        assert!(before, "contains must return true before expiry");
+
+        // Agree with trait method before expiry.
+        assert_eq!(
+            cache.contains(&1),
+            cache.cache_contains(&1).unwrap(),
+            "inherent and trait contains must agree before expiry"
+        );
+
+        // Sleep past the TTL with a comfortable margin.
+        std::thread::sleep(Duration::from_millis(150));
+
+        // Entry must be expired now.
+        let after: bool = cache.contains(&1);
+        assert!(!after, "contains must return false after TTL expiry");
+
+        // Agree with trait method after expiry.
+        assert_eq!(
+            cache.contains(&1),
+            cache.cache_contains(&1).unwrap(),
+            "inherent and trait contains must agree after expiry"
+        );
+    }
+}
+
+// ── 3b. Remaining sharded stores: inherent contains ──────────────────────────
+
+/// `ShardedLruTtlCache::contains` returns plain `bool`, agrees with
+/// `cache_contains`, and returns false for expired entries.
+#[cfg(feature = "time_stores")]
+mod lru_ttl_contains {
+    use cached::{ConcurrentCached, ShardedLruTtlCache};
+    use std::time::Duration;
+
+    #[test]
+    fn sharded_lru_ttl_contains_true_and_false() {
+        let cache: ShardedLruTtlCache<u32, String> = ShardedLruTtlCache::builder()
+            .max_size(16)
+            .ttl(Duration::from_millis(50))
+            .build()
+            .expect("build ShardedLruTtlCache");
+
+        // Absent before insertion.
+        let absent: bool = cache.contains(&1);
+        assert!(!absent, "contains must be false before any insertion");
+
+        cache.cache_set(1, "a".to_string()).unwrap();
+
+        // Present immediately after insertion.
+        let b: bool = cache.contains(&1);
+        assert!(b, "contains must return true after cache_set");
+
+        // Absent key.
+        let b2: bool = cache.contains(&999);
+        assert!(!b2, "contains must return false for absent key");
+
+        // Agrees with trait method.
+        assert_eq!(
+            cache.contains(&1),
+            cache.cache_contains(&1).unwrap(),
+            "inherent contains must agree with trait cache_contains"
+        );
+
+        // Wait past TTL.
+        std::thread::sleep(Duration::from_millis(150));
+
+        let after: bool = cache.contains(&1);
+        assert!(!after, "contains must return false after TTL expiry");
+
+        // Agrees with trait method after expiry.
+        assert_eq!(
+            cache.contains(&1),
+            cache.cache_contains(&1).unwrap(),
+            "inherent and trait contains must agree after expiry"
+        );
+    }
+}
+
+/// `ShardedExpiringCache::contains` returns plain `bool`, is false for expired
+/// entries (by value expiry), and agrees with `cache_contains`.
+mod expiring_cache_contains {
+    use cached::time::Instant;
+    use cached::{ConcurrentCached, Expires, ShardedExpiringCache};
+
+    #[derive(Clone)]
+    struct MayExpire {
+        expired: bool,
+    }
+
+    impl Expires for MayExpire {
+        fn is_expired(&self) -> bool {
+            self.expired
+        }
+        fn expires_at(&self) -> Option<Instant> {
+            None
+        }
+    }
+
+    #[test]
+    fn sharded_expiring_cache_contains_live_and_expired() {
+        let cache: ShardedExpiringCache<u32, MayExpire> = ShardedExpiringCache::new();
+
+        // Absent before insertion.
+        let absent: bool = cache.contains(&1);
+        assert!(!absent, "contains must be false before insertion");
+
+        // Live entry.
+        cache.cache_set(1, MayExpire { expired: false }).unwrap();
+        let b: bool = cache.contains(&1);
+        assert!(b, "contains must return true for a live entry");
+
+        // Agrees with trait method.
+        assert_eq!(
+            cache.contains(&1),
+            cache.cache_contains(&1).unwrap(),
+            "inherent and trait contains must agree"
+        );
+
+        // Expired entry.
+        cache.cache_set(2, MayExpire { expired: true }).unwrap();
+        let expired: bool = cache.contains(&2);
+        assert!(!expired, "contains must return false for an expired entry");
+
+        assert_eq!(
+            cache.contains(&2),
+            cache.cache_contains(&2).unwrap(),
+            "inherent and trait contains must agree for expired entry"
+        );
+    }
+}
+
+/// `ShardedExpiringLruCache::contains` returns plain `bool`, is false for
+/// expired entries, and agrees with `cache_contains`.
+mod expiring_lru_cache_contains {
+    use cached::time::Instant;
+    use cached::{ConcurrentCached, Expires, ShardedExpiringLruCache};
+
+    #[derive(Clone)]
+    struct MayExpire {
+        expired: bool,
+    }
+
+    impl Expires for MayExpire {
+        fn is_expired(&self) -> bool {
+            self.expired
+        }
+        fn expires_at(&self) -> Option<Instant> {
+            None
+        }
+    }
+
+    #[test]
+    fn sharded_expiring_lru_cache_contains_live_and_expired() {
+        let cache: ShardedExpiringLruCache<u32, MayExpire> = ShardedExpiringLruCache::builder()
+            .max_size(16)
+            .build()
+            .expect("build ShardedExpiringLruCache");
+
+        // Absent before insertion.
+        let absent: bool = cache.contains(&1);
+        assert!(!absent, "contains must be false before insertion");
+
+        // Live entry.
+        cache.cache_set(1, MayExpire { expired: false }).unwrap();
+        let b: bool = cache.contains(&1);
+        assert!(b, "contains must return true for a live entry");
+
+        // Agrees with trait method.
+        assert_eq!(
+            cache.contains(&1),
+            cache.cache_contains(&1).unwrap(),
+            "inherent and trait contains must agree"
+        );
+
+        // Expired entry.
+        cache.cache_set(2, MayExpire { expired: true }).unwrap();
+        let expired: bool = cache.contains(&2);
+        assert!(!expired, "contains must return false for an expired entry");
+
+        assert_eq!(
+            cache.contains(&2),
+            cache.cache_contains(&2).unwrap(),
+            "inherent and trait contains must agree for expired entry"
+        );
+    }
+}
+
+// ── 3c. ConcurrentCachedExt::contains via fully-qualified syntax ─────────────
+
+/// Prove that `ConcurrentCachedExt::contains` still exists and compiles on a
+/// sharded store when called via fully-qualified syntax.  The FQS path returns
+/// `Result<bool, Infallible>`, not `bool`, which is distinct from the inherent
+/// `contains` that returns plain `bool`.  This also proves the ext-trait alias
+/// has no `V: Clone` bound (ShardedUnboundCache<u32, String> would compile
+/// anyway, but the assertion is on the return type).
+#[test]
+fn ext_trait_contains_via_fqs_returns_result_bool() {
+    use cached::ConcurrentCachedExt;
+
+    let cache: ShardedUnboundCache<u32, String> =
+        ShardedUnboundCache::builder().build().expect("build");
+
+    cache.cache_set(7, "hello".to_string()).unwrap();
+
+    // Fully-qualified call goes to the ext-trait impl, not the inherent method.
+    let result: Result<bool, _> = ConcurrentCachedExt::contains(&cache, &7u32);
+    assert!(
+        result.unwrap(),
+        "ext-trait contains must return true for present key"
+    );
+
+    let result_absent: Result<bool, _> = ConcurrentCachedExt::contains(&cache, &99u32);
+    assert!(
+        !result_absent.unwrap(),
+        "ext-trait contains must return false for absent key"
+    );
+}
+
+// ── 3d. Inherent contains does not promote LRU recency on ShardedLruCache ────
+
+/// With a single shard and per_shard_max_size=2, inserting a third entry evicts
+/// the LRU entry.  If `contains` promoted recency, the order would shift and a
+/// different entry would survive.  We verify that calling `contains` on key 1
+/// (the insertion-order LRU) before overflowing does NOT change which key is
+/// evicted: key 1 should still be the LRU victim.
+///
+/// Setup (single shard, cap=2):
+///   set(1), set(2)   → LRU order: 1 < 2
+///   contains(1)      → must NOT move 1 to MRU
+///   set(3)           → if no promotion: evicts 1; if promotion: evicts 2
+///   assert 1 absent, 2 present, 3 present
+#[test]
+fn sharded_lru_contains_does_not_promote_recency() {
+    let cache: ShardedLruCache<u32, String> = ShardedLruCache::builder()
+        .shards(1)
+        .per_shard_max_size(2)
+        .build()
+        .expect("build ShardedLruCache with single shard cap=2");
+
+    cache.cache_set(1, "one".to_string()).unwrap();
+    cache.cache_set(2, "two".to_string()).unwrap();
+
+    // Call contains on key 1 (currently LRU). Must NOT promote it.
+    let _: bool = cache.contains(&1);
+
+    // Insert key 3: should evict key 1 (still LRU because contains did not promote).
+    cache.cache_set(3, "three".to_string()).unwrap();
+
+    assert!(
+        !cache.contains(&1),
+        "key 1 must have been evicted -- contains must not promote LRU recency"
+    );
+    assert!(cache.contains(&2), "key 2 must still be present");
+    assert!(cache.contains(&3), "key 3 must be present");
+}
+
+// ── 4. Peek semantics: contains does not change metrics ──────────────────────
+
+/// After calling `contains` on a key that is present, `metrics().hits` and
+/// `metrics().misses` must be unchanged -- `contains` is peek-based and must not
+/// record a hit or miss.
+#[test]
+fn sharded_lru_contains_does_not_affect_hit_miss_metrics() {
+    let cache: ShardedLruCache<u32, String> = ShardedLruCache::builder()
+        .max_size(16)
+        .build()
+        .expect("build ShardedLruCache");
+
+    cache.cache_set(1, "a".to_string()).unwrap();
+
+    let before = cache.metrics();
+
+    // Call contains on a present key and on an absent key.
+    let _present: bool = cache.contains(&1);
+    let _absent: bool = cache.contains(&999);
+
+    let after = cache.metrics();
+
+    assert_eq!(after.hits, before.hits, "contains must not increment hits");
+    assert_eq!(
+        after.misses, before.misses,
+        "contains must not increment misses"
+    );
+}

--- a/tests/v3_expiring_lru_order.rs
+++ b/tests/v3_expiring_lru_order.rs
@@ -1,0 +1,339 @@
+//! Tests for `ExpiringLruCache::iter_order`, `key_order`, and `value_order`.
+//!
+//! Behavior pinned:
+//! 1. The three methods return entries in most-to-least-recently-used order and
+//!    their results agree with each other.
+//! 2. Already-expired entries are excluded from all three methods while `len()`
+//!    may still count them (lazy eviction).
+//! 3. The return types are `Vec<(K, V)>`, `Vec<K>`, and `Vec<V>` respectively.
+
+use cached::time::Instant;
+use cached::{Cached, Expires, ExpiringLruCache};
+
+// ── Value type with configurable expiry ──────────────────────────────────────
+
+/// A simple value that can be configured to be live or expired.
+#[derive(Clone, Debug, PartialEq)]
+struct Val {
+    id: u32,
+    /// When true, `is_expired()` returns true regardless of any other state.
+    expired: bool,
+}
+
+impl Val {
+    fn live(id: u32) -> Self {
+        Self { id, expired: false }
+    }
+
+    fn dead(id: u32) -> Self {
+        Self { id, expired: true }
+    }
+}
+
+impl Expires for Val {
+    fn is_expired(&self) -> bool {
+        self.expired
+    }
+
+    fn expires_at(&self) -> Option<Instant> {
+        None
+    }
+}
+
+// ── 1 & 3. Order and return-type shape ────────────────────────────────────────
+
+/// `iter_order`, `key_order`, and `value_order` return live entries in
+/// most-to-least-recently-used order and agree with each other.
+///
+/// Access sequence that makes the order deterministic:
+///   insert 1, 2, 3  (LRU order after inserts: 1 < 2 < 3)
+///   get(1)          (1 becomes MRU)
+///   get(2)          (2 becomes MRU, order: 3 < 1 < 2)
+///
+/// Expected MRU order: [2, 1, 3]
+#[test]
+fn iter_order_key_order_value_order_most_to_least_recent() {
+    let mut cache: ExpiringLruCache<u32, Val> = ExpiringLruCache::builder()
+        .max_size(10)
+        .build()
+        .expect("build ExpiringLruCache");
+
+    // Insert three live entries.
+    cache.cache_set(1, Val::live(1));
+    cache.cache_set(2, Val::live(2));
+    cache.cache_set(3, Val::live(3));
+
+    // Access 1 then 2 to make 2 the MRU.
+    let _ = cache.cache_get(&1); // 1 becomes MRU
+    let _ = cache.cache_get(&2); // 2 becomes MRU
+
+    // Expected order: 2 (MRU), 1, 3 (LRU)
+    let expected_keys: Vec<u32> = vec![2, 1, 3];
+    let expected_vals: Vec<Val> = expected_keys.iter().map(|k| Val::live(*k)).collect();
+    let expected_pairs: Vec<(u32, Val)> = expected_keys
+        .iter()
+        .cloned()
+        .zip(expected_vals.iter().cloned())
+        .collect();
+
+    // ── iter_order returns Vec<(K, V)> ──────────────────────────────────────
+    let pairs: Vec<(u32, Val)> = cache.iter_order();
+    assert_eq!(
+        pairs, expected_pairs,
+        "iter_order must return (key, value) pairs in MRU order"
+    );
+
+    // ── key_order returns Vec<K> ─────────────────────────────────────────────
+    let keys: Vec<u32> = cache.key_order();
+    assert_eq!(
+        keys, expected_keys,
+        "key_order must return keys in MRU order"
+    );
+
+    // ── value_order returns Vec<V> ───────────────────────────────────────────
+    let vals: Vec<Val> = cache.value_order();
+    assert_eq!(
+        vals, expected_vals,
+        "value_order must return values in MRU order"
+    );
+
+    // ── all three methods agree with each other ──────────────────────────────
+    let keys_from_pairs: Vec<u32> = pairs.iter().map(|(k, _)| *k).collect();
+    let vals_from_pairs: Vec<Val> = pairs.into_iter().map(|(_, v)| v).collect();
+
+    assert_eq!(
+        keys, keys_from_pairs,
+        "key_order and iter_order keys must agree"
+    );
+    assert_eq!(
+        vals, vals_from_pairs,
+        "value_order and iter_order values must agree"
+    );
+}
+
+// ── 2. Expired entries are excluded; len() may still count them ───────────────
+
+/// An expired entry is invisible to all three order methods but `len()` (lazy
+/// eviction) may still count it.
+#[test]
+fn expired_entries_excluded_from_order_methods() {
+    let mut cache: ExpiringLruCache<u32, Val> = ExpiringLruCache::builder()
+        .max_size(10)
+        .build()
+        .expect("build ExpiringLruCache");
+
+    cache.cache_set(1, Val::live(1));
+    cache.cache_set(2, Val::dead(2)); // expired -- set directly as dead
+    cache.cache_set(3, Val::live(3));
+
+    // The cache stores 3 entries (lazy eviction: expired entry is still counted
+    // by cache_size until a mutating operation removes it).
+    let raw_size = cache.cache_size();
+    assert!(
+        raw_size >= 2,
+        "cache_size should count stored entries (including expired); got {raw_size}"
+    );
+
+    // iter_order must exclude the expired entry.
+    let pairs: Vec<(u32, Val)> = cache.iter_order();
+    let keys_in_pairs: Vec<u32> = pairs.iter().map(|(k, _)| *k).collect();
+    assert!(
+        !keys_in_pairs.contains(&2),
+        "iter_order must exclude expired entry (key=2)"
+    );
+    assert!(
+        keys_in_pairs.contains(&1) && keys_in_pairs.contains(&3),
+        "iter_order must include live entries (keys 1 and 3)"
+    );
+
+    // key_order must exclude the expired entry.
+    let keys: Vec<u32> = cache.key_order();
+    assert!(
+        !keys.contains(&2),
+        "key_order must exclude expired entry (key=2)"
+    );
+    assert!(
+        keys.contains(&1) && keys.contains(&3),
+        "key_order must include live entries (keys 1 and 3)"
+    );
+
+    // value_order must exclude the expired entry.
+    let vals: Vec<Val> = cache.value_order();
+    let val_ids: Vec<u32> = vals.iter().map(|v| v.id).collect();
+    assert!(
+        !val_ids.contains(&2),
+        "value_order must exclude value of expired entry (id=2)"
+    );
+    assert!(
+        val_ids.contains(&1) && val_ids.contains(&3),
+        "value_order must include live values (ids 1 and 3)"
+    );
+
+    // All three return the same (live) count.
+    assert_eq!(
+        pairs.len(),
+        keys.len(),
+        "iter_order and key_order must have the same length"
+    );
+    assert_eq!(
+        keys.len(),
+        vals.len(),
+        "key_order and value_order must have the same length"
+    );
+}
+
+// ── Combined: expired entry excluded while len may be larger ──────────────────
+
+/// When ALL inserted entries are expired, all three order methods return empty
+/// vecs, but `cache_size` may still report the raw stored count.
+#[test]
+fn all_expired_returns_empty_vecs() {
+    let mut cache: ExpiringLruCache<u32, Val> = ExpiringLruCache::builder()
+        .max_size(10)
+        .build()
+        .expect("build ExpiringLruCache");
+
+    cache.cache_set(1, Val::dead(1));
+    cache.cache_set(2, Val::dead(2));
+
+    assert_eq!(cache.iter_order(), Vec::<(u32, Val)>::new());
+    assert_eq!(cache.key_order(), Vec::<u32>::new());
+    assert_eq!(cache.value_order(), Vec::<Val>::new());
+}
+
+// ── Single-entry edge case ────────────────────────────────────────────────────
+
+#[test]
+fn single_live_entry_appears_in_all_order_methods() {
+    let mut cache: ExpiringLruCache<u32, Val> = ExpiringLruCache::builder()
+        .max_size(5)
+        .build()
+        .expect("build ExpiringLruCache");
+
+    cache.cache_set(7, Val::live(7));
+
+    let pairs: Vec<(u32, Val)> = cache.iter_order();
+    assert_eq!(pairs, vec![(7, Val::live(7))]);
+
+    let keys: Vec<u32> = cache.key_order();
+    assert_eq!(keys, vec![7]);
+
+    let vals: Vec<Val> = cache.value_order();
+    assert_eq!(vals, vec![Val::live(7)]);
+}
+
+// ── Empty cache ───────────────────────────────────────────────────────────────
+
+#[test]
+fn empty_cache_returns_empty_vecs() {
+    let cache: ExpiringLruCache<u32, Val> = ExpiringLruCache::builder()
+        .max_size(5)
+        .build()
+        .expect("build ExpiringLruCache");
+
+    assert_eq!(cache.iter_order(), Vec::<(u32, Val)>::new());
+    assert_eq!(cache.key_order(), Vec::<u32>::new());
+    assert_eq!(cache.value_order(), Vec::<Val>::new());
+}
+
+// ── After capacity overflow (LRU eviction) ───────────────────────────────────
+
+/// When the cache is full and a new entry is inserted, the LRU entry is evicted.
+/// The order methods must reflect only the survivors and still report
+/// most-to-least recently used order among them.
+///
+/// Setup (cap=2):
+///   set(1), set(2)   → LRU order: 1 < 2
+///   get(1)           → 1 becomes MRU; order: 2 < 1
+///   set(3)           → evicts 2 (LRU); order after: 3 < 1  (3 is MRU as most recent insert)
+///
+/// Wait -- insertion of 3 promotes 3 to MRU, so order is: 3, 1
+#[test]
+fn order_methods_after_lru_eviction() {
+    let mut cache: ExpiringLruCache<u32, Val> = ExpiringLruCache::builder()
+        .max_size(2)
+        .build()
+        .expect("build ExpiringLruCache with cap=2");
+
+    cache.cache_set(1, Val::live(1));
+    cache.cache_set(2, Val::live(2));
+
+    // Access key 1 to make it MRU. LRU order is now: 2 < 1.
+    let _ = cache.cache_get(&1);
+
+    // Insert key 3. Evicts key 2 (the LRU). LRU order after: 1 < 3.
+    cache.cache_set(3, Val::live(3));
+
+    // key 2 must be gone.
+    let keys: Vec<u32> = cache.key_order();
+    assert!(
+        !keys.contains(&2),
+        "key 2 must have been evicted; got keys: {keys:?}"
+    );
+
+    // Survivors are keys 1 and 3.
+    assert!(
+        keys.contains(&1) && keys.contains(&3),
+        "keys 1 and 3 must be present; got: {keys:?}"
+    );
+
+    // Most-recently-used is key 3 (inserted last), then key 1.
+    assert_eq!(
+        keys,
+        vec![3, 1],
+        "order must be most-to-least recently used: [3, 1]; got: {keys:?}"
+    );
+
+    // iter_order, key_order, value_order must agree.
+    let pairs: Vec<(u32, Val)> = cache.iter_order();
+    let vals: Vec<Val> = cache.value_order();
+
+    assert_eq!(
+        pairs.iter().map(|(k, _)| *k).collect::<Vec<_>>(),
+        keys,
+        "iter_order keys must match key_order"
+    );
+    assert_eq!(
+        vals.iter().map(|v| v.id).collect::<Vec<_>>(),
+        keys,
+        "value_order ids must match key_order"
+    );
+}
+
+/// When a mix of live and expired entries are in the cache and capacity
+/// overflow occurs, the order methods show only the live survivors.
+#[test]
+fn order_methods_after_eviction_with_pre_existing_expired_entry() {
+    let mut cache: ExpiringLruCache<u32, Val> = ExpiringLruCache::builder()
+        .max_size(3)
+        .build()
+        .expect("build ExpiringLruCache with cap=3");
+
+    cache.cache_set(1, Val::live(1));
+    cache.cache_set(2, Val::dead(2)); // expired
+    cache.cache_set(3, Val::live(3));
+
+    // Access key 1 to make it MRU.
+    let _ = cache.cache_get(&1);
+
+    // Insert key 4 to overflow capacity. LRU victim is key 2 (or 1, or 3 depending
+    // on internal order after a dead-value get). Either way, key 4 must appear in
+    // the live results and key 2 must never appear (it is expired).
+    cache.cache_set(4, Val::live(4));
+
+    let keys: Vec<u32> = cache.key_order();
+    assert!(
+        !keys.contains(&2),
+        "expired key 2 must not appear in key_order; got: {keys:?}"
+    );
+    assert!(
+        keys.contains(&4),
+        "newly inserted key 4 must appear in key_order; got: {keys:?}"
+    );
+
+    // All three order methods must agree in length.
+    let pairs = cache.iter_order();
+    let vals = cache.value_order();
+    assert_eq!(pairs.len(), keys.len());
+    assert_eq!(vals.len(), keys.len());
+}

--- a/tests/v3_single_owner_zero_ttl.rs
+++ b/tests/v3_single_owner_zero_ttl.rs
@@ -662,59 +662,42 @@ fn ttl_sorted_cache_set_overflow_stores_never_expiring_value() {
     );
 }
 
-// Gap A: `TtlSortedCache` has BOTH an inherent `set_ttl` (method-call syntax resolves to
-// it, shadowing the trait) and the `CacheTtl::set_ttl` trait method. They are two separate
-// implementations that must not diverge. In particular, the "previous ttl was zero"
-// contract (return `None`, not `Some(Duration::ZERO)`) must hold identically on both. The
-// existing suite only exercises the trait method via UFCS; nothing pins the inherent method
-// against the trait method, so a regression to only one of them would go unnoticed.
+// Gap A: `CacheTtl::set_ttl` on `TtlSortedCache` must honour the "previous ttl was zero"
+// contract: return `None` (not `Some(Duration::ZERO)`) when expiry was disabled, and
+// return `Some(prev)` when the previous ttl was a real non-zero duration. The new ttl
+// must take effect for subsequent inserts. Runtime TTL control is via the `CacheTtl`
+// trait; there is no separate inherent `set_ttl`.
 #[test]
-fn ttl_sorted_cache_inherent_and_trait_set_ttl_agree() {
+fn ttl_sorted_cache_trait_set_ttl_semantics() {
     use cached::TtlSortedCache;
 
-    // ── previous-was-NONZERO: both must return Some(prev) ──
-    let mut a = TtlSortedCache::<u32, u32>::builder()
+    // ── previous-was-NONZERO: set_ttl must return Some(prev) ──
+    let mut cache = TtlSortedCache::<u32, u32>::builder()
         .ttl(Duration::from_secs(60))
         .build()
-        .expect("build a");
-    let mut b = TtlSortedCache::<u32, u32>::builder()
-        .ttl(Duration::from_secs(60))
-        .build()
-        .expect("build b");
+        .expect("build cache");
 
-    // `a.set_ttl(..)` binds the inherent method; UFCS pins the trait method on `b`.
-    let inherent_nonzero = a.set_ttl(Duration::ZERO);
-    let trait_nonzero = CacheTtl::set_ttl(&mut b, Duration::ZERO);
+    // Disable expiry via the trait method; previous ttl was 60s so Some(60s) is expected.
+    let prev = CacheTtl::set_ttl(&mut cache, Duration::ZERO);
     assert_eq!(
-        inherent_nonzero, trait_nonzero,
-        "inherent and trait set_ttl must agree when the previous ttl was non-zero"
-    );
-    assert_eq!(
-        inherent_nonzero,
+        prev,
         Some(Duration::from_secs(60)),
         "previous non-zero ttl must be reported as Some(prev)"
     );
 
-    // Both stores are now disabled (ttl == zero); ttl() must resolve to None on each.
-    assert_eq!(CacheTtl::ttl(&a), None);
-    assert_eq!(CacheTtl::ttl(&b), None);
+    // Cache is now disabled (ttl == zero); ttl() must resolve to None.
+    assert_eq!(CacheTtl::ttl(&cache), None);
 
-    // ── previous-was-ZERO: both must return None (NOT Some(Duration::ZERO)) ──
-    // `a` and `b` currently have a zero (disabled) ttl, so the next set observes prev==zero.
-    let inherent_prev_zero = a.set_ttl(Duration::from_secs(5));
-    let trait_prev_zero = CacheTtl::set_ttl(&mut b, Duration::from_secs(5));
+    // ── previous-was-ZERO: set_ttl must return None (NOT Some(Duration::ZERO)) ──
+    // The cache currently has a zero (disabled) ttl, so the next set observes prev==zero.
+    let prev_zero = CacheTtl::set_ttl(&mut cache, Duration::from_secs(5));
     assert_eq!(
-        inherent_prev_zero, trait_prev_zero,
-        "inherent and trait set_ttl must agree when the previous ttl was zero"
-    );
-    assert_eq!(
-        inherent_prev_zero, None,
-        "a zero previous ttl must be reported as None by BOTH the inherent and trait set_ttl"
+        prev_zero, None,
+        "a zero previous ttl must be reported as None by CacheTtl::set_ttl"
     );
 
-    // Post-state must also agree: both re-armed to 5s.
-    assert_eq!(CacheTtl::ttl(&a), Some(Duration::from_secs(5)));
-    assert_eq!(CacheTtl::ttl(&b), CacheTtl::ttl(&a));
+    // Cache is now re-armed to 5s; ttl() must reflect the new value.
+    assert_eq!(CacheTtl::ttl(&cache), Some(Duration::from_secs(5)));
 }
 
 // Gap B: `try_set_ttl` (the `CacheTtl` default) on `TtlSortedCache` after the `ttl()`


### PR DESCRIPTION
- Make `ConcurrentCached::cache_contains` and `ConcurrentCachedAsync::async_cache_contains` required and drop the `V: Clone` bound; add explicit impls to `RedisCache`, `AsyncRedisCache`, and `RedbCache`
- Add defaulted `Cached::cache_contains`; built-in single-owner stores override it peek-based (no hit/miss counts, no LRU promotion, no ttl refresh, expired entries report false); `CachedExt::contains` delegates to it
- Add inherent infallible `contains` to the six sharded stores, matching the other inherent shims
- Add `ExpiringLruCache::iter_order`/`key_order`/`value_order` (expired entries excluded)
- Remove the inherent `TtlSortedCache::set_ttl`; runtime ttl controls are trait-only via `CacheTtl`/`ConcurrentCacheTtl`
- Update changelog, migration guides, and specs; add `v3_contains_parity` and `v3_expiring_lru_order` test suites

Note that the required-method change and the `set_ttl` removal are breaking for the 3.0.0 rcs only; both surfaces first shipped in rc releases.