### PR TITLE
feat: remove `CacheSetError`, rename `TtlSortedCache` `insert*` to `set*`, wrap order-method values in `CacheValue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- `CacheSetError` is removed. A TTL that would overflow `Instant` bounds (hundreds of years)
+  now stores the entry with no expiry (never expires) on every set path, matching the sharded
+  TTL stores; `cache_set` already behaved this way. `TtlCache`, `LruTtlCache`, and
+  `TtlSortedCache` set `Cached::Error = std::convert::Infallible`, so every built-in in-memory
+  store is now infallible. Call sites binding `CacheSetError` or matching `TimeBounds` must
+  drop the error handling.
+- `TtlSortedCache` `insert` / `insert_ttl` / `insert_evict` / `insert_ttl_evict` are renamed to
+  `set` / `set_with_ttl` / `set_evict` / `set_with_ttl_evict` and return `Option<V>` (the
+  displaced unexpired value) instead of `Result<Option<V>, CacheSetError>`.
+- `iter_order` / `value_order` on `LruCache`, `LruTtlCache`, and `ExpiringLruCache` return
+  `CacheValue`-wrapped values: `iter_order() -> Vec<(K, CacheValue<V, M>)>` and
+  `value_order() -> Vec<CacheValue<V, M>>`, one shape across the LRU family. `M` is per-entry
+  metadata: `()` for `LruCache` / `ExpiringLruCache`, `Option<Instant>` for `LruTtlCache`
+  (exposed via `CacheValue::expires_at`; `None` means never expires). `LruTtlCache` no longer
+  leaks bare `(Option<Instant>, V)` tuples. `key_order` is unchanged.
+
+### Added
+
+- `CacheValue<V, M = ()>`: value-plus-metadata wrapper returned by the LRU-family order
+  methods, re-exported from the crate root. `Deref<Target = V>`, `PartialEq<V>` against bare
+  values, `value()` / `into_value()`, and `expires_at()` when `M = Option<Instant>`.
+
 ## [3.0.0-rc.9] - 2026-07-19
 
 ### Breaking Changes

--- a/docs/migrations/2.0-to-3.0.md
+++ b/docs/migrations/2.0-to-3.0.md
@@ -431,23 +431,23 @@ let c: ShardedUnboundCache<String, u32> = ShardedUnboundCache::new();
 ```
 The `#[concurrent_cached]` macro (no `max_size`/`ttl`/`expires`) still selects this store automatically; only the type name changed.
 
-### 18. `ttl_sorted::Error` / `TtlSortedCacheError` removed; use `CacheSetError`
+### 18. `ttl_sorted::Error` / `TtlSortedCacheError` removed; TTL set paths are infallible
 
 Detection: grep for `ttl_sorted::Error` or `TtlSortedCacheError`.
 
-Action: both names are gone. `TtlSortedCache` now uses the shared `cached::CacheSetError`
-(variant `TimeBounds`), the same error type as `TtlCache` and `LruTtlCache`. Replace any
-reference to either old name with `CacheSetError`. The unused
-`From<ttl_sorted::Error> for std::io::Error` conversion is also removed; if you relied on `?`
-turning this error into an `io::Error`, convert explicitly.
+Action: both names are gone, with no replacement error type. A TTL that would overflow
+`Instant` bounds (hundreds of years) now stores the entry with no expiry (never expires)
+instead of erroring, so every set path on `TtlSortedCache` is infallible and the store's
+`Cached::Error` is `std::convert::Infallible`. Drop the error handling. The unused
+`From<ttl_sorted::Error> for std::io::Error` conversion is also removed.
 ```rust
 // Before
 use cached::TtlSortedCacheError;
 let _: Result<Option<V>, TtlSortedCacheError> = cache.try_set(k, v);
 // After
-use cached::CacheSetError;
-let _: Result<Option<V>, CacheSetError> = cache.try_set(k, v);
+let _: Result<Option<V>, std::convert::Infallible> = cache.try_set(k, v);
 ```
+The `insert*` methods are also renamed; see #75.
 
 ### 19. `unbound` macro attribute removed
 
@@ -474,16 +474,20 @@ Detection: grep your `Cargo.toml` for `"wasm"` in the `cached` features list.
 
 Action: remove it. It gated nothing - `web-time` provides wasm-compatible time types transparently, so no opt-in feature is needed for wasm targets.
 
-### 22. `cache_try_set` returns `CacheSetError` instead of `Box<dyn Error>`
+### 22. `cache_try_set` error is `Self::Error` instead of `Box<dyn Error>`
 
 Detection: grep for `cache_try_set` / `try_set` call sites that bind the error, and custom `impl Cached` blocks that override `cache_try_set`.
 
-Action: the error type is now the concrete `cached::CacheSetError` (a `#[non_exhaustive]` enum, variant `TimeBounds`). Match on it instead of a boxed error; for a custom `Cached` impl, change the override's return type to `Result<Option<V>, Self::Error>` where `type Error` is declared on the impl (see #33 for the `type Error` requirement). For TTL stores `type Error = CacheSetError`; for infallible stores `type Error = std::convert::Infallible`.
+Action: the error type is now the associated `Cached::Error` (see #33). Every built-in
+in-memory store, including the TTL stores, sets `type Error = std::convert::Infallible`:
+a TTL that would overflow `Instant` bounds stores the entry with no expiry (never expires)
+instead of erroring. For a custom `Cached` impl, change the override's return type to
+`Result<Option<V>, Self::Error>` where `type Error` is declared on the impl.
 ```rust
 // Before
 fn cache_try_set(&mut self, k: K, v: V) -> Result<Option<V>, Box<dyn std::error::Error>> { ... }
-// After (TTL store, type Error = CacheSetError)
-fn cache_try_set(&mut self, k: K, v: V) -> Result<Option<V>, cached::CacheSetError> { ... }
+// After (infallible store)
+fn cache_try_set(&mut self, k: K, v: V) -> Result<Option<V>, std::convert::Infallible> { ... }
 ```
 
 ### 23. `DiskCache*` aliases removed
@@ -671,20 +675,17 @@ only use `set_ttl` to configure the TTL before insertions are unaffected.
 ### 33. `Cached` trait: `type Error` associated type required; `cache_try_set` / `try_set` return `Result<Option<V>, Self::Error>`
 
 `Cached` gained an associated `type Error`. Every `impl Cached` must declare it. The return type
-of `cache_try_set` (and its `try_set` alias) changed from `Result<Option<V>, CacheSetError>` to
+of `cache_try_set` (and its `try_set` alias) changed from `Result<Option<V>, Box<dyn Error>>` to
 `Result<Option<V>, Self::Error>`.
 
-Built-in mappings:
-
-| Store | `type Error` |
-|---|---|
-| `UnboundCache`, `LruCache`, `ExpiringCache`, `ExpiringLruCache`, sharded stores | `std::convert::Infallible` |
-| `TtlCache`, `LruTtlCache`, `TtlSortedCache` | `cached::CacheSetError` |
+Built-in mappings: every in-memory store (including `TtlCache`, `LruTtlCache`, and
+`TtlSortedCache`) sets `type Error = std::convert::Infallible`. A TTL that would overflow
+`Instant` bounds stores the entry with no expiry (never expires) instead of erroring, so no
+in-memory set path fails.
 
 Detection:
 - A custom `impl Cached` without `type Error` fails with `E0046`.
-- A call site that bound the error as `CacheSetError` for an infallible store fails with a type
-  mismatch.
+- A call site that bound the error to a concrete error type fails with a type mismatch.
 
 Action:
 ```rust
@@ -694,10 +695,7 @@ impl Cached<K, V> for MyStore {
     // ...
 }
 
-// Call site using an infallible store -- remove the CacheSetError annotation
-// Before
-let _: Result<Option<V>, CacheSetError> = cache.try_set(k, v);
-// After
+// Call site -- drop the concrete error annotation
 let _: Result<Option<V>, std::convert::Infallible> = cache.try_set(k, v);
 // or just let inference work:
 let _ = cache.try_set(k, v);
@@ -882,22 +880,22 @@ pub fn compute(x: u64) -> u64 { x * 2 }
 The default is to inherit the cached function's visibility (unchanged behavior). This is
 additive -- no action required.
 
-### 43. `TtlSortedCacheError` removed; `TtlSortedCache` uses `CacheSetError`
+### 43. `TtlSortedCacheError` removed; TTL set paths are infallible
 
-`TtlSortedCacheError` is removed. `TtlSortedCache` now uses the shared `cached::CacheSetError`
-(variant `TimeBounds`), the same error type as `TtlCache` and `LruTtlCache`, so all three TTL
-stores report one error type.
+`TtlSortedCacheError` is removed with no replacement error type. All three TTL stores
+(`TtlCache`, `LruTtlCache`, `TtlSortedCache`) treat a TTL that would overflow `Instant`
+bounds as never-expires instead of erroring, so their `Cached::Error` is
+`std::convert::Infallible` and no set path fails. See #18 and #22.
 
 Detection: `cannot find type TtlSortedCacheError` at an import or a type annotation.
 
-Action: replace `TtlSortedCacheError` with `CacheSetError` (the variant name `TimeBounds` is unchanged).
+Action: drop the error import and any error handling on set paths.
 ```rust
 // Before
 use cached::TtlSortedCacheError;
 let _: Result<Option<V>, TtlSortedCacheError> = cache.try_set(k, v);
 // After
-use cached::CacheSetError;
-let _: Result<Option<V>, CacheSetError> = cache.try_set(k, v);
+let _ = cache.try_set(k, v); // Err is Infallible
 ```
 
 ### 44. `disk_store` cargo feature renamed to `redb_store`
@@ -1528,7 +1526,7 @@ impl std::fmt::Display for MyStoreError {
 impl std::error::Error for MyStoreError {}
 ```
 Using `thiserror::Error` derive satisfies the bound automatically.
-All built-in error types (`std::convert::Infallible`, `CacheSetError`, `RedisCacheError`,
+All built-in error types (`std::convert::Infallible`, `RedisCacheError`,
 `RedbCacheError`) already satisfy the bound and require no changes.
 
 ### 72. `ConcurrentCached::cache_contains` and `async_cache_contains` are now required; `V: Clone` bound removed
@@ -1588,6 +1586,50 @@ cache.set_ttl(Duration::from_secs(30));
 Note: `unset_ttl`, `ttl`, `refresh_on_hit`, and `set_refresh_on_hit` were already trait-only on
 `TtlSortedCache`; only `set_ttl` had an inherent duplicate that is now removed.
 
+### 74. `iter_order` / `value_order` return `CacheValue`-wrapped values
+
+`LruCache`, `LruTtlCache`, and `ExpiringLruCache` share one shape for the recency-order
+accessors: `iter_order() -> Vec<(K, CacheValue<V, M>)>` and
+`value_order() -> Vec<CacheValue<V, M>>` (`key_order() -> Vec<K>` is unchanged).
+`CacheValue<V, M>` (re-exported from the root) derefs to `V`, compares directly against bare
+values (`PartialEq<V>`), and exposes `value()` / `into_value()`. `M` is per-entry metadata:
+`()` for `LruCache` / `ExpiringLruCache`, `Option<Instant>` for `LruTtlCache`, where
+`expires_at()` returns the entry's expiry (`None` means never expires). The 2.x
+`LruTtlCache` shapes exposing bare `(Option<Instant>, V)` tuples are gone.
+
+Detection: type mismatches at `iter_order` / `value_order` call sites, e.g.
+`expected Vec<(K, V)>, found Vec<(K, CacheValue<V>)>`.
+
+Action: destructure through the wrapper.
+```rust
+// Read through Deref, or unwrap explicitly:
+for (k, v) in cache.iter_order() {
+    println!("{k}: {}", *v);
+}
+let vals: Vec<V> = cache.value_order().into_iter().map(|v| v.into_value()).collect();
+// LruTtlCache: expiry moves from the tuple to the accessor
+let exp = cache.iter_order()[0].1.expires_at();
+```
+
+### 75. `TtlSortedCache` `insert*` renamed to `set*` and made infallible
+
+`insert` / `insert_ttl` / `insert_evict` / `insert_ttl_evict` are renamed to `set` /
+`set_with_ttl` / `set_evict` / `set_with_ttl_evict` and return `Option<V>` (the displaced
+unexpired value) instead of `Result<Option<V>, _>`; see #18 for the error removal.
+
+Detection: `no method named insert found for struct TtlSortedCache` (the compiler suggests
+`set`), or `.unwrap()` / `?` on the old `Result` return.
+
+Action: rename the call and drop the error handling.
+```rust
+// Before
+cache.insert(k, v).unwrap();
+cache.insert_ttl(k, v, Duration::from_secs(5)).unwrap();
+// After
+cache.set(k, v);
+cache.set_with_ttl(k, v, Duration::from_secs(5));
+```
+
 ### Single-owner `contains` semantic change (rc surface only; no code change required)
 
 `CachedExt::contains` now delegates to `Cached::cache_contains` (a new defaulted method on
@@ -1629,18 +1671,20 @@ has a breaking change this major, see #51).
   - `no function or associated item named 'new' found for struct RedbCache` / `RedisCache` / `AsyncRedisCache` → replace `::new(` with `::builder(` (#11).
   - an error like "`ttl` now takes a Duration expression ... for whole seconds use `ttl_secs = 60`" in a macro → rename `ttl = N` to `ttl_secs = N` (#12).
   - `cannot find type ShardedCache` / `ShardedCacheBase` / `ShardedCacheBuilder` → rename to `ShardedUnbound*` (#17).
-  - `cannot find type TtlSortedCacheError` or `ttl_sorted::Error` → both names are removed; `TtlSortedCache` now uses `CacheSetError` (#18 / #43).
+  - `cannot find type TtlSortedCacheError` or `ttl_sorted::Error` → both names are removed with no replacement; the TTL set paths are infallible (#18 / #43).
   - `E0046` "not all trait items implemented: cache_clear, cache_reset" on a custom concurrent store → implement them (#15); same for `cache_peek_with_expiry_status` on a custom `CloneCached`/`ConcurrentCloneCached` (#16).
   - `the unbound attribute has been removed` in a macro → drop `unbound` (#19).
   - `no method named refresh_on_hit`/`set_refresh_on_hit` on a `TtlCache`/`LruTtlCache` value → `use cached::CacheTtl;` (#20).
   - an unknown-feature error for `wasm` → remove it from your features (#21).
-  - a type-mismatch on a `cache_try_set`/`try_set` error binding, or `E0053` on a custom `cache_try_set` override → switch to `cached::CacheSetError` (#22).
+  - a type-mismatch on a `cache_try_set`/`try_set` error binding, or `E0053` on a custom `cache_try_set` override → the error is now `Self::Error` (`Infallible` for every built-in in-memory store); drop the concrete annotation (#22 / #33).
   - `cannot find type DiskCache*` → rename to `RedbCache*` (#23).
   - `no method named store` on an in-memory cache → use the public `Cached` API (#24).
   - `the trait bound MyHasher: Clone is not satisfied ... required by ... ShardHasher` → derive `Clone` on your custom shard hasher (#25).
   - `unused ... that must be used` on a `cache_size`/`cache_remove`/`metrics`/... call under `-D warnings` → bind with `let _ = ...` or use the value (see New APIs: `#[must_use]`).
   - `E0046` "not all trait items implemented, missing: Error" on a custom `Cached` impl → add `type Error = std::convert::Infallible;` (or your error type) to the impl (#33).
-  - `TtlSortedCache`'s `cache_try_set`/`try_set` error type is `CacheSetError`, unified with `TtlCache`/`LruTtlCache`; a previous binding to `TtlSortedCacheError` or `ttl_sorted::Error` must change to `CacheSetError` (#18 / #43).
+  - `TtlSortedCache`'s `cache_try_set`/`try_set` error type is `Infallible`, unified with `TtlCache`/`LruTtlCache`; a previous binding to `TtlSortedCacheError` or `ttl_sorted::Error` should be dropped (#18 / #43).
+  - `no method named insert`/`insert_ttl`/`insert_evict`/`insert_ttl_evict` on a `TtlSortedCache` → renamed to `set`/`set_with_ttl`/`set_evict`/`set_with_ttl_evict`, returning `Option<V>` (#75).
+  - a type mismatch `expected Vec<(K, V)>, found Vec<(K, CacheValue<V>)>` at an `iter_order`/`value_order` call site → the order methods return `CacheValue`-wrapped values; deref or `into_value()` (#74).
   - type mismatch `Result<Option<V>, Infallible>` where `Option<V>` is now expected from a sharded store's `get`/`set`/`remove`/`delete`/`reset` → remove the `Result` wrapper; call through the trait or use `cache_` prefix if `Result` is needed (#34).
   - `use of undeclared type TimedEntry` or `cannot find type TimedEntry in module cached` → remove the import; `TimedEntry` is no longer public (#35).
   - unknown feature `async_tokio_rt_multi_thread` → remove from `cached` features, add `tokio = { ..., features = ["rt-multi-thread"] }` to your own dev-dependencies (#36).

--- a/examples/expiring_sized_cache.rs
+++ b/examples/expiring_sized_cache.rs
@@ -27,9 +27,7 @@ async fn main() {
         for _ in 0..10 {
             {
                 let mut cache = write_cache.write().await;
-                cache
-                    .insert("A".to_string(), "A".to_string())
-                    .expect("write failure");
+                cache.set("A".to_string(), "A".to_string());
                 println!("[expiring_sized] wrote to cache");
             }
             tokio::time::sleep(Duration::from_millis(500)).await;

--- a/specs/design/0020-argument-error-unification.md
+++ b/specs/design/0020-argument-error-unification.md
@@ -1,20 +1,22 @@
 # 0020 - Unify single-variant argument errors
 
-Status: Needs research
+Status: Declined (split kept; `CacheSetError` removed instead)
 
 ## Current state
 
-- Three single-variant error enums for bad setter arguments: `SetMaxSizeError::ZeroMaxSize`,
-  `SetTtlError::ZeroTtl`, `CacheSetError::TimeBounds` (`src/stores/mod.rs`).
-- All are "you passed a bad argument at a setter".
+- Two single-variant error enums for bad setter arguments: `SetMaxSizeError::ZeroMaxSize`,
+  `SetTtlError::ZeroTtl` (`src/stores/mod.rs`).
+- Both are "you passed a bad argument at a setter".
+- `CacheSetError::TimeBounds` was removed for 3.0.0: TTL stores treat an
+  `Instant`-overflowing expiry as never-expires (matching the sharded stores), so
+  the unsync TTL stores are `Cached::Error = Infallible` and no set path fails.
 
 ## Desired work
 
-- Merge into one small enum (e.g. `ValueError` with `ZeroMaxSize | ZeroTtl | TimeBounds`), reducing
-  the number of public error types.
+- None. Merging the remaining two was considered and declined.
 
 ## Notes
 
-- Counter-argument: the current per-operation single-variant typing is precise (a
-  try_set_max_size can only fail one way). Lean toward keeping them split.
-- Tracked as a conscious 3.0 decision. All are already #[non_exhaustive].
+- The per-operation single-variant typing is precise (a try_set_max_size can only
+  fail one way); keeping them split was the conscious 3.0 decision. Both are
+  #[non_exhaustive].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -672,7 +672,7 @@ pub use stores::{AsyncRedisCache, AsyncRedisCacheBuilder};
 // preempt it. The requirement is documented on each capability feature in Cargo.toml: pair it
 // with a `redis_tokio*` or `redis_smol*` runtime feature.
 pub use stores::{
-    BuildError, CacheEvict, CacheSetError, ConcurrentCacheEvict, DefaultHashBuilder,
+    BuildError, CacheEvict, CacheValue, ConcurrentCacheEvict, DefaultHashBuilder,
     DefaultShardHasher, Expires, ExpiringCache, ExpiringCacheBuilder, ExpiringLruCache,
     ExpiringLruCacheBuilder, LruCache, LruCacheBuilder, SetMaxSizeError, SetTtlError, ShardHasher,
     ShardedExpiringCache, ShardedExpiringCacheBase, ShardedExpiringCacheBuilder,
@@ -893,8 +893,9 @@ pub trait Cached<K, V> {
     /// The error type returned by [`cache_try_set`](Cached::cache_try_set).
     ///
     /// Use [`std::convert::Infallible`] for stores where insertion can never fail.
-    /// TTL-capable stores that may overflow `Instant` bounds use
-    /// [`CacheSetError`].
+    /// Every built-in in-memory store (including the TTL stores, which treat an
+    /// `Instant`-overflowing expiry as never-expires) is infallible; the type exists
+    /// for custom stores whose insertion can fail.
     ///
     /// The bound `std::error::Error + Send + Sync + 'static` lets generic code call
     /// `.unwrap()` on `Result<_, Self::Error>`, propagate with `?` into
@@ -931,13 +932,10 @@ pub trait Cached<K, V> {
     /// Insert a key-value pair and return the previous value.
     fn cache_set(&mut self, k: K, v: V) -> Option<V>;
 
-    /// Fallible variant of [`Self::cache_set`]. Returns `Err` if the store cannot accept the entry
-    /// (e.g. the TTL duration overflows `Instant` bounds). The default implementation is
-    /// infallible and delegates to [`Self::cache_set`]; it always returns `Ok`.
-    ///
-    /// The error type is the associated [`Self::Error`]. Infallible stores set
-    /// `type Error = std::convert::Infallible`, while TTL-capable stores set it to
-    /// [`CacheSetError`].
+    /// Fallible variant of [`Self::cache_set`] for custom stores whose insertion can fail.
+    /// The default implementation is infallible and delegates to [`Self::cache_set`]; it
+    /// always returns `Ok`. Every built-in in-memory store keeps that default
+    /// (`type Error = std::convert::Infallible`).
     fn cache_try_set(&mut self, k: K, v: V) -> Result<Option<V>, Self::Error> {
         Ok(self.cache_set(k, v))
     }

--- a/src/stores/expiring_lru.rs
+++ b/src/stores/expiring_lru.rs
@@ -415,17 +415,21 @@ impl<K: Clone + Hash + Eq, V: Expires, S: BuildHasher> ExpiringLruCache<K, V, S>
     }
 
     /// Return all live entries in current LRU order (most-recently-used first)
-    /// as a `Vec` of `(K, V)` pairs. Expired entries are excluded.
+    /// as `(K, `[`CacheValue<V>`](super::CacheValue)`)` pairs. `ExpiringLruCache`
+    /// carries no per-entry metadata beyond what `V: Expires` itself exposes, so
+    /// the wrapper's metadata type is `()`; the wrapper `Deref`s to `V`.
+    /// Expired entries are excluded.
     #[must_use]
-    pub fn iter_order(&self) -> Vec<(K, V)>
+    pub fn iter_order(&self) -> Vec<(K, super::CacheValue<V>)>
     where
         K: Clone,
         V: Clone,
     {
         self.store
-            .iter_order()
+            .iter_order_raw()
             .into_iter()
             .filter(|(_, v)| !v.is_expired())
+            .map(|(k, v)| (k, super::CacheValue::new(v, ())))
             .collect()
     }
 
@@ -449,10 +453,10 @@ impl<K: Clone + Hash + Eq, V: Expires, S: BuildHasher> ExpiringLruCache<K, V, S>
             .collect()
     }
 
-    /// Return a `Vec` of values in the current order from most to least recently
-    /// used. Expired entries are excluded.
+    /// Return a `Vec` of [`CacheValue`](super::CacheValue)-wrapped values in the
+    /// current order from most to least recently used. Expired entries are excluded.
     #[must_use]
-    pub fn value_order(&self) -> Vec<V>
+    pub fn value_order(&self) -> Vec<super::CacheValue<V>>
     where
         V: Clone,
     {
@@ -463,7 +467,7 @@ impl<K: Clone + Hash + Eq, V: Expires, S: BuildHasher> ExpiringLruCache<K, V, S>
                 if v.is_expired() {
                     None
                 } else {
-                    Some(v.clone())
+                    Some(super::CacheValue::new(v.clone(), ()))
                 }
             })
             .collect()

--- a/src/stores/lru.rs
+++ b/src/stores/lru.rs
@@ -327,9 +327,24 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruCache<K, V, S> {
         Ok(self.set_max_size(max_size))
     }
 
-    /// Return all entries in current LRU order (most-recently-used first) as a `Vec` of `(K, V)` pairs.
+    /// Return all entries in current LRU order (most-recently-used first) as a `Vec` of
+    /// `(K, `[`CacheValue<V>`](super::CacheValue)`)` pairs. `LruCache` carries no per-entry
+    /// metadata, so the wrapper's metadata type is `()`; the wrapper `Deref`s to `V`.
     #[must_use]
-    pub fn iter_order(&self) -> Vec<(K, V)>
+    pub fn iter_order(&self) -> Vec<(K, super::CacheValue<V>)>
+    where
+        K: Clone,
+        V: Clone,
+    {
+        self.order
+            .iter()
+            .map(|(k, v)| (k.clone(), super::CacheValue::new(v.clone(), ())))
+            .collect()
+    }
+
+    /// Internal tuple-form of [`iter_order`](Self::iter_order) for the wrapping
+    /// stores and the sharded deep-clone paths.
+    pub(crate) fn iter_order_raw(&self) -> Vec<(K, V)>
     where
         K: Clone,
         V: Clone,
@@ -347,14 +362,17 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruCache<K, V, S> {
         self.order.iter().map(|(k, _v)| k.clone()).collect()
     }
 
-    /// Return a `Vec` of values in the current order from most
-    /// to least recently used.
+    /// Return a `Vec` of [`CacheValue`](super::CacheValue)-wrapped values in the
+    /// current order from most to least recently used.
     #[must_use]
-    pub fn value_order(&self) -> Vec<V>
+    pub fn value_order(&self) -> Vec<super::CacheValue<V>>
     where
         V: Clone,
     {
-        self.order.iter().map(|(_k, v)| v.clone()).collect()
+        self.order
+            .iter()
+            .map(|(_k, v)| super::CacheValue::new(v.clone(), ()))
+            .collect()
     }
 
     pub(super) fn pop_raw<Q>(&mut self, k: &Q) -> Option<(K, V)>

--- a/src/stores/lru_ttl.rs
+++ b/src/stores/lru_ttl.rs
@@ -364,18 +364,15 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruTtlCache<K, V, S> {
 
     /// Compute the expiry instant for a new or refreshed entry given the current TTL.
     /// Returns `None` when `ttl` is zero (expiry disabled), or `Some(now + ttl)`.
-    /// Returns `Err(CacheSetError::TimeBounds)` on overflow.
+    /// On overflow (`now + ttl` exceeds `Instant`'s representable range, a TTL on the
+    /// order of hundreds of years) returns `None`: the entry never expires, matching
+    /// the sharded TTL stores.
     #[inline]
-    pub(super) fn compute_expires_at(
-        ttl: Duration,
-        now: Instant,
-    ) -> Result<Option<Instant>, super::CacheSetError> {
+    pub(super) fn compute_expires_at(ttl: Duration, now: Instant) -> Option<Instant> {
         if ttl.is_zero() {
-            Ok(None)
+            None
         } else {
             now.checked_add(ttl)
-                .map(Some)
-                .ok_or(super::CacheSetError::TimeBounds)
         }
     }
 
@@ -399,22 +396,27 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruTtlCache<K, V, S> {
         })
     }
 
-    /// Return an iterator of key-value pairs with their expiry instants
-    /// in the current order from most to least recently used.
+    /// Return all live entries in the current order from most to least recently
+    /// used, as `(K, `[`CacheValue`](super::CacheValue)`)` pairs. The wrapper
+    /// `Deref`s to `V` and exposes the entry's expiry via
+    /// [`expires_at`](super::CacheValue::expires_at).
     /// Items past their expiry will be excluded.
     #[must_use]
-    pub fn iter_order(&self) -> Vec<(K, (Option<Instant>, V))>
+    pub fn iter_order(&self) -> Vec<(K, super::CacheValue<V, Option<Instant>>)>
     where
         K: Clone,
         V: Clone,
     {
         self.store
-            .iter_order()
-            .into_iter()
+            .order
+            .iter()
             .filter_map(|(k, entry)| {
                 let expires_at = entry.expires_at;
                 if Self::entry_live(expires_at) {
-                    Some((k.clone(), (expires_at, entry.value.clone())))
+                    Some((
+                        k.clone(),
+                        super::CacheValue::new(entry.value.clone(), expires_at),
+                    ))
                 } else {
                     None
                 }
@@ -443,11 +445,11 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruTtlCache<K, V, S> {
             .collect()
     }
 
-    /// Return a `Vec` of (expiry, value) pairs in the current order
-    /// from most to least recently used.
+    /// Return a `Vec` of [`CacheValue`](super::CacheValue)-wrapped values (each
+    /// carrying its expiry) in the current order from most to least recently used.
     /// Items past their expiry will be excluded.
     #[must_use]
-    pub fn value_order(&self) -> Vec<(Option<Instant>, V)>
+    pub fn value_order(&self) -> Vec<super::CacheValue<V, Option<Instant>>>
     where
         V: Clone,
     {
@@ -457,7 +459,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruTtlCache<K, V, S> {
             .filter_map(|(_k, entry)| {
                 let expires_at = entry.expires_at;
                 if Self::entry_live(expires_at) {
-                    Some((expires_at, entry.value.clone()))
+                    Some(super::CacheValue::new(entry.value.clone(), expires_at))
                 } else {
                     None
                 }
@@ -605,7 +607,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruTtlCache<K, V, S> {
 }
 
 impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V, S> {
-    type Error = super::CacheSetError;
+    type Error = std::convert::Infallible;
 
     fn cache_get<Q>(&mut self, key: &Q) -> Option<&V>
     where
@@ -620,10 +622,12 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
                 self.hits.fetch_add(1, Ordering::Relaxed);
                 if self.refresh {
                     let now = Instant::now();
-                    let new_exp = Self::compute_expires_at(self.ttl, now)
-                        .ok()
-                        .flatten()
-                        .or(self.store.order.get(index).1.expires_at);
+                    let new_exp = Self::compute_expires_at(self.ttl, now).or(self
+                        .store
+                        .order
+                        .get(index)
+                        .1
+                        .expires_at);
                     self.store.order.get_mut(index).1.expires_at = new_exp;
                 }
                 Some(&self.store.order.get(index).1.value)
@@ -656,10 +660,12 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
                 self.hits.fetch_add(1, Ordering::Relaxed);
                 if self.refresh {
                     let now = Instant::now();
-                    let new_exp = Self::compute_expires_at(self.ttl, now)
-                        .ok()
-                        .flatten()
-                        .or(self.store.order.get(index).1.expires_at);
+                    let new_exp = Self::compute_expires_at(self.ttl, now).or(self
+                        .store
+                        .order
+                        .get(index)
+                        .1
+                        .expires_at);
                     self.store.order.get_mut(index).1.expires_at = new_exp;
                 }
                 Some(&mut self.store.order.get_mut(index).1.value)
@@ -686,7 +692,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
             // not eat into the fresh entry's TTL (CORE-3).
             let value = f();
             let now = Instant::now();
-            let expires_at = Self::compute_expires_at(ttl, now).unwrap_or(None);
+            let expires_at = Self::compute_expires_at(ttl, now);
             TimedEntry { expires_at, value }
         };
         // On replacement the store returns the STORED key/entry of the displaced value, so the
@@ -698,10 +704,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
         if was_present && was_valid {
             if self.refresh {
                 let now = Instant::now();
-                let new_exp = Self::compute_expires_at(self.ttl, now)
-                    .ok()
-                    .flatten()
-                    .or(entry.expires_at);
+                let new_exp = Self::compute_expires_at(self.ttl, now).or(entry.expires_at);
                 entry.expires_at = new_exp;
             }
             self.hits.fetch_add(1, Ordering::Relaxed);
@@ -727,7 +730,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
             // Anchor the expiry after the factory succeeds (CORE-3).
             let value = f()?;
             let now = Instant::now();
-            let expires_at = Self::compute_expires_at(ttl, now).unwrap_or(None);
+            let expires_at = Self::compute_expires_at(ttl, now);
             Ok(TimedEntry { expires_at, value })
         };
         // On replacement the store returns the STORED key/entry of the displaced value (C1/C8).
@@ -737,10 +740,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
         if was_present && was_valid {
             if self.refresh {
                 let now = Instant::now();
-                let new_exp = Self::compute_expires_at(self.ttl, now)
-                    .ok()
-                    .flatten()
-                    .or(entry.expires_at);
+                let new_exp = Self::compute_expires_at(self.ttl, now).or(entry.expires_at);
                 entry.expires_at = new_exp;
             }
             self.hits.fetch_add(1, Ordering::Relaxed);
@@ -765,7 +765,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
     /// from the current TTL). Read with `cache_get` first if you need to promote it.
     fn cache_set(&mut self, key: K, val: V) -> Option<V> {
         let now = Instant::now();
-        let expires_at = Self::compute_expires_at(self.ttl, now).unwrap_or(None);
+        let expires_at = Self::compute_expires_at(self.ttl, now);
         self.set_entry(
             key,
             TimedEntry {
@@ -773,18 +773,6 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
                 value: val,
             },
         )
-    }
-
-    fn cache_try_set(&mut self, key: K, val: V) -> Result<Option<V>, super::CacheSetError> {
-        let now = Instant::now();
-        let expires_at = Self::compute_expires_at(self.ttl, now)?;
-        Ok(self.set_entry(
-            key,
-            TimedEntry {
-                expires_at,
-                value: val,
-            },
-        ))
     }
 
     fn cache_remove<Q>(&mut self, k: &Q) -> Option<V>
@@ -955,10 +943,12 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher + Clone> CloneCached<K, V>
                 self.hits.fetch_add(1, Ordering::Relaxed);
                 if self.refresh {
                     let now = Instant::now();
-                    let new_exp = Self::compute_expires_at(self.ttl, now)
-                        .ok()
-                        .flatten()
-                        .or(self.store.order.get(index).1.expires_at);
+                    let new_exp = Self::compute_expires_at(self.ttl, now).or(self
+                        .store
+                        .order
+                        .get(index)
+                        .1
+                        .expires_at);
                     self.store.order.get_mut(index).1.expires_at = new_exp;
                 }
                 (Some(self.store.order.get(index).1.value.clone()), false)
@@ -1013,7 +1003,7 @@ where
                 // Anchor the expiry after the factory resolves (CORE-3).
                 let value = f().await;
                 let now = Instant::now();
-                let expires_at = Self::compute_expires_at(ttl, now).unwrap_or(None);
+                let expires_at = Self::compute_expires_at(ttl, now);
                 TimedEntry { expires_at, value }
             };
             // On replacement the store returns the STORED key/entry of the displaced value (C1/C8).
@@ -1024,10 +1014,7 @@ where
             if was_present && was_valid {
                 if self.refresh {
                     let now = Instant::now();
-                    let new_exp = Self::compute_expires_at(self.ttl, now)
-                        .ok()
-                        .flatten()
-                        .or(entry.expires_at);
+                    let new_exp = Self::compute_expires_at(self.ttl, now).or(entry.expires_at);
                     entry.expires_at = new_exp;
                 }
                 self.hits.fetch_add(1, Ordering::Relaxed);
@@ -1061,7 +1048,7 @@ where
             let setter = || async move {
                 let new_val = f().await?;
                 let now = Instant::now();
-                let expires_at = Self::compute_expires_at(ttl, now).unwrap_or(None);
+                let expires_at = Self::compute_expires_at(ttl, now);
                 Ok(TimedEntry {
                     expires_at,
                     value: new_val,
@@ -1077,10 +1064,7 @@ where
             if was_present && was_valid {
                 if self.refresh {
                     let now = Instant::now();
-                    let new_exp = Self::compute_expires_at(self.ttl, now)
-                        .ok()
-                        .flatten()
-                        .or(entry.expires_at);
+                    let new_exp = Self::compute_expires_at(self.ttl, now).or(entry.expires_at);
                     entry.expires_at = new_exp;
                 }
                 self.hits.fetch_add(1, Ordering::Relaxed);
@@ -1109,6 +1093,36 @@ mod tests {
     use super::*;
     use crate::{Cached, CachedExt};
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+    #[test]
+    fn iter_order_and_value_order_expose_expiry_via_cache_value() {
+        let mut c: LruTtlCache<u32, u32> = LruTtlCache::builder()
+            .max_size(4)
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        let before = Instant::now();
+        c.cache_set(1, 10);
+        c.cache_set(2, 20);
+
+        // MRU-first order; the wrapper Derefs to V and compares against bare values.
+        let ordered = c.iter_order();
+        assert_eq!(ordered.len(), 2);
+        assert_eq!(ordered[0].0, 2);
+        assert_eq!(*ordered[0].1, 20);
+        assert_eq!(ordered[1].1, 10);
+        // Finite ttl: every entry carries a future expiry.
+        for (_k, v) in &ordered {
+            let exp = v.expires_at().expect("finite ttl entries carry an expiry");
+            assert!(exp > before);
+        }
+
+        let vals = c.value_order();
+        assert_eq!(vals, vec![20, 10]);
+        assert!(vals[0].expires_at().is_some());
+        assert_eq!(vals[0].value(), &20);
+        assert_eq!(vals.into_iter().map(|v| v.into_value()).sum::<u32>(), 30);
+    }
 
     #[test]
     fn cache_set_over_expired_returns_none_fires_on_evict_and_counts() {

--- a/src/stores/mod.rs
+++ b/src/stores/mod.rs
@@ -227,34 +227,62 @@ impl std::fmt::Display for SetTtlError {
 
 impl std::error::Error for SetTtlError {}
 
-/// Error returned by [`TtlCache`], [`LruTtlCache`], and
-/// [`TtlSortedCache`] via [`Cached::cache_try_set`] when
-/// an entry cannot be stored - currently only when computing the entry's expiry
-/// `Instant` overflows.
+/// A cached value plus store-specific per-entry metadata, returned by the
+/// LRU-family order methods ([`LruCache::iter_order`], [`LruCache::value_order`],
+/// and their `LruTtlCache` / `ExpiringLruCache` counterparts).
 ///
-/// The separate `TtlSortedCacheError` type was removed in favor of this unified type; the
-/// following must not compile (guards against the old error type being reintroduced):
-///
-/// ```compile_fail
-/// use cached::stores::TtlSortedCacheError;
-/// ```
-/// ```compile_fail
-/// let _ = cached::TtlSortedCacheError::TimeBounds;
-/// ```
-#[non_exhaustive]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum CacheSetError {
-    /// Computing the entry's expiry `Instant` overflowed `Instant`'s representable range.
-    TimeBounds,
+/// `M` is the metadata carried alongside the value: `()` (the default) for stores
+/// with no per-entry metadata (`LruCache`, `ExpiringLruCache`) and
+/// `Option<Instant>` (the entry's expiry) for `LruTtlCache`. The wrapper
+/// [`Deref`](std::ops::Deref)s to `V`, so read access is transparent; metadata is
+/// exposed through typed accessors (e.g.
+/// [`expires_at`](CacheValue::expires_at)) that exist only for the carrying `M`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CacheValue<V, M = ()> {
+    value: V,
+    meta: M,
 }
-impl std::fmt::Display for CacheSetError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CacheSetError::TimeBounds => f.write_str("ttl is outside Instant bounds"),
-        }
+
+impl<V, M> CacheValue<V, M> {
+    pub(crate) fn new(value: V, meta: M) -> Self {
+        Self { value, meta }
+    }
+
+    /// Shared reference to the wrapped value.
+    #[must_use]
+    pub fn value(&self) -> &V {
+        &self.value
+    }
+
+    /// Consume the wrapper and return the wrapped value.
+    #[must_use]
+    pub fn into_value(self) -> V {
+        self.value
     }
 }
-impl std::error::Error for CacheSetError {}
+
+impl<V> CacheValue<V, Option<crate::time::Instant>> {
+    /// The entry's expiry instant. `None` means the entry never expires.
+    #[must_use]
+    pub fn expires_at(&self) -> Option<crate::time::Instant> {
+        self.meta
+    }
+}
+
+impl<V, M> std::ops::Deref for CacheValue<V, M> {
+    type Target = V;
+    fn deref(&self) -> &V {
+        &self.value
+    }
+}
+
+/// Compare directly against a bare value, ignoring metadata:
+/// `CacheValue::new(1, meta) == 1`.
+impl<V: PartialEq, M> PartialEq<V> for CacheValue<V, M> {
+    fn eq(&self, other: &V) -> bool {
+        self.value == *other
+    }
+}
 
 /// Validate that `ttl` is non-zero; used by all TTL-capable store builders.
 #[cfg(any(
@@ -593,12 +621,6 @@ mod tests {
             err2.to_string(),
             "invalid value for field `max_size`: must be greater than zero"
         );
-    }
-
-    #[test]
-    fn cache_set_error_is_clone_eq() {
-        // Parity with `SetMaxSizeError`/`SetTtlError`, which already derive these.
-        assert_eq!(CacheSetError::TimeBounds, CacheSetError::TimeBounds.clone());
     }
 
     // Compile-time assertion: BuildError must implement Clone + PartialEq + Eq.

--- a/src/stores/sharded/expiring_lru.rs
+++ b/src/stores/sharded/expiring_lru.rs
@@ -998,7 +998,7 @@ impl<K, V, H> ShardedExpiringLruCacheBuilder<K, V, H> {
             // that MRU entries land at the head of the new cache.
             let entries: Vec<(K, V)> = {
                 let guard = shard.lock.read();
-                guard.iter_order()
+                guard.iter_order_raw()
             };
             for (k, v) in entries.into_iter().rev() {
                 if !v.is_expired() {

--- a/src/stores/sharded/lru.rs
+++ b/src/stores/sharded/lru.rs
@@ -861,7 +861,7 @@ impl<K, V, H> ShardedLruCacheBuilder<K, V, H> {
             // so that the MRU entries are pushed in last and land at the head.
             let entries: Vec<(K, V)> = {
                 let guard = shard.lock.read();
-                guard.iter_order()
+                guard.iter_order_raw()
             };
             for (k, v) in entries.into_iter().rev() {
                 let _ = ConcurrentCached::cache_set(&new_cache, k, v);

--- a/src/stores/sharded/lru_ttl.rs
+++ b/src/stores/sharded/lru_ttl.rs
@@ -1292,7 +1292,7 @@ where
     for shard in existing.inner.shards.iter() {
         let entries: Vec<(K, TimedEntry<V>)> = {
             let guard = shard.lock.read();
-            guard.iter_order()
+            guard.iter_order_raw()
         };
         for (k, entry) in entries.into_iter().rev() {
             // Skip entries already expired per their per-entry expires_at.

--- a/src/stores/ttl.rs
+++ b/src/stores/ttl.rs
@@ -287,18 +287,15 @@ impl<K: Hash + Eq, V, S: BuildHasher> TtlCache<K, V, S> {
 
     /// Compute the expiry instant for a new or refreshed entry given the current TTL.
     /// Returns `None` when `ttl` is zero (expiry disabled), or `Some(now + ttl)`.
-    /// Returns `Err(CacheSetError::TimeBounds)` on overflow.
+    /// On overflow (`now + ttl` exceeds `Instant`'s representable range, a TTL on the
+    /// order of hundreds of years) returns `None`: the entry never expires, matching
+    /// the sharded TTL stores.
     #[inline]
-    pub(super) fn compute_expires_at(
-        ttl: Duration,
-        now: Instant,
-    ) -> Result<Option<Instant>, super::CacheSetError> {
+    pub(super) fn compute_expires_at(ttl: Duration, now: Instant) -> Option<Instant> {
         if ttl.is_zero() {
-            Ok(None)
+            None
         } else {
             now.checked_add(ttl)
-                .map(Some)
-                .ok_or(super::CacheSetError::TimeBounds)
         }
     }
 
@@ -350,7 +347,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> TtlCache<K, V, S> {
 }
 
 impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for TtlCache<K, V, S> {
-    type Error = super::CacheSetError;
+    type Error = std::convert::Infallible;
 
     fn cache_get<Q>(&mut self, key: &Q) -> Option<&V>
     where
@@ -363,10 +360,8 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for TtlCache<K, V, S> {
             Some(entry) if Self::entry_live(entry.expires_at) => {
                 self.hits.fetch_add(1, Ordering::Relaxed);
                 if self.refresh {
-                    entry.expires_at = Self::compute_expires_at(self.ttl, Instant::now())
-                        .ok()
-                        .flatten()
-                        .or(entry.expires_at);
+                    entry.expires_at =
+                        Self::compute_expires_at(self.ttl, Instant::now()).or(entry.expires_at);
                 }
                 // SAFETY: `ptr` points into a HashMap entry obtained from
                 // `get_mut`. We return immediately without modifying the map, so
@@ -400,10 +395,8 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for TtlCache<K, V, S> {
             Some(entry) if Self::entry_live(entry.expires_at) => {
                 self.hits.fetch_add(1, Ordering::Relaxed);
                 if self.refresh {
-                    entry.expires_at = Self::compute_expires_at(self.ttl, Instant::now())
-                        .ok()
-                        .flatten()
-                        .or(entry.expires_at);
+                    entry.expires_at =
+                        Self::compute_expires_at(self.ttl, Instant::now()).or(entry.expires_at);
                 }
                 // SAFETY: same as `cache_get` -- entry is not moved between
                 // obtaining the pointer and returning, and `&mut self` prevents
@@ -430,10 +423,8 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for TtlCache<K, V, S> {
                 if Self::entry_live(occupied.get().expires_at) {
                     if self.refresh {
                         let now = Instant::now();
-                        let new_exp = Self::compute_expires_at(self.ttl, now)
-                            .ok()
-                            .flatten()
-                            .or(occupied.get().expires_at);
+                        let new_exp =
+                            Self::compute_expires_at(self.ttl, now).or(occupied.get().expires_at);
                         occupied.get_mut().expires_at = new_exp;
                     }
                     self.hits.fetch_add(1, Ordering::Relaxed);
@@ -449,7 +440,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for TtlCache<K, V, S> {
                     }
                     self.evictions.fetch_add(1, Ordering::Relaxed);
                     let now = Instant::now();
-                    let expires_at = Self::compute_expires_at(self.ttl, now).unwrap_or(None);
+                    let expires_at = Self::compute_expires_at(self.ttl, now);
                     occupied.insert(TimedEntry {
                         expires_at,
                         value: val,
@@ -461,7 +452,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for TtlCache<K, V, S> {
                 self.misses.fetch_add(1, Ordering::Relaxed);
                 let val = f();
                 let now = Instant::now();
-                let expires_at = Self::compute_expires_at(self.ttl, now).unwrap_or(None);
+                let expires_at = Self::compute_expires_at(self.ttl, now);
                 &mut vacant
                     .insert(TimedEntry {
                         expires_at,
@@ -482,10 +473,8 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for TtlCache<K, V, S> {
                 if Self::entry_live(occupied.get().expires_at) {
                     if self.refresh {
                         let now = Instant::now();
-                        let new_exp = Self::compute_expires_at(self.ttl, now)
-                            .ok()
-                            .flatten()
-                            .or(occupied.get().expires_at);
+                        let new_exp =
+                            Self::compute_expires_at(self.ttl, now).or(occupied.get().expires_at);
                         occupied.get_mut().expires_at = new_exp;
                     }
                     self.hits.fetch_add(1, Ordering::Relaxed);
@@ -501,7 +490,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for TtlCache<K, V, S> {
                     }
                     self.evictions.fetch_add(1, Ordering::Relaxed);
                     let now = Instant::now();
-                    let expires_at = Self::compute_expires_at(self.ttl, now).unwrap_or(None);
+                    let expires_at = Self::compute_expires_at(self.ttl, now);
                     occupied.insert(TimedEntry {
                         expires_at,
                         value: val,
@@ -513,7 +502,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for TtlCache<K, V, S> {
                 self.misses.fetch_add(1, Ordering::Relaxed);
                 let val = f()?;
                 let now = Instant::now();
-                let expires_at = Self::compute_expires_at(self.ttl, now).unwrap_or(None);
+                let expires_at = Self::compute_expires_at(self.ttl, now);
                 Ok(&mut vacant
                     .insert(TimedEntry {
                         expires_at,
@@ -528,11 +517,10 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for TtlCache<K, V, S> {
     /// Expired previous values are silently discarded.
     ///
     /// If computing the expiry instant overflows (very large TTL), the entry is stored
-    /// with `expires_at = None` (never expires). Use [`cache_try_set`](crate::Cached::cache_try_set)
-    /// when you need to detect this overflow condition.
+    /// with `expires_at = None` (never expires), matching the sharded TTL stores.
     fn cache_set(&mut self, key: K, val: V) -> Option<V> {
         let now = Instant::now();
-        let expires_at = Self::compute_expires_at(self.ttl, now).unwrap_or(None);
+        let expires_at = Self::compute_expires_at(self.ttl, now);
         self.set_entry(
             key,
             TimedEntry {
@@ -542,17 +530,6 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for TtlCache<K, V, S> {
         )
     }
 
-    fn cache_try_set(&mut self, key: K, val: V) -> Result<Option<V>, super::CacheSetError> {
-        let now = Instant::now();
-        let expires_at = Self::compute_expires_at(self.ttl, now)?;
-        Ok(self.set_entry(
-            key,
-            TimedEntry {
-                expires_at,
-                value: val,
-            },
-        ))
-    }
     fn cache_remove<Q>(&mut self, k: &Q) -> Option<V>
     where
         K: std::borrow::Borrow<Q>,
@@ -710,10 +687,7 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher + Clone> CloneCached<K, V>
                 self.hits.fetch_add(1, Ordering::Relaxed);
                 if self.refresh {
                     let now = Instant::now();
-                    let new_exp = Self::compute_expires_at(self.ttl, now)
-                        .ok()
-                        .flatten()
-                        .or(entry.expires_at);
+                    let new_exp = Self::compute_expires_at(self.ttl, now).or(entry.expires_at);
                     entry.expires_at = new_exp;
                 }
                 (Some(entry.value.clone()), false)
@@ -768,8 +742,6 @@ where
                         if self.refresh {
                             let now = Instant::now();
                             let new_exp = Self::compute_expires_at(self.ttl, now)
-                                .ok()
-                                .flatten()
                                 .or(occupied.get().expires_at);
                             occupied.get_mut().expires_at = new_exp;
                         }
@@ -789,7 +761,7 @@ where
                         }
                         self.evictions.fetch_add(1, Ordering::Relaxed);
                         let now = Instant::now();
-                        let expires_at = Self::compute_expires_at(self.ttl, now).unwrap_or(None);
+                        let expires_at = Self::compute_expires_at(self.ttl, now);
                         occupied.insert(TimedEntry {
                             expires_at,
                             value: val,
@@ -801,7 +773,7 @@ where
                     self.misses.fetch_add(1, Ordering::Relaxed);
                     let val = f().await;
                     let now = Instant::now();
-                    let expires_at = Self::compute_expires_at(self.ttl, now).unwrap_or(None);
+                    let expires_at = Self::compute_expires_at(self.ttl, now);
                     &mut vacant
                         .insert(TimedEntry {
                             expires_at,
@@ -832,8 +804,6 @@ where
                         if self.refresh {
                             let now = Instant::now();
                             let new_exp = Self::compute_expires_at(self.ttl, now)
-                                .ok()
-                                .flatten()
                                 .or(occupied.get().expires_at);
                             occupied.get_mut().expires_at = new_exp;
                         }
@@ -850,7 +820,7 @@ where
                         }
                         self.evictions.fetch_add(1, Ordering::Relaxed);
                         let now = Instant::now();
-                        let expires_at = Self::compute_expires_at(self.ttl, now).unwrap_or(None);
+                        let expires_at = Self::compute_expires_at(self.ttl, now);
                         occupied.insert(TimedEntry {
                             expires_at,
                             value: val,
@@ -862,7 +832,7 @@ where
                     self.misses.fetch_add(1, Ordering::Relaxed);
                     let val = f().await?;
                     let now = Instant::now();
-                    let expires_at = Self::compute_expires_at(self.ttl, now).unwrap_or(None);
+                    let expires_at = Self::compute_expires_at(self.ttl, now);
                     &mut vacant
                         .insert(TimedEntry {
                             expires_at,

--- a/src/stores/ttl_sorted.rs
+++ b/src/stores/ttl_sorted.rs
@@ -158,19 +158,6 @@ impl<K, V: Clone> Clone for Entry<K, V> {
     }
 }
 
-/// Policy for [`TtlSortedCache::insert_inner`] when `now + ttl` overflows `Instant`.
-#[derive(Clone, Copy)]
-enum TtlOverflow {
-    /// Return [`super::CacheSetError::TimeBounds`] without mutating the cache.
-    Error,
-    /// Saturate the expiry to "now" (immediately stale) and still store the entry.
-    SaturateNow,
-    /// Store the entry with `expiry = None` (never expires) instead of failing. Matches
-    /// the infallible `cache_set` of `TtlCache` / `LruTtlCache`, which treat an
-    /// unrepresentable expiry as "no expiry" rather than dropping the value.
-    NeverExpire,
-}
-
 /// A cache enforcing time expiration and an optional maximum size.
 /// When a maximum size is specified, the values are dropped in the
 /// order of expiration date, e.g. the next value to expire is dropped.
@@ -617,93 +604,69 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> TtlSortedCache<K, V, S> {
         count
     }
 
-    /// Insert k/v pair without running eviction logic. See `.insert_ttl_evict`
-    pub fn insert(&mut self, key: K, value: V) -> Result<Option<V>, super::CacheSetError> {
-        self.insert_ttl_evict(key, value, None, false)
+    /// Set k/v pair without running eviction logic. See `.set_with_ttl_evict`
+    pub fn set(&mut self, key: K, value: V) -> Option<V> {
+        self.set_with_ttl_evict(key, value, None, false)
     }
 
-    /// Insert k/v pair with explicit ttl. See `.insert_ttl_evict`
-    pub fn insert_ttl(
-        &mut self,
-        key: K,
-        value: V,
-        ttl: Duration,
-    ) -> Result<Option<V>, super::CacheSetError> {
-        self.insert_ttl_evict(key, value, Some(ttl), false)
+    /// Set k/v pair with explicit ttl. See `.set_with_ttl_evict`
+    pub fn set_with_ttl(&mut self, key: K, value: V, ttl: Duration) -> Option<V> {
+        self.set_with_ttl_evict(key, value, Some(ttl), false)
     }
 
-    /// Insert k/v pair and run eviction logic. See `.insert_ttl_evict`
-    pub fn insert_evict(
-        &mut self,
-        key: K,
-        value: V,
-        evict: bool,
-    ) -> Result<Option<V>, super::CacheSetError> {
-        self.insert_ttl_evict(key, value, None, evict)
+    /// Set k/v pair and run eviction logic. See `.set_with_ttl_evict`
+    pub fn set_evict(&mut self, key: K, value: V, evict: bool) -> Option<V> {
+        self.set_with_ttl_evict(key, value, None, evict)
     }
 
-    /// Insert a k/v pair with an optional explicit TTL, then optionally run eviction logic.
+    /// Set a k/v pair with an optional explicit TTL, then optionally run eviction logic.
     /// The entry is inserted first. If a `size_limit` was specified and capacity is exceeded,
     /// the next-to-expire entry is dropped after insertion. The eviction callback fires after
     /// insertion, not before. Returns any existing unexpired value that was replaced.
-    pub fn insert_ttl_evict(
+    ///
+    /// If computing the expiry instant overflows (a TTL on the order of hundreds of
+    /// years), the entry is stored with no expiry (never expires), matching
+    /// [`cache_set`](crate::Cached::cache_set) on the other TTL stores.
+    pub fn set_with_ttl_evict(
         &mut self,
         key: K,
         value: V,
         ttl: Option<Duration>,
         evict: bool,
-    ) -> Result<Option<V>, super::CacheSetError> {
-        self.insert_inner(key, value, ttl, evict, TtlOverflow::Error, false)
+    ) -> Option<V> {
+        self.set_inner(key, value, ttl, evict, false)
     }
 
-    /// Shared insertion routine for [`insert_ttl_evict`](Self::insert_ttl_evict) and the
-    /// infallible `cache_get_or_set_with_mut` paths.
-    ///
-    /// `on_overflow` selects what happens in the (practically unreachable) case where
-    /// `now + ttl` exceeds `Instant`'s representable range — a TTL on the order of
-    /// hundreds of years:
-    /// - [`TtlOverflow::Error`]: return [`super::CacheSetError::TimeBounds`] before any mutation
-    ///   (used by the fallible public API).
-    /// - [`TtlOverflow::SaturateNow`]: store the entry with an already-elapsed expiry
-    ///   so the value is still retained (and returnable by reference) but is treated as
-    ///   immediately stale. Size-limit enforcement is skipped in this branch so the
-    ///   just-inserted entry cannot be the one evicted, which lets the infallible
-    ///   `get_or_set` paths return `&mut V` without a fallible re-lookup.
-    /// - [`TtlOverflow::NeverExpire`]: store the entry with `expiry = None` (never
-    ///   expires) so the value is retained and stays live, rather than being dropped or
-    ///   made immediately stale. Used by the infallible `cache_set` to match the
-    ///   never-expires-on-overflow behavior of `TtlCache` / `LruTtlCache`. Like the
-    ///   zero-TTL case, `overflowed` stays `false`, so normal size-limit eviction runs.
+    /// Shared insertion routine for [`set_with_ttl_evict`](Self::set_with_ttl_evict) and the
+    /// `cache_get_or_set_with_mut` paths.
     ///
     /// When the effective TTL (explicit `ttl` arg or `self.ttl`) is zero, the entry is
     /// stored with `expiry = None` (never expires) rather than being given an immediate
     /// expiry. Zero TTL means "disable expiry" for new inserts, consistent with the other
-    /// TTL stores. In this case `overflowed` is always `false`.
-    fn insert_inner(
+    /// TTL stores. In the (practically unreachable) case where `now + ttl` exceeds
+    /// `Instant`'s representable range — a TTL on the order of hundreds of years — the
+    /// entry is likewise stored with `expiry = None`, matching the never-expires-on-overflow
+    /// behavior of `TtlCache` / `LruTtlCache` and the sharded TTL stores.
+    ///
+    /// `skip_size_eviction` defers size-limit enforcement to the caller
+    /// (`set_and_get_mut` must protect the just-inserted entry before evicting).
+    fn set_inner(
         &mut self,
         key: K,
         value: V,
         ttl: Option<Duration>,
         evict: bool,
-        on_overflow: TtlOverflow,
         skip_size_eviction: bool,
-    ) -> Result<Option<V>, super::CacheSetError> {
+    ) -> Option<V> {
         let arc_key = CacheArc::new(key.clone());
         let effective_ttl = ttl.unwrap_or(self.ttl);
 
-        // A zero TTL means "never expires": store expiry = None.
-        let (expiry, overflowed) = if effective_ttl.is_zero() {
-            (None, false)
+        // A zero TTL means "never expires": store expiry = None. `checked_add`
+        // returning `None` on overflow lands on the same never-expires representation.
+        let expiry = if effective_ttl.is_zero() {
+            None
         } else {
-            let now = Instant::now();
-            match now.checked_add(effective_ttl) {
-                Some(t) => (Some(t), false),
-                None => match on_overflow {
-                    TtlOverflow::Error => return Err(super::CacheSetError::TimeBounds),
-                    TtlOverflow::SaturateNow => (Some(now), true),
-                    TtlOverflow::NeverExpire => (None, false),
-                },
-            }
+            Instant::now().checked_add(effective_ttl)
         };
 
         let new_stamped = Stamped {
@@ -740,13 +703,10 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> TtlSortedCache<K, V, S> {
             None => None,
         };
 
-        // Skip size-limit eviction in two cases:
-        // 1. The TTL overflowed and was saturated to `now` — the new entry has the earliest
-        //    possible expiry and would be the first thing `retain_latest` drops.
-        // 2. The caller explicitly requests it (`skip_size_eviction`) — e.g. `set_and_get_mut`
-        //    must guarantee the just-inserted entry is still present to return `&mut V` safely,
-        //    regardless of the entry's TTL.
-        if !overflowed && !skip_size_eviction {
+        // Size-limit eviction is skipped only when the caller explicitly requests it
+        // (`skip_size_eviction`) — e.g. `set_and_get_mut` must guarantee the just-inserted
+        // entry is still present to return `&mut V` safely, regardless of the entry's TTL.
+        if !skip_size_eviction {
             if let Some(size_limit) = self.size_limit {
                 if self.map.len() > size_limit {
                     self.retain_latest(size_limit, evict);
@@ -756,28 +716,18 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> TtlSortedCache<K, V, S> {
             }
         }
 
-        Ok(old_value)
+        old_value
     }
 
     /// Insert `key`/`value` and return a mutable reference to the stored value.
     ///
-    /// Unlike [`insert`](Self::insert) this never fails and never drops the value:
-    /// an unrepresentable TTL saturates to an immediately-stale entry rather than
-    /// erroring. When a `size_limit` is configured the just-inserted entry is
+    /// When a `size_limit` is configured the just-inserted entry is
     /// protected from eviction: other entries are evicted in TTL order to restore
-    /// capacity. Used by the infallible `cache_get_or_set_with_mut` family.
+    /// capacity. Used by the `cache_get_or_set_with_mut` family.
     fn set_and_get_mut(&mut self, key: K, value: V) -> &mut V {
-        // `Ok` is guaranteed: `TtlOverflow::SaturateNow` never returns `Err`.
         // `skip_size_eviction = true` defers size enforcement to the block below,
         // where we can protect the just-inserted entry.
-        let _ = self.insert_inner(
-            key.clone(),
-            value,
-            None,
-            false,
-            TtlOverflow::SaturateNow,
-            true,
-        );
+        let _ = self.set_inner(key.clone(), value, None, false, true);
 
         if let Some(size_limit) = self.size_limit
             && self.map.len() > size_limit
@@ -789,18 +739,13 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> TtlSortedCache<K, V, S> {
             let protected = self.map[&key].as_stamped();
             self.keys.remove(&protected);
             self.retain_latest(size_limit, false);
-            // If the TTL overflowed (SaturateNow), protected.expiry == now —
-            // the entry is immediately stale but the caller holds a live &mut V.
             self.keys.insert(protected);
         }
 
         &mut self
             .map
             .get_mut(&key)
-            .expect(
-                "set_and_get_mut: SaturateNow never errors and the protected eviction \
-                 path guarantees the entry is present",
-            )
+            .expect("set_and_get_mut: the protected eviction path guarantees the entry is present")
             .value
     }
 
@@ -844,7 +789,7 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> TtlSortedCache<K, V, S> {
 }
 
 impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> Cached<K, V> for TtlSortedCache<K, V, S> {
-    type Error = super::CacheSetError;
+    type Error = std::convert::Infallible;
 
     fn cache_get<Q>(&mut self, key: &Q) -> Option<&V>
     where
@@ -898,17 +843,7 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> Cached<K, V> for TtlSortedCa
     }
 
     fn cache_set(&mut self, key: K, value: V) -> Option<V> {
-        // On an (practically unreachable) Instant overflow, store the value with
-        // `expiry = None` (never expires) rather than dropping it, matching the
-        // infallible `cache_set` of TtlCache / LruTtlCache. Callers that need the
-        // overflow surfaced as an error should use cache_try_set instead, which stays
-        // on the `TtlOverflow::Error` path.
-        self.insert_inner(key, value, None, false, TtlOverflow::NeverExpire, false)
-            .unwrap_or(None)
-    }
-
-    fn cache_try_set(&mut self, k: K, v: V) -> Result<Option<V>, super::CacheSetError> {
-        self.insert(k, v)
+        self.set_inner(key, value, None, false, false)
     }
 
     fn cache_get_or_set_with_mut<F: FnOnce() -> V>(&mut self, key: K, f: F) -> &mut V {
@@ -1338,26 +1273,22 @@ mod test {
     }
 
     #[test]
-    fn ttl_sorted_cache_set_error_is_clone_eq() {
-        // TtlSortedCache now uses CacheSetError (unified with TtlCache / LruTtlCache).
-        use crate::stores::CacheSetError;
-        assert_eq!(CacheSetError::TimeBounds, CacheSetError::TimeBounds.clone());
-    }
-
-    #[test]
-    fn ttl_sorted_cache_try_set_returns_cache_set_error_on_overflow() {
-        // insert_ttl with a Duration that would overflow Instant bounds must return
-        // CacheSetError::TimeBounds (no longer TtlSortedCacheError).
-        use crate::stores::CacheSetError;
+    fn set_with_ttl_overflow_stores_never_expiring_entry() {
+        // set_with_ttl with a Duration that would overflow Instant bounds stores the
+        // entry with no expiry (never expires), matching cache_set on the other TTL
+        // stores. No error surface: TtlSortedCache's Cached::Error is Infallible.
         let mut cache = TtlSortedCache::<u32, u32>::builder()
             .ttl(Duration::from_secs(60))
             .build()
             .unwrap();
-        // Duration::MAX overflows Instant::now().checked_add -> None -> Error branch.
-        let result = cache.insert_ttl(1u32, 42u32, Duration::MAX);
-        assert_eq!(result, Err(CacheSetError::TimeBounds));
-        // The cache must not be mutated on error.
-        assert_eq!(cache.cache_size(), 0);
+        // Duration::MAX overflows Instant::now().checked_add -> None -> never expires.
+        let prev = cache.set_with_ttl(1u32, 42u32, Duration::MAX);
+        assert_eq!(prev, None);
+        assert_eq!(cache.cache_size(), 1);
+        assert_eq!(cache.cache_get(&1u32), Some(&42u32));
+        // The entry survives an explicit eviction sweep (it never expires).
+        assert_eq!(cache.evict(), 0);
+        assert_eq!(cache.cache_get(&1u32), Some(&42u32));
     }
 
     #[derive(Clone, Debug)]
@@ -1459,7 +1390,7 @@ mod test {
             .initial_capacity(100)
             .build()
             .unwrap();
-        cache.insert(String::from("a"), "a").unwrap();
+        cache.set(String::from("a"), "a");
         assert_eq!(cache.get("a").unwrap(), &"a");
 
         let mut cache = TtlSortedCache::builder()
@@ -1467,7 +1398,7 @@ mod test {
             .initial_capacity(100)
             .build()
             .unwrap();
-        cache.insert(vec![0], "a").unwrap();
+        cache.set(vec![0], "a");
         assert_eq!(cache.get([0].as_slice()).unwrap(), &"a");
     }
 
@@ -1479,7 +1410,7 @@ mod test {
             .initial_capacity(1)
             .build()
             .unwrap();
-        cache.insert(key.clone(), 10).unwrap();
+        cache.set(key.clone(), 10);
 
         assert_eq!(cache.cache_get(&key), Some(&10));
         assert_eq!(cache.cache_hits(), Some(1));
@@ -1496,7 +1427,7 @@ mod test {
             .initial_capacity(1)
             .build()
             .unwrap();
-        cache.insert(key.clone(), 10).unwrap();
+        cache.set(key.clone(), 10);
 
         let value = cache.cache_get_mut(&key).expect("entry should be live");
         *value = 11;
@@ -1521,9 +1452,7 @@ mod test {
             .expect("cache should build");
 
         // Use a very short but non-zero TTL (zero now means "never expires").
-        cache
-            .insert_ttl("expired", 10, Duration::from_millis(1))
-            .unwrap();
+        cache.set_with_ttl("expired", 10, Duration::from_millis(1));
         assert_eq!(cache.cache_size(), 1);
         assert_eq!(cache.keys.len(), 1);
 
@@ -1555,9 +1484,7 @@ mod test {
             .expect("cache should build");
 
         // Use a very short but non-zero TTL (zero now means "never expires").
-        cache
-            .insert_ttl("expired-mut", 20, Duration::from_millis(1))
-            .unwrap();
+        cache.set_with_ttl("expired-mut", 20, Duration::from_millis(1));
         assert_eq!(cache.cache_size(), 1);
         assert_eq!(cache.keys.len(), 1);
 
@@ -1585,7 +1512,7 @@ mod test {
         assert_eq!(0, cache.retain_latest(100, true));
         assert!(cache.get("a").is_none());
 
-        cache.insert("a".to_string(), "A".to_string()).unwrap();
+        cache.set("a".to_string(), "A".to_string());
         assert_eq!(cache.get("a"), Some("A".to_string()).as_ref());
         assert_eq!(cache.len(), 1);
         std::thread::sleep(Duration::from_millis(200));
@@ -1593,7 +1520,7 @@ mod test {
         assert!(cache.get("a").is_none());
         assert_eq!(cache.len(), 0);
 
-        cache.insert("a".to_string(), "A".to_string()).unwrap();
+        cache.set("a".to_string(), "A".to_string());
         assert_eq!(cache.get("a"), Some("A".to_string()).as_ref());
         assert_eq!(cache.len(), 1);
         std::thread::sleep(Duration::from_millis(200));
@@ -1607,11 +1534,11 @@ mod test {
         assert!(cache.get("a").is_none());
         assert_eq!(cache.len(), 0);
 
-        cache.insert("a".to_string(), "a".to_string()).unwrap();
-        cache.insert("b".to_string(), "b".to_string()).unwrap();
-        cache.insert("c".to_string(), "c".to_string()).unwrap();
-        cache.insert("d".to_string(), "d".to_string()).unwrap();
-        cache.insert("e".to_string(), "e".to_string()).unwrap();
+        cache.set("a".to_string(), "a".to_string());
+        cache.set("b".to_string(), "b".to_string());
+        cache.set("c".to_string(), "c".to_string());
+        cache.set("d".to_string(), "d".to_string());
+        cache.set("e".to_string(), "e".to_string());
         assert_eq!(3, cache.retain_latest(2, false));
         assert_eq!(2, cache.len());
         assert_eq!(cache.get("a"), None);
@@ -1620,10 +1547,10 @@ mod test {
         assert_eq!(cache.get("d"), Some("d".to_string()).as_ref());
         assert_eq!(cache.get("e"), Some("e".to_string()).as_ref());
 
-        cache.insert("a".to_string(), "a".to_string()).unwrap();
-        cache.insert("a".to_string(), "a".to_string()).unwrap();
-        cache.insert("b".to_string(), "b".to_string()).unwrap();
-        cache.insert("b".to_string(), "b".to_string()).unwrap();
+        cache.set("a".to_string(), "a".to_string());
+        cache.set("a".to_string(), "a".to_string());
+        cache.set("b".to_string(), "b".to_string());
+        cache.set("b".to_string(), "b".to_string());
         assert_eq!(4, cache.len());
 
         assert_eq!(2, cache.retain_latest(2, false));
@@ -1638,7 +1565,7 @@ mod test {
         // trying to get something expired will expire values
         assert_eq!(1, cache.len());
 
-        cache.insert("a".to_string(), "a".to_string()).unwrap();
+        cache.set("a".to_string(), "a".to_string());
         assert_eq!(cache.remove("a"), Some("a".to_string()));
         // we haven't done anything to evict "b" so there's still one entry
         assert_eq!(1, cache.len());
@@ -1647,22 +1574,18 @@ mod test {
         assert_eq!(0, cache.len());
 
         // default ttl is 100ms
-        cache
-            .insert_ttl("a".to_string(), "a".to_string(), Duration::from_millis(300))
-            .unwrap();
+        cache.set_with_ttl("a".to_string(), "a".to_string(), Duration::from_millis(300));
         std::thread::sleep(Duration::from_millis(200));
         assert_eq!(cache.get("a"), Some("a".to_string()).as_ref());
         assert_eq!(1, cache.len());
 
         std::thread::sleep(Duration::from_millis(200));
-        cache
-            .insert_ttl_evict(
-                "b".to_string(),
-                "b".to_string(),
-                Some(Duration::from_millis(300)),
-                true,
-            )
-            .unwrap();
+        cache.set_with_ttl_evict(
+            "b".to_string(),
+            "b".to_string(),
+            Some(Duration::from_millis(300)),
+            true,
+        );
         // a should now be evicted
         assert_eq!(1, cache.len());
         assert_eq!(cache.get("a"), None);
@@ -1680,13 +1603,13 @@ mod test {
         assert_eq!(0, cache.retain_latest(100, true));
         assert!(cache.get("a").is_none());
 
-        cache.insert("a".to_string(), "A".to_string()).unwrap();
+        cache.set("a".to_string(), "A".to_string());
         assert_eq!(cache.get("a"), Some("A".to_string()).as_ref());
         assert_eq!(cache.len(), 1);
-        cache.insert("b".to_string(), "B".to_string()).unwrap();
+        cache.set("b".to_string(), "B".to_string());
         assert_eq!(cache.get("b"), Some("B".to_string()).as_ref());
         assert_eq!(cache.len(), 2);
-        cache.insert("c".to_string(), "C".to_string()).unwrap();
+        cache.set("c".to_string(), "C".to_string());
         assert_eq!(cache.len(), 2);
         assert_eq!(cache.get("b"), Some("B".to_string()).as_ref());
         assert_eq!(cache.get("c"), Some("C".to_string()).as_ref());
@@ -1702,12 +1625,12 @@ mod test {
             .unwrap();
         cache.set_max_size(2);
 
-        cache.insert("a".to_string(), "A".to_string()).unwrap();
-        cache.insert("b".to_string(), "B".to_string()).unwrap();
+        cache.set("a".to_string(), "A".to_string());
+        cache.set("b".to_string(), "B".to_string());
         assert_eq!(cache.len(), 2);
 
         assert_eq!(
-            cache.insert("a".to_string(), "A2".to_string()).unwrap(),
+            cache.set("a".to_string(), "A2".to_string()),
             Some("A".to_string())
         );
         assert_eq!(cache.len(), 2);
@@ -1837,9 +1760,7 @@ mod test {
             .build()
             .unwrap();
         cache.set_max_size(1);
-        cache
-            .insert_ttl("long", 1u32, Duration::from_secs(60))
-            .unwrap();
+        cache.set_with_ttl("long", 1u32, Duration::from_secs(60));
         // Must not panic; "long" should be evicted to make room for "short".
         let v = cache.cache_get_or_set_with("short", || 2u32);
         assert_eq!(*v, 2);
@@ -1859,9 +1780,7 @@ mod test {
             .build()
             .unwrap();
         cache.set_max_size(1);
-        cache
-            .insert_ttl("long", 1u32, Duration::from_secs(60))
-            .unwrap();
+        cache.set_with_ttl("long", 1u32, Duration::from_secs(60));
         let v: &mut u32 = cache
             .cache_try_get_or_set_with_mut("short", || Ok::<u32, ()>(2))
             .unwrap();
@@ -1903,9 +1822,7 @@ mod test {
             .build()
             .unwrap();
         cache.set_max_size(1);
-        cache
-            .insert_ttl("long", 1u32, Duration::from_secs(60))
-            .unwrap();
+        cache.set_with_ttl("long", 1u32, Duration::from_secs(60));
         let v = cache
             .async_cache_get_or_set_with("short", || async { 2u32 })
             .await;
@@ -2303,17 +2220,17 @@ mod test {
         assert_eq!(cache.cache_get(&2u32), Some(&20u32));
     }
 
-    /// `insert_ttl` called with an EXPLICIT `Duration::ZERO` (not the cache-level
+    /// `set_with_ttl` called with an EXPLICIT `Duration::ZERO` (not the cache-level
     /// `set_ttl`) must store `expiry = None` (never expires), not `Some(now)`
     /// (immediate). The cache's default TTL stays finite the whole time.
     #[test]
-    fn insert_ttl_explicit_zero_never_expires() {
+    fn set_with_ttl_explicit_zero_never_expires() {
         let mut cache = TtlSortedCache::<u32, u32>::builder()
             .ttl(Duration::from_millis(20))
             .build()
             .unwrap();
         // Explicit zero TTL on this one entry — default ttl remains 20ms.
-        cache.insert_ttl(1u32, 10u32, Duration::ZERO).unwrap();
+        cache.set_with_ttl(1u32, 10u32, Duration::ZERO);
         // The entry's internal expiry must be None (never), not Some(now).
         assert!(
             cache
@@ -2342,10 +2259,10 @@ mod test {
         assert_eq!(cache.cache_get(&1u32), Some(&10u32));
     }
 
-    /// `insert_ttl_evict` with explicit `Duration::ZERO` also stores `None`,
+    /// `set_with_ttl_evict` with explicit `Duration::ZERO` also stores `None`,
     /// and the never-expiring entry is not swept by the eviction pass it triggers.
     #[test]
-    fn insert_ttl_evict_explicit_zero_never_expires_and_survives_evict() {
+    fn set_with_ttl_evict_explicit_zero_never_expires_and_survives_evict() {
         let mut cache = TtlSortedCache::<u32, u32>::builder()
             .ttl(Duration::from_millis(10))
             .build()
@@ -2354,9 +2271,7 @@ mod test {
         cache.cache_set(1u32, 10u32);
         std::thread::sleep(std::time::Duration::from_millis(40));
         // Insert a never-expiring entry AND run the eviction pass in the same call.
-        cache
-            .insert_ttl_evict(2u32, 20u32, Some(Duration::ZERO), true)
-            .unwrap();
+        cache.set_with_ttl_evict(2u32, 20u32, Some(Duration::ZERO), true);
         assert!(
             cache
                 .map

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -6242,20 +6242,20 @@ fn test_lru_ttl_cache_zero_ttl() {
 fn test_ttl_sorted_cache_try_set_time_bounds() {
     use cached::Cached;
     use cached::stores::TtlSortedCache;
-    // A near-maximum TTL triggers TimeBounds overflow on some platforms.
-    // cache_set silently no-ops; cache_try_set returns Err.
+    // A near-maximum TTL triggers Instant overflow on some platforms; the entry
+    // is stored with no expiry (never expires) on both set paths.
     let ttl = Duration::from_secs(u64::MAX / 2);
     let mut cache = TtlSortedCache::<u32, u32>::builder()
         .ttl(ttl)
         .build()
         .unwrap();
-    // cache_set must not panic
+    // cache_set must not panic and must store the entry.
     cache.cache_set(1, 42);
-    // cache_try_set must surface the error
-    let result = cache.cache_try_set(2, 99);
-    // The result is either Ok (if no overflow) or Err (if overflow occurred).
-    // Either is valid — the important thing is it does not panic.
-    let _ = result;
+    assert_eq!(cache.cache_get(&1), Some(&42));
+    // cache_try_set is infallible and behaves identically.
+    let result: Result<Option<u32>, std::convert::Infallible> = cache.cache_try_set(2, 99);
+    assert_eq!(result.unwrap(), None);
+    assert_eq!(cache.cache_get(&2), Some(&99));
 }
 
 #[test]
@@ -7123,8 +7123,8 @@ fn test_ttl_sorted_cache_generic_get_str_key() {
         .ttl(Duration::from_secs(60))
         .build()
         .unwrap();
-    cache.insert(String::from("hello"), 1).unwrap();
-    cache.insert(String::from("world"), 2).unwrap();
+    cache.set(String::from("hello"), 1);
+    cache.set(String::from("world"), 2);
 
     // &str lookup works via Borrow<str>
     assert_eq!(cache.get("hello"), Some(&1));
@@ -7140,7 +7140,7 @@ fn test_ttl_sorted_cache_generic_get_slice_key() {
         .ttl(Duration::from_secs(60))
         .build()
         .unwrap();
-    cache.insert(vec![1, 2, 3], "abc").unwrap();
+    cache.set(vec![1, 2, 3], "abc");
 
     // &[T] lookup works via Borrow<[T]>
     assert_eq!(cache.get([1u32, 2, 3].as_slice()), Some(&"abc"));

--- a/tests/v3_expiring_lru_order.rs
+++ b/tests/v3_expiring_lru_order.rs
@@ -76,8 +76,12 @@ fn iter_order_key_order_value_order_most_to_least_recent() {
         .zip(expected_vals.iter().cloned())
         .collect();
 
-    // ── iter_order returns Vec<(K, V)> ──────────────────────────────────────
-    let pairs: Vec<(u32, Val)> = cache.iter_order();
+    // ── iter_order returns Vec<(K, CacheValue<V>)> ──────────────────────────
+    let pairs: Vec<(u32, Val)> = cache
+        .iter_order()
+        .into_iter()
+        .map(|(k, v)| (k, v.into_value()))
+        .collect();
     assert_eq!(
         pairs, expected_pairs,
         "iter_order must return (key, value) pairs in MRU order"
@@ -90,12 +94,13 @@ fn iter_order_key_order_value_order_most_to_least_recent() {
         "key_order must return keys in MRU order"
     );
 
-    // ── value_order returns Vec<V> ───────────────────────────────────────────
-    let vals: Vec<Val> = cache.value_order();
+    // ── value_order returns Vec<CacheValue<V>>; comparable against bare V ───
+    let wrapped_vals = cache.value_order();
     assert_eq!(
-        vals, expected_vals,
+        wrapped_vals, expected_vals,
         "value_order must return values in MRU order"
     );
+    let vals: Vec<Val> = wrapped_vals.into_iter().map(|v| v.into_value()).collect();
 
     // ── all three methods agree with each other ──────────────────────────────
     let keys_from_pairs: Vec<u32> = pairs.iter().map(|(k, _)| *k).collect();
@@ -135,7 +140,7 @@ fn expired_entries_excluded_from_order_methods() {
     );
 
     // iter_order must exclude the expired entry.
-    let pairs: Vec<(u32, Val)> = cache.iter_order();
+    let pairs = cache.iter_order();
     let keys_in_pairs: Vec<u32> = pairs.iter().map(|(k, _)| *k).collect();
     assert!(
         !keys_in_pairs.contains(&2),
@@ -157,8 +162,8 @@ fn expired_entries_excluded_from_order_methods() {
         "key_order must include live entries (keys 1 and 3)"
     );
 
-    // value_order must exclude the expired entry.
-    let vals: Vec<Val> = cache.value_order();
+    // value_order must exclude the expired entry (the wrapper Derefs to Val).
+    let vals = cache.value_order();
     let val_ids: Vec<u32> = vals.iter().map(|v| v.id).collect();
     assert!(
         !val_ids.contains(&2),
@@ -196,7 +201,7 @@ fn all_expired_returns_empty_vecs() {
     cache.cache_set(1, Val::dead(1));
     cache.cache_set(2, Val::dead(2));
 
-    assert_eq!(cache.iter_order(), Vec::<(u32, Val)>::new());
+    assert!(cache.iter_order().is_empty());
     assert_eq!(cache.key_order(), Vec::<u32>::new());
     assert_eq!(cache.value_order(), Vec::<Val>::new());
 }
@@ -212,14 +217,18 @@ fn single_live_entry_appears_in_all_order_methods() {
 
     cache.cache_set(7, Val::live(7));
 
-    let pairs: Vec<(u32, Val)> = cache.iter_order();
+    let pairs: Vec<(u32, Val)> = cache
+        .iter_order()
+        .into_iter()
+        .map(|(k, v)| (k, v.into_value()))
+        .collect();
     assert_eq!(pairs, vec![(7, Val::live(7))]);
 
     let keys: Vec<u32> = cache.key_order();
     assert_eq!(keys, vec![7]);
 
-    let vals: Vec<Val> = cache.value_order();
-    assert_eq!(vals, vec![Val::live(7)]);
+    // CacheValue compares directly against the bare value.
+    assert_eq!(cache.value_order(), vec![Val::live(7)]);
 }
 
 // ── Empty cache ───────────────────────────────────────────────────────────────
@@ -231,7 +240,7 @@ fn empty_cache_returns_empty_vecs() {
         .build()
         .expect("build ExpiringLruCache");
 
-    assert_eq!(cache.iter_order(), Vec::<(u32, Val)>::new());
+    assert!(cache.iter_order().is_empty());
     assert_eq!(cache.key_order(), Vec::<u32>::new());
     assert_eq!(cache.value_order(), Vec::<Val>::new());
 }
@@ -285,8 +294,8 @@ fn order_methods_after_lru_eviction() {
     );
 
     // iter_order, key_order, value_order must agree.
-    let pairs: Vec<(u32, Val)> = cache.iter_order();
-    let vals: Vec<Val> = cache.value_order();
+    let pairs = cache.iter_order();
+    let vals = cache.value_order();
 
     assert_eq!(
         pairs.iter().map(|(k, _)| *k).collect::<Vec<_>>(),

--- a/tests/v3_single_owner_zero_ttl.rs
+++ b/tests/v3_single_owner_zero_ttl.rs
@@ -329,7 +329,15 @@ fn lru_ttl_cache_post_zero_entry_live_on_iter_peek_status_and_orders() {
 
     // iter_order / key_order / value_order all filter by entry_live and must
     // include the never-expiring entries.
-    assert_eq!(c.iter_order().len(), 2, "iter_order must keep live entries");
+    let ordered = c.iter_order();
+    assert_eq!(ordered.len(), 2, "iter_order must keep live entries");
+    for (_k, v) in &ordered {
+        assert_eq!(
+            v.expires_at(),
+            None,
+            "entries inserted under zero ttl carry no expiry"
+        );
+    }
     assert_eq!(c.key_order().len(), 2, "key_order must keep live entries");
     assert_eq!(
         c.value_order().len(),
@@ -598,11 +606,11 @@ fn ttl_sorted_cache_zero_disables_expiry() {
     );
 }
 
-// Fix 2: the infallible `cache_set` must NOT drop the value when the computed expiry
+// The infallible `cache_set` must NOT drop the value when the computed expiry
 // `Instant` overflows. Siblings (`TtlCache` / `LruTtlCache`) store the value with no
 // expiry (never expires) on overflow rather than silently discarding it, and
-// `TtlSortedCache` must match. `cache_try_set` keeps surfacing the overflow as
-// `Err(CacheSetError::TimeBounds)` (the fallible path is unchanged).
+// `TtlSortedCache` must match. `cache_try_set` behaves identically (the store's
+// `Cached::Error` is `Infallible`).
 //
 // The overflow is triggered portably with a near-`Duration::MAX` default ttl: it is
 // non-zero (so `build()` succeeds and it is NOT treated as "expiry disabled"), yet
@@ -610,7 +618,7 @@ fn ttl_sorted_cache_zero_disables_expiry() {
 // anywhere near `Duration::MAX` from its epoch.
 #[test]
 fn ttl_sorted_cache_set_overflow_stores_never_expiring_value() {
-    use cached::{CacheSetError, TtlSortedCache};
+    use cached::TtlSortedCache;
 
     let mut c = TtlSortedCache::<u32, u32>::builder()
         .ttl(Duration::MAX)
@@ -648,17 +656,13 @@ fn ttl_sorted_cache_set_overflow_stores_never_expiring_value() {
         "overwriting the never-expiring entry returns the prior value"
     );
 
-    // The fallible cache_try_set path is unchanged: the same overflow still errors.
-    let result: Result<Option<u32>, CacheSetError> = c.cache_try_set(2, 7);
-    assert_eq!(
-        result,
-        Err(CacheSetError::TimeBounds),
-        "cache_try_set must still surface TimeBounds on overflow"
-    );
+    // cache_try_set matches: the same overflow stores a never-expiring entry.
+    let result: Result<Option<u32>, std::convert::Infallible> = c.cache_try_set(2, 7);
+    assert_eq!(result.unwrap(), None);
     assert_eq!(
         c.cache_get(&2),
-        None,
-        "the erroring cache_try_set must not insert anything"
+        Some(&7),
+        "cache_try_set on TTL overflow must store the value (never expires)"
     );
 }
 

--- a/tests/v3_traits.rs
+++ b/tests/v3_traits.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the 3.0 trait additions and audit-fix batch:
 //! - `*_mut` get-or-set variants (#179)
 //! - `SerializeCached`/`SerializeCachedAsync` borrowed set (#196)
-//! - `CacheSetError` concrete error type for `cache_try_set`
+//! - infallible `cache_try_set` via the `Cached::Error` associated type
 //! - `ConcurrentCached::refresh_on_hit` getter default and override
 //! - `ConcurrentCached::cache_get_or_set_with` / `async_cache_get_or_set_with`
 //! - `store()` getter removal verified via public API
@@ -826,29 +826,7 @@ mod redb_serialize_cached_async {
     }
 }
 
-// ── Item 1: CacheSetError ─────────────────────────────────────────────────────
-
-/// `CacheSetError` is a well-formed concrete `std::error::Error` type:
-/// it is `Debug`, has a `Display` impl, and can be boxed as a trait object.
-#[test]
-fn cache_set_error_is_std_error() {
-    use cached::CacheSetError;
-    use std::error::Error;
-
-    let err = CacheSetError::TimeBounds;
-
-    // Debug and Display both work.
-    assert!(format!("{err:?}").contains("TimeBounds"));
-    assert_eq!(err.to_string(), "ttl is outside Instant bounds");
-
-    // It is a leaf error: no source.
-    assert!(err.source().is_none());
-
-    // Can be boxed as a trait object.
-    let boxed: Box<dyn Error> = Box::new(CacheSetError::TimeBounds);
-    assert_eq!(boxed.to_string(), "ttl is outside Instant bounds");
-    assert!(boxed.source().is_none());
-}
+// ── Infallible in-memory `cache_try_set` ─────────────────────────────────────
 
 /// The default `cache_try_set` on stores that do not override it is infallible:
 /// it always returns `Ok(prev)`. The associated `Error` type is `Infallible`
@@ -869,14 +847,14 @@ fn cache_try_set_default_is_infallible() {
     assert_eq!(result.unwrap(), Some(10));
 }
 
-/// `TtlSortedCache::cache_try_set` returns `Err(CacheSetError::TimeBounds)` when
-/// the computed expiry `Instant` would overflow. With a normally-representable TTL
-/// it succeeds and returns the previous value.
+/// `TtlSortedCache::cache_try_set` is infallible (`type Error = Infallible`),
+/// matching every other in-memory store. With a normally-representable TTL it
+/// succeeds and returns the previous value.
 #[cfg(feature = "time_stores")]
 #[test]
 fn ttl_sorted_cache_try_set_succeeds_normal_ttl() {
     use cached::time::Duration;
-    use cached::{CacheSetError, Cached, TtlSortedCache};
+    use cached::{Cached, TtlSortedCache};
 
     let mut cache = TtlSortedCache::<u32, u32>::builder()
         .ttl(Duration::from_secs(60))
@@ -884,74 +862,61 @@ fn ttl_sorted_cache_try_set_succeeds_normal_ttl() {
         .expect("build TtlSortedCache");
 
     // A normal insert via cache_try_set must succeed and return the previous value.
-    let result: Result<Option<u32>, CacheSetError> = cache.cache_try_set(1, 42);
+    let result: Result<Option<u32>, std::convert::Infallible> = cache.cache_try_set(1, 42);
     assert_eq!(result.unwrap(), None);
 
     // A second insert returns the previous value.
-    let result: Result<Option<u32>, CacheSetError> = cache.cache_try_set(1, 99);
+    let result: Result<Option<u32>, std::convert::Infallible> = cache.cache_try_set(1, 99);
     assert_eq!(result.unwrap(), Some(42));
 }
 
-/// `TtlSortedCache::cache_try_set` returns `Err(CacheSetError::TimeBounds)` when
-/// the configured ttl makes the computed expiry `Instant` overflow.
+/// A TTL that overflows `Instant` bounds stores a never-expiring entry instead of
+/// erroring, on every set path.
 ///
-/// The overflow is triggered deterministically and portably: the public default ttl
-/// drives the expiry (`insert` -> `insert_inner` computes `Instant::now() + self.ttl`),
-/// and the builder's `validate_ttl` only rejects a *zero* ttl, so a near-`Duration::MAX`
-/// ttl passes `build()` and then overflows `Instant::checked_add` on every platform
-/// (no real `Instant` is anywhere near `Duration::MAX` from the epoch). The fallible
-/// `cache_try_set` path uses `TtlOverflow::Error`, so it must report the overflow rather
-/// than silently saturating or panicking, and the cache must be left unmutated.
-/// The associated `type Error = CacheSetError` surfaces it directly without mapping
-/// (TtlSortedCache now shares the unified error type with TtlCache / LruTtlCache).
+/// The overflow is triggered deterministically and portably: the default ttl drives
+/// the expiry (`cache_set` computes `Instant::now() + self.ttl`), and the builder's
+/// `validate_ttl` only rejects a *zero* ttl, so a near-`Duration::MAX` ttl passes
+/// `build()` and then overflows `Instant::checked_add` on every platform (no real
+/// `Instant` is anywhere near `Duration::MAX` from the epoch). The entry must be
+/// stored with no expiry, matching the sharded TTL stores.
 #[cfg(feature = "time_stores")]
 #[test]
-fn ttl_sorted_cache_try_set_overflow_returns_time_bounds() {
+fn ttl_sorted_cache_try_set_overflow_stores_never_expiring_entry() {
     use cached::time::Duration;
-    use cached::{CacheSetError, Cached, CachedExt, TtlSortedCache};
+    use cached::{Cached, CachedExt, TtlSortedCache};
 
     let mut cache = TtlSortedCache::<u32, u32>::builder()
         .ttl(Duration::MAX)
         .build()
         .expect("Duration::MAX is non-zero so build() must succeed");
 
-    let result: Result<Option<u32>, CacheSetError> = cache.cache_try_set(1, 42);
-    assert!(
-        matches!(result, Err(CacheSetError::TimeBounds)),
-        "near-MAX ttl must overflow Instant and surface TimeBounds, got {result:?}"
-    );
+    let result: Result<Option<u32>, std::convert::Infallible> = cache.cache_try_set(1, 42);
+    assert_eq!(result.unwrap(), None);
 
-    // The failed try_set must not have stored anything (Error path mutates nothing).
-    assert_eq!(cache.cache_size(), 0, "overflowing try_set must not insert");
-    assert_eq!(
-        cache.cache_get(&1),
-        None,
-        "overflowing try_set must not insert"
-    );
+    // The entry is stored and readable: overflow means never-expires, not an error.
+    assert_eq!(cache.cache_size(), 1);
+    assert_eq!(cache.cache_get(&1), Some(&42));
 
-    // The ergonomic alias surfaces the same error.
-    let via_alias: Result<Option<u32>, CacheSetError> = cache.try_set(2, 7);
-    assert!(
-        matches!(via_alias, Err(CacheSetError::TimeBounds)),
-        "try_set alias must also surface TimeBounds, got {via_alias:?}"
-    );
-    assert_eq!(cache.cache_size(), 0);
+    // The ergonomic alias behaves the same.
+    let via_alias: Result<Option<u32>, std::convert::Infallible> = cache.try_set(2, 7);
+    assert_eq!(via_alias.unwrap(), None);
+    assert_eq!(cache.cache_size(), 2);
 }
 
 /// `try_set` (the ergonomic alias) delegates to `cache_try_set` and returns the
 /// same `Result<Option<V>, Self::Error>` type.
 #[cfg(feature = "time_stores")]
 #[test]
-fn try_set_alias_returns_cache_set_error_for_ttl_sorted_cache() {
+fn try_set_alias_is_infallible_for_ttl_sorted_cache() {
     use cached::time::Duration;
-    use cached::{CacheSetError, CachedExt, TtlSortedCache};
+    use cached::{CachedExt, TtlSortedCache};
 
     let mut cache = TtlSortedCache::<u32, u32>::builder()
         .ttl(Duration::from_secs(60))
         .build()
         .expect("build TtlSortedCache");
 
-    let result: Result<Option<u32>, CacheSetError> = cache.try_set(1, 7);
+    let result: Result<Option<u32>, std::convert::Infallible> = cache.try_set(1, 7);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), None);
 }
@@ -968,7 +933,6 @@ fn cached_error_associated_type_infallible_for_unbound_cache() {
         UnboundCache::builder().build().expect("build UnboundCache");
 
     // The type annotation pins the associated type to Infallible at compile time.
-    // This test fails to compile on the old signature (Result<_, CacheSetError>).
     let r1: Result<Option<u32>, std::convert::Infallible> = cache.cache_try_set(10, 100);
     assert_eq!(r1.unwrap(), None);
 
@@ -994,29 +958,29 @@ fn cached_error_associated_type_infallible_for_lru_cache() {
     assert_eq!(r.unwrap(), None);
 }
 
-/// `TtlCache` sets `type Error = CacheSetError`; `cache_try_set` surfaces the concrete
-/// error type through the associated type without any extra mapping at the call site.
+/// `TtlCache` sets `type Error = Infallible`: a TTL overflow stores a
+/// never-expiring entry rather than erroring, so `cache_try_set` cannot fail.
 #[cfg(feature = "time_stores")]
 #[test]
-fn cached_error_associated_type_cache_set_error_for_ttl_cache() {
+fn cached_error_associated_type_infallible_for_ttl_cache() {
     use cached::time::Duration;
-    use cached::{CacheSetError, Cached, TtlCache};
+    use cached::{Cached, TtlCache};
 
     let mut cache: TtlCache<u32, u32> = TtlCache::builder()
         .ttl(Duration::from_secs(60))
         .build()
         .expect("build TtlCache");
 
-    let r: Result<Option<u32>, CacheSetError> = cache.cache_try_set(1, 99);
+    let r: Result<Option<u32>, std::convert::Infallible> = cache.cache_try_set(1, 99);
     assert_eq!(r.unwrap(), None);
 }
 
-/// `LruTtlCache` sets `type Error = CacheSetError` too.
+/// `LruTtlCache` sets `type Error = Infallible` too.
 #[cfg(feature = "time_stores")]
 #[test]
-fn cached_error_associated_type_cache_set_error_for_lru_ttl_cache() {
+fn cached_error_associated_type_infallible_for_lru_ttl_cache() {
     use cached::time::Duration;
-    use cached::{CacheSetError, Cached, LruTtlCache};
+    use cached::{Cached, LruTtlCache};
 
     let mut cache: LruTtlCache<u32, u32> = LruTtlCache::builder()
         .max_size(4)
@@ -1024,17 +988,17 @@ fn cached_error_associated_type_cache_set_error_for_lru_ttl_cache() {
         .build()
         .expect("build LruTtlCache");
 
-    let r: Result<Option<u32>, CacheSetError> = cache.cache_try_set(1, 7);
+    let r: Result<Option<u32>, std::convert::Infallible> = cache.cache_try_set(1, 7);
     assert_eq!(r.unwrap(), None);
 }
 
-/// `TtlSortedCache` sets `type Error = CacheSetError` (unified with `TtlCache` /
-/// `LruTtlCache`), surfacing a shared error type from `cache_try_set`.
+/// `TtlSortedCache` sets `type Error = Infallible` (unified with `TtlCache` /
+/// `LruTtlCache`); an overflowing TTL stores a never-expiring entry.
 #[cfg(feature = "time_stores")]
 #[test]
-fn cached_error_associated_type_cache_set_error_for_ttl_sorted_cache() {
+fn cached_error_associated_type_infallible_for_ttl_sorted_cache() {
     use cached::time::Duration;
-    use cached::{CacheSetError, Cached, TtlSortedCache};
+    use cached::{Cached, TtlSortedCache};
 
     // Normal TTL: succeeds.
     let mut cache: TtlSortedCache<u32, u32> = TtlSortedCache::builder()
@@ -1042,21 +1006,19 @@ fn cached_error_associated_type_cache_set_error_for_ttl_sorted_cache() {
         .build()
         .expect("build TtlSortedCache");
 
-    let r: Result<Option<u32>, CacheSetError> = cache.cache_try_set(1, 55);
+    let r: Result<Option<u32>, std::convert::Infallible> = cache.cache_try_set(1, 55);
     assert_eq!(r.unwrap(), None);
 
-    // Near-MAX TTL: returns Err(CacheSetError::TimeBounds) directly.
+    // Near-MAX TTL: the entry is stored with no expiry (never expires).
     let mut overflow: TtlSortedCache<u32, u32> = TtlSortedCache::builder()
         .ttl(Duration::MAX)
         .build()
         .expect("Duration::MAX is non-zero");
 
-    let r2: Result<Option<u32>, CacheSetError> = overflow.cache_try_set(1, 55);
-    assert!(
-        matches!(r2, Err(CacheSetError::TimeBounds)),
-        "expected TimeBounds, got {r2:?}"
-    );
-    assert_eq!(overflow.cache_size(), 0, "failed try_set must not insert");
+    let r2: Result<Option<u32>, std::convert::Infallible> = overflow.cache_try_set(1, 55);
+    assert_eq!(r2.unwrap(), None);
+    assert_eq!(overflow.cache_size(), 1, "overflowing set stores the entry");
+    assert_eq!(overflow.cache_get(&1), Some(&55));
 }
 
 // ── Item 5: refresh_on_hit getter on ConcurrentCacheTtl ──────────────────────


### PR DESCRIPTION
Breaking changes ahead of 3.0.0 final.

- Remove `CacheSetError`: a TTL that would overflow `Instant` bounds now stores the entry with no expiry (never expires) on every set path, matching the sharded TTL stores (`cache_set` already behaved this way). `TtlCache` / `LruTtlCache` / `TtlSortedCache` set `Cached::Error = Infallible`, so every built-in in-memory store is infallible; `type Error` remains for custom and IO stores.
- Rename `TtlSortedCache::insert` / `insert_ttl` / `insert_evict` / `insert_ttl_evict` to `set` / `set_with_ttl` / `set_evict` / `set_with_ttl_evict`, returning `Option<V>` instead of `Result`.
- Unify the LRU-family order methods on one shape: `iter_order() -> Vec<(K, CacheValue<V, M>)>` and `value_order() -> Vec<CacheValue<V, M>>` on `LruCache`, `LruTtlCache`, and `ExpiringLruCache`. `CacheValue<V, M = ()>` (new root re-export) derefs to `V`, compares against bare values (`PartialEq<V>`), and exposes `expires_at()` on `LruTtlCache` entries (`M = Option<Instant>`). `LruTtlCache` no longer leaks bare `(Option<Instant>, V)` tuples.
- Update migration guide sections 18/22/33/43, add sections 74/75; mark design doc 0020 declined (error split kept, `TimeBounds` gone).