### PR TITLE
release: 3.0.0-rc.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,12 @@ on:
     branches:
       - master
       - main
+  workflow_dispatch:
 jobs:
   publish:
+    # Only request release-environment approval for actual release commits
+    # (or a manual dispatch); other merges to master skip the job entirely.
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'release:')
     runs-on: ubuntu-latest
     environment: release  # Optional: for enhanced security
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [3.0.0-rc.9] - 2026-07-19
+
 ### Breaking Changes
 
 - `Cached::Error` and `ConcurrentCacheBase::Error` are now bounded by

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cached"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 authors = ["James Kominick <james@kominick.com>"]
 description = "Generic cache implementations and simplified function memoization"
 repository = "https://github.com/jaemk/cached"


### PR DESCRIPTION
- Bump `cached` to 3.0.0-rc.9 (`cached_proc_macro` / `cached_proc_macro_types` unchanged, no changes since rc.8)
- Move the `[Unreleased]` changelog section to `[3.0.0-rc.9] - 2026-07-19`
- Gate the crates.io publish job on a `release:` head commit message so the release-environment approval is only requested for releases; add `workflow_dispatch` as a manual fallback