### PR TITLE
fix: clear `Clone` error for `#[cached]` return types, `async_core` docsrs badges, doc and spec corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,10 +39,11 @@
   `ConcurrentCachedAsync::async_cache_try_get_or_set_with` (both provided): fallible-init
   get-or-set returning `Result<Result<V, E>, Self::Error>`, store error outer, closure error
   inner. On a closure `Err` nothing is stored.
-- `retain(keep)` on `TtlCache` and `ExpiringCache`, completing `retain` across the
-  expiry-aware stores. Expired entries are removed regardless of the predicate; each
-  removed entry fires `on_evict` and counts an eviction. `UnboundCache` intentionally
-  has no `retain`: it has no eviction dimension backing the operation.
+- `retain(keep)` on `UnboundCache`, `TtlCache`, and `ExpiringCache`, completing `retain`
+  across the map stores. Each removed entry fires `on_evict`. On the expiry-aware stores
+  expired entries are removed regardless of the predicate and every removal counts an
+  eviction; on `UnboundCache` (no expiry dimension, no eviction counter) an entry
+  survives exactly when `keep` returns `true`.
 - `TtlSortedCache::capacity() -> Option<usize>`: the configured size bound (`None` when
   unbounded), plus the missing `doc(alias = "capacity")` on `TtlSortedCacheBuilder::max_size`.
 
@@ -56,6 +57,12 @@
   corrected to match.
 - Macro docs note the `Arc<T>` return pattern for expensive-to-clone values ([#64]): the
   cache stores the `Arc`, hits clone only the pointer.
+- docs.rs feature badges on the `async_core`-gated `CachedGetOrSetAsync` and
+  `ConcurrentCachedAsync` impls for the in-memory and sharded stores (and `HashMap`), which
+  previously rendered as unconditionally available.
+- `#[cached]` on a function whose return type does not implement `Clone` now emits a clear
+  `Clone`-bound error spanned at the return type, ahead of the opaque errors from the
+  generated internals.
 
 [#64]: https://github.com/jaemk/cached/issues/64
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,11 @@ Because LRU caches require updating access recency, `ShardedLruCache`, `ShardedL
   fallible) and `ConcurrentCached::cache_set` returns a `#[must_use] Result<Option<V>, Error>`.
   The concurrent family returns owned values because its implementors include IO stores that
   serialize entries and cannot hand out a borrow into the store, and it is fallible because those
-  stores can fail; the single-owner family stays infallible and borrow-returning. A prelude glob
+  stores can fail; the single-owner family stays infallible and borrow-returning. Lookup keys
+  differ the same way: single-owner `cache_get` accepts any borrowed form of the key
+  (`&Q where K: Borrow<Q>`, so `cache.get("a")` works on an `LruCache<String, _>`), while the
+  concurrent family takes `&K` exactly (`store.get(&"a".to_string())` on a sharded store) because
+  its IO-store implementors serialize the full key. A prelude glob
   can bring both families into scope without collision.
 - **The inherent-method asymmetry between the two families is deliberate.** On a sharded store the
   short `set`/`get`/`len` calls resolve to *inherent* methods (infallible, `&self`), so

--- a/cached_proc_macro/src/cached.rs
+++ b/cached_proc_macro/src/cached.rs
@@ -601,6 +601,13 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
         Err(e) => return e.to_compile_error().into(),
     };
 
+    // The generated cache internals `.clone()` the value on `cache_set` and
+    // `.to_owned()` it on a cache hit; without a `Clone` bound on the cached
+    // value type those calls fail deep inside macro-generated code with an
+    // opaque trait-bound error. Emit a clear, precisely-spanned assertion
+    // instead (see `clone_return_assertion`).
+    let clone_type_assertion = clone_return_assertion(&cache_value_ty, output_span);
+
     // make the cache identifier
     let cache_ident = match args.name {
         Some(ref name) => {
@@ -1333,6 +1340,7 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
             #body_static
             use #krate::Cached;
             #clone_cached_import
+            #clone_type_assertion
             let __cached_key = #key_convert_block;
             #do_set_return_block
         }

--- a/cached_proc_macro/src/helpers.rs
+++ b/cached_proc_macro/src/helpers.rs
@@ -4,7 +4,7 @@ use proc_macro::TokenStream;
 use proc_macro_crate::{FoundCrate, crate_name};
 use proc_macro2::Span;
 use proc_macro2::TokenStream as TokenStream2;
-use quote::{format_ident, quote};
+use quote::{format_ident, quote, quote_spanned};
 use std::ops::Deref;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
@@ -369,6 +369,45 @@ pub(super) fn find_value_type(
                 }
             }
         },
+    }
+}
+
+/// Emits a compile-time assertion that `value_ty` (the type actually stored/
+/// returned by the generated cache - the unwrapped `T` of a `Result<T, E>`/
+/// `Option<T>` return, or the `cached::Return<T>` wrapper under
+/// `with_cached_flag`) implements `Clone`.
+///
+/// Without this, a non-`Clone` return type only fails deep inside the
+/// generated cache internals (the `.clone()` call in the `cache_set` block, or
+/// the `.to_owned()` call on a cache hit), producing a trait-bound error that
+/// points at macro-generated code rather than at the user's return type -
+/// confusing and hard to act on.
+///
+/// The assertion is a local, non-generic-over-`value_ty` helper fn plus a
+/// call that names `value_ty` as its turbofish argument, e.g.
+/// `fn __cached_assert_return_type_implements_clone<T: Clone>() {}` followed
+/// by `__cached_assert_return_type_implements_clone::<#value_ty>();`. This
+/// works even when `value_ty` names a generic parameter of the enclosing
+/// function (or, for `in_impl` methods, of the enclosing `impl` block):
+/// naming an in-scope generic parameter as a type argument to another
+/// generic call is ordinary code, not a new item definition, so it does not
+/// hit E0401 ("can't use generic parameters from outer item"). Rust checks
+/// the `Clone` bound against the enclosing generic's own declared bounds at
+/// definition time, so a generic function whose signature already requires
+/// `T: Clone` continues to compile, while one that does not gets a precise
+/// diagnostic.
+///
+/// `value_ty`'s tokens carry their original source spans (they are threaded
+/// through unmodified from the parsed return type), so the turbofish
+/// argument alone is enough to underline the user's return type in the
+/// resulting error; `span` (the return type's span) additionally covers the
+/// surrounding generated syntax so the whole assertion is attributed to the
+/// return type rather than macro-internal call-site code.
+pub(super) fn clone_return_assertion(value_ty: &TokenStream2, span: Span) -> TokenStream2 {
+    quote_spanned! {span=>
+        #[allow(non_snake_case)]
+        fn __cached_assert_return_type_implements_clone<__CachedAssertClone: ::std::clone::Clone>() {}
+        __cached_assert_return_type_implements_clone::<#value_ty>();
     }
 }
 

--- a/docs/migrations/2.0-to-3.0-human.md
+++ b/docs/migrations/2.0-to-3.0-human.md
@@ -235,7 +235,7 @@ rolling upgrade does not invalidate a shared redis cache.
 
 ## Additional breaking changes from the final 3.0 API
 
-These changes landed after the rc.1 snapshot above. For full Detection/Action entries see the
+Breaking changes not covered by the sections above. For full Detection/Action entries see the
 [agent-oriented guide](2.0-to-3.0.md).
 
 ### `cache_set_ref` / `async_cache_set_ref` return `Result<(), _>`
@@ -288,6 +288,15 @@ take no arguments and chain with setters. Only the `CacheType::builder(x)` short
 `RedisCache::builder("prefix").build()` no longer returns `MissingRequired("ttl")`. An unset TTL
 means entries are written without an expiry command and never expire. Set `.ttl(Duration)` if you
 want expiry.
+
+### Redis builders reject an empty prefix
+
+`RedisCacheBuilder::build()` / `AsyncRedisCacheBuilder::build()` now return
+`Err(BuildError::InvalidValue { field: "prefix", .. })` for a prefix explicitly set to `""`
+(2.x accepted it silently). The prefix is what scopes `cache_clear` to one logical cache; with
+an empty prefix, clear deletes the entries of every cache sharing the namespace. Give each
+logical cache a distinct non-empty prefix. `#[concurrent_cached(redis = true)]` supplies the
+function name as the prefix, so macro-generated caches are unaffected.
 
 ### `#[concurrent_cached(disk = true, cache_prefix_block = ...)]` is a compile error
 
@@ -344,6 +353,26 @@ Note that the trait declares `async_cache_contains` in RPIT form
 shows the full RPIT form.
 
 If you only use the built-in sharded, redis, or redb stores, no change is needed.
+
+### `CacheTtl` / `CacheEvict` removed from concurrent stores
+
+`CacheTtl` and `CacheEvict` are single-owner (`&mut self`) traits, no longer implemented for
+`RedisCache`, `AsyncRedisCache`, `RedbCache`, or the sharded stores. Use the `&self`
+equivalents on concurrent stores:
+
+```rust
+use cached::{ConcurrentCacheTtl, ConcurrentCacheEvict};
+// Before
+CacheTtl::set_ttl(&mut store, Duration::from_secs(30));
+let n = CacheEvict::evict(&mut store);
+// After
+store.set_ttl(Duration::from_secs(30)); // ConcurrentCacheTtl; works through Arc/static
+let n = store.evict();                  // ConcurrentCacheEvict, or the inherent evict(&self)
+```
+
+`ConcurrentCacheEvict` is implemented by the TTL/expiring sharded stores (`ShardedTtlCache`,
+`ShardedLruTtlCache`, `ShardedExpiringCache`, `ShardedExpiringLruCache`). The single-owner
+in-memory stores keep `CacheTtl` / `CacheEvict` unchanged.
 
 ### `TtlSortedCache::set_ttl` inherent method removed
 

--- a/docs/migrations/2.0-to-3.0.md
+++ b/docs/migrations/2.0-to-3.0.md
@@ -1223,8 +1223,8 @@ Client-side caching is the same shape: `features = ["redis_async_cache", "redis_
 Several trait bounds tightened for consistency:
 
 - `CloneCached::cache_get_with_expiry_status` now carries `V: Clone`, matching its
-  `cache_get_expired` sibling. A custom `impl CloneCached` for a `V` that is not `Clone` no longer
-  compiles.
+  `cache_peek_with_expiry_status` sibling. A custom `impl CloneCached` for a `V` that is not
+  `Clone` no longer compiles.
 - `UnboundCache` / `LruCache` implement `Eq` only when `V: Eq` (previously the `Eq` impl did not
   require it).
 - `#[concurrent_cached(redis = true, ty = ...)]` / `#[concurrent_cached(disk = true, ty = ...)]`
@@ -1376,8 +1376,9 @@ let empty = store.cache_is_empty()?;
 their primary identifier as a positional argument: `builder(prefix)` for the redis stores and
 `builder(name)` for the redb store. The no-argument form no longer compiles.
 
-This supersedes the direction in #26 (which moved from `::new(arg)` to `::builder().field(arg)`
-in rc.1). The net change from 2.x is: replace `::new(arg)` with `::builder(arg)`.
+This only affects code written against the rc-era no-argument `builder().name(...)` /
+`builder().prefix(...)` form. Coming straight from 2.x, the net change is the one described in
+#26: `builder(prefix, ttl)` becomes `builder(prefix)` with an optional `.ttl(...)` setter.
 
 Detection: `RedisCache::builder()` / `AsyncRedisCache::builder()` / `RedbCache::builder()` with
 no arguments now fails to compile. `RedisCacheBuilder::new()` / `RedbCacheBuilder::new()`

--- a/specs/design/README.md
+++ b/specs/design/README.md
@@ -38,7 +38,7 @@ the item stays here for history.
 | [0017](0017-redis-feature-axes.md) | Orthogonal redis runtime x TLS features | Capability axis resolved; TLS orthogonality needs research |
 | [0018](0018-redis-key-escaping.md) | Escape redis namespace/prefix/key segments | Needs research |
 | [0019](0019-ahash-default-feature.md) | Drop `ahash` from default features | Declined (kept in defaults) |
-| [0020](0020-argument-error-unification.md) | Unify single-variant argument errors | Needs research |
+| [0020](0020-argument-error-unification.md) | Unify single-variant argument errors | Declined (split kept; `CacheSetError` removed instead) |
 | [0021](0021-redb-refresh-on-hit-cost.md) | Amortize redb refresh-on-hit write txns | Needs research |
 | [0022](0022-serialize-cached-set-ref-return.md) | `cache_set_ref` returning previous value | Implemented |
 | [0023](0023-peek-read-trait-merge.md) | Merge `CachedPeek`/`CachedRead`; trait fragmentation | Declined |

--- a/specs/store-expiring.md
+++ b/specs/store-expiring.md
@@ -33,3 +33,9 @@ check expiry themselves. See [design/0030-force-refresh-result-fallback-interact
 `CachedIter::iter()` filters expired entries but does not remove them; call `evict()`
 (`CacheEvict`) periodically for high-cardinality workloads. See
 [design/0002-size-iter-evict-semantics.md](design/0002-size-iter-evict-semantics.md).
+
+## EXPIRE-6
+
+`ExpiringLruCache` has the LRU-family order accessors (`iter_order` / `key_order` /
+`value_order`) with `CacheValue<V>` values (no per-entry metadata; expiry lives on the value
+itself via `Expires`). See [store-lru.md](store-lru.md) LRU-5.

--- a/specs/store-lru.md
+++ b/specs/store-lru.md
@@ -25,10 +25,21 @@ See [metrics.md](metrics.md).
 Implements `Cached`, `CachedPeek`, and `CachedIter`. Size/iter/evict semantics follow
 [design/0002-size-iter-evict-semantics.md](design/0002-size-iter-evict-semantics.md).
 Inherent `retain(keep)` removes entries failing the predicate (firing `on_evict` and counting
-evictions); it exists on every unsync store with an eviction dimension. The expiry-aware stores
+evictions); it exists on every unsync map store. The expiry-aware stores
 (`TtlCache`, `LruTtlCache`, `ExpiringCache`, `ExpiringLruCache`) share the contract but also
 remove expired entries regardless of the predicate; `TtlSortedCache` has the differently-purposed
-`retain_latest`; `UnboundCache` has no `retain` (no eviction dimension).
+`retain_latest`; on `UnboundCache` (no eviction dimension) `retain` is a plain predicate filter
+that fires `on_evict` per removed entry but counts no evictions.
 `set_max_size(n) -> Option<usize>`
 resizes a live cache (returns the previous capacity, panics on zero). `try_set_max_size(n) ->
 Result<Option<usize>, SetMaxSizeError>` is the non-panicking variant.
+
+## LRU-5
+
+Order accessors, shared across the LRU family (`LruCache`, `LruTtlCache`, `ExpiringLruCache`):
+`iter_order() -> Vec<(K, CacheValue<V, M>)>`, `key_order() -> Vec<K>`, and
+`value_order() -> Vec<CacheValue<V, M>>`, all most-recently-used first. `CacheValue<V, M = ()>`
+(exported at the crate root) wraps the value with per-entry metadata: `M = ()` for `LruCache`
+and `ExpiringLruCache`, `M = Option<Instant>` for `LruTtlCache`, read via `expires_at()`. The
+wrapper `Deref`s to `V`, exposes `value()` / `into_value()`, and compares equal against bare
+values (`PartialEq<V>`).

--- a/specs/store-ttl.md
+++ b/specs/store-ttl.md
@@ -30,3 +30,9 @@ These stores implement `CacheTtl` (`ttl()` / `set_ttl()` / `unset_ttl()` / `try_
 `CachedIter`, `CachedPeek`, and `CloneCached`; `TimedEntry<V>` is `pub(crate)` and not part of
 the public surface. Size/iter/evict semantics follow
 [design/0002-size-iter-evict-semantics.md](design/0002-size-iter-evict-semantics.md).
+
+## TTL-5
+
+`LruTtlCache` has the LRU-family order accessors (`iter_order` / `key_order` / `value_order`)
+with `CacheValue<V, Option<Instant>>` values carrying the entry expiry via `expires_at()`. See
+[store-lru.md](store-lru.md) LRU-5.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,7 +226,11 @@ Because LRU caches require updating access recency, `ShardedLruCache`, `ShardedL
   fallible) and `ConcurrentCached::cache_set` returns a `#[must_use] Result<Option<V>, Error>`.
   The concurrent family returns owned values because its implementors include IO stores that
   serialize entries and cannot hand out a borrow into the store, and it is fallible because those
-  stores can fail; the single-owner family stays infallible and borrow-returning. A prelude glob
+  stores can fail; the single-owner family stays infallible and borrow-returning. Lookup keys
+  differ the same way: single-owner `cache_get` accepts any borrowed form of the key
+  (`&Q where K: Borrow<Q>`, so `cache.get("a")` works on an `LruCache<String, _>`), while the
+  concurrent family takes `&K` exactly (`store.get(&"a".to_string())` on a sharded store) because
+  its IO-store implementors serialize the full key. A prelude glob
   can bring both families into scope without collision.
 - **The inherent-method asymmetry between the two families is deliberate.** On a sharded store the
   short `set`/`get`/`len` calls resolve to *inherent* methods (infallible, `&self`), so

--- a/src/stores/expiring.rs
+++ b/src/stores/expiring.rs
@@ -588,6 +588,7 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> CachedPeek<K, V> for ExpiringCach
 }
 
 #[cfg(feature = "async_core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async_core")))]
 impl<K, V, S> CachedGetOrSetAsync<K, V> for ExpiringCache<K, V, S>
 where
     K: Hash + Eq + Send,

--- a/src/stores/expiring_lru.rs
+++ b/src/stores/expiring_lru.rs
@@ -732,6 +732,7 @@ impl<K: Hash + Eq + Clone, V: Expires, S: BuildHasher> CachedPeek<K, V>
 }
 
 #[cfg(feature = "async_core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async_core")))]
 impl<K, V, S> CachedGetOrSetAsync<K, V> for ExpiringLruCache<K, V, S>
 where
     K: Hash + Eq + Clone + Send,

--- a/src/stores/lru.rs
+++ b/src/stores/lru.rs
@@ -943,6 +943,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> CachedPeek<K, V> for LruCache<K, V
 }
 
 #[cfg(feature = "async_core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async_core")))]
 impl<K, V, S> CachedGetOrSetAsync<K, V> for LruCache<K, V, S>
 where
     K: Hash + Eq + Clone + Send,

--- a/src/stores/lru_ttl.rs
+++ b/src/stores/lru_ttl.rs
@@ -1002,6 +1002,7 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher + Clone> CloneCached<K, V>
 }
 
 #[cfg(feature = "async_core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async_core")))]
 impl<K, V, S> CachedGetOrSetAsync<K, V> for LruTtlCache<K, V, S>
 where
     K: Hash + Eq + Clone + Send,

--- a/src/stores/mod.rs
+++ b/src/stores/mod.rs
@@ -495,6 +495,7 @@ where
 }
 
 #[cfg(feature = "async_core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async_core")))]
 impl<K, V, S> CachedGetOrSetAsync<K, V> for HashMap<K, V, S>
 where
     K: Hash + Eq + Clone + Send,

--- a/src/stores/sharded/expiring.rs
+++ b/src/stores/sharded/expiring.rs
@@ -583,6 +583,7 @@ where
 }
 
 #[cfg(feature = "async_core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async_core")))]
 impl<K, V, H> ConcurrentCachedAsync<K, V> for ShardedExpiringCacheBase<K, V, H>
 where
     K: Hash + Eq + Send + Sync,

--- a/src/stores/sharded/expiring_lru.rs
+++ b/src/stores/sharded/expiring_lru.rs
@@ -703,6 +703,7 @@ where
 }
 
 #[cfg(feature = "async_core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async_core")))]
 impl<K, V, H> ConcurrentCachedAsync<K, V> for ShardedExpiringLruCacheBase<K, V, H>
 where
     K: Hash + Eq + Clone + Send + Sync,

--- a/src/stores/sharded/lru.rs
+++ b/src/stores/sharded/lru.rs
@@ -591,6 +591,7 @@ where
 }
 
 #[cfg(feature = "async_core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async_core")))]
 impl<K, V, H> ConcurrentCachedAsync<K, V> for ShardedLruCacheBase<K, V, H>
 where
     K: Hash + Eq + Clone + Send + Sync,

--- a/src/stores/sharded/lru_ttl.rs
+++ b/src/stores/sharded/lru_ttl.rs
@@ -837,6 +837,7 @@ where
 }
 
 #[cfg(feature = "async_core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async_core")))]
 impl<K, V, H> ConcurrentCachedAsync<K, V> for ShardedLruTtlCacheBase<K, V, H>
 where
     K: Hash + Eq + Clone + Send + Sync,

--- a/src/stores/sharded/ttl.rs
+++ b/src/stores/sharded/ttl.rs
@@ -705,6 +705,7 @@ where
 }
 
 #[cfg(feature = "async_core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async_core")))]
 impl<K, V, H> ConcurrentCachedAsync<K, V> for ShardedTtlCacheBase<K, V, H>
 where
     K: Hash + Eq + Send + Sync,

--- a/src/stores/sharded/unbound.rs
+++ b/src/stores/sharded/unbound.rs
@@ -454,6 +454,7 @@ where
 }
 
 #[cfg(feature = "async_core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async_core")))]
 impl<K, V, H> ConcurrentCachedAsync<K, V> for ShardedUnboundCacheBase<K, V, H>
 where
     K: Hash + Eq + Send + Sync,

--- a/src/stores/ttl.rs
+++ b/src/stores/ttl.rs
@@ -753,6 +753,7 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher + Clone> CloneCached<K, V>
 }
 
 #[cfg(feature = "async_core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async_core")))]
 impl<K, V, S> CachedGetOrSetAsync<K, V> for TtlCache<K, V, S>
 where
     K: Hash + Eq + Clone + Send,

--- a/src/stores/ttl_sorted.rs
+++ b/src/stores/ttl_sorted.rs
@@ -1160,6 +1160,7 @@ impl<K: Hash + Eq + Ord + Clone, V: Clone, S: BuildHasher + Clone> CloneCached<K
 }
 
 #[cfg(feature = "async_core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async_core")))]
 impl<K, V, S> CachedGetOrSetAsync<K, V> for TtlSortedCache<K, V, S>
 where
     K: Hash + Eq + Ord + Clone + Send + Sync,

--- a/src/stores/unbound.rs
+++ b/src/stores/unbound.rs
@@ -408,6 +408,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> CachedRead<K, V> for UnboundCache<K, V, S>
 }
 
 #[cfg(feature = "async_core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async_core")))]
 impl<K, V, S> CachedGetOrSetAsync<K, V> for UnboundCache<K, V, S>
 where
     K: Hash + Eq + Clone + Send,

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -64,6 +64,33 @@ fn compile_fail_sharded_constructor() {
     t.compile_fail("tests/ui/sharded_base_custom_hasher_constructor.rs");
 }
 
+// `#[cached]` clones the cached value on every insert and cache hit, so the
+// return type must implement `Clone`. This is a real `E0277` from rustc (like
+// `compile_fail_sharded_constructor` above), not a macro-defined `syn::Error`,
+// so its golden is pinned to the toolchain in `rust-toolchain.toml` the same
+// way. Asserts the diagnostic is spanned at the function's return type rather
+// than at macro-generated internals (the `.clone()`/`.to_owned()` calls deep
+// in the expansion).
+#[test]
+#[cfg(feature = "proc_macro")]
+fn compile_fail_cached_return_type_requires_clone() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/cached_return_type_requires_clone.rs");
+}
+
+// Companion to the above for `with_cached_flag = true`: the cached value type
+// is then the `cached::Return<T>` wrapper, so the return-type `Clone`
+// assertion is spliced with `Return<T>` (not bare `T`) as its argument. This
+// pins that a non-`Clone` inner type still yields a clear `E0277` spanned at
+// the function's return type through the assertion, covering the distinct
+// wrapper-typed value path rather than only the bare-value path above.
+#[test]
+#[cfg(feature = "proc_macro")]
+fn compile_fail_cached_with_cached_flag_return_type_requires_clone() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/cached_with_cached_flag_return_type_requires_clone.rs");
+}
+
 // One negative trybuild case per *semantic* compile error the macros raise
 // (i.e. errors we define for invalid attribute/signature states). Pure
 // syn-parser pass-through messages for malformed user strings (bad `ty` /
@@ -7186,6 +7213,56 @@ mod generic_where_tests {
         assert_eq!(generic_cached_where(7u32), "7");
         assert_eq!(generic_cached_where(7u32), "7");
         assert_eq!(generic_cached_where(8u64), "8");
+    }
+
+    // Regression guard for the return-type `Clone` assertion inside a *generic*
+    // function body. The assertion splices a nested
+    // `fn __cached_assert_return_type_implements_clone<..: Clone>() {}` item plus
+    // a call `::<#value_ty>()` into the generated body; a naive splice that named
+    // an outer generic parameter in the nested item's signature would trip E0401
+    // ("can't use generic parameters from outer item"). Here the enclosing fn is
+    // generic over `T` while the cached value type is the concrete user-defined
+    // `Clone` struct `Wrapped`, so the assertion names `Wrapped` (not `T`) and
+    // must compile. (A bare generic-parameter return such as `-> T` is not
+    // expressible under `#[cached]` at all: the cache lives in a `static`, which
+    // cannot capture an outer generic parameter - so `value_ty` is always a
+    // concrete type in compiling code, and this exercises that reachable shape.)
+    #[derive(Clone, PartialEq, Debug)]
+    struct Wrapped {
+        inner: String,
+    }
+
+    #[cached(key = "String", convert = r#"{ x.to_string() }"#)]
+    fn generic_cached_concrete_clone_value<T>(x: T) -> Wrapped
+    where
+        T: std::string::ToString + Clone,
+    {
+        Wrapped {
+            inner: x.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_generic_cached_concrete_clone_value() {
+        let a = generic_cached_concrete_clone_value(7u32);
+        assert_eq!(
+            a,
+            Wrapped {
+                inner: "7".to_string()
+            }
+        );
+        // second call for the same key hits the cache and returns a clone
+        let b = generic_cached_concrete_clone_value(7u32);
+        assert_eq!(a, b);
+        // a different monomorphization (u64) still shares the same String-keyed
+        // store and computes a distinct value
+        let c = generic_cached_concrete_clone_value(8u64);
+        assert_eq!(
+            c,
+            Wrapped {
+                inner: "8".to_string()
+            }
+        );
     }
 
     // Minimal in-test `ConcurrentCached` store. Exercises the

--- a/tests/ui/cached_return_type_requires_clone.rs
+++ b/tests/ui/cached_return_type_requires_clone.rs
@@ -1,0 +1,17 @@
+use cached::macros::cached;
+
+// `#[cached]` clones the cached value on every cache hit (`.to_owned()`) and
+// on insert (`.clone()` into the store), so the return type must implement
+// `Clone`. Without the dedicated assertion this only fails deep inside
+// macro-generated internals; it should instead produce a clear diagnostic
+// spanned at the function's return type.
+struct NotClone {
+    _value: u32,
+}
+
+#[cached]
+fn not_clone_return() -> NotClone {
+    NotClone { _value: 0 }
+}
+
+fn main() {}

--- a/tests/ui/cached_return_type_requires_clone.stderr
+++ b/tests/ui/cached_return_type_requires_clone.stderr
@@ -1,0 +1,40 @@
+error[E0277]: the trait bound `NotClone: Clone` is not satisfied
+  --> tests/ui/cached_return_type_requires_clone.rs:13:26
+   |
+13 | fn not_clone_return() -> NotClone {
+   |                          ^^^^^^^^ the trait `Clone` is not implemented for `NotClone`
+   |
+note: required by a bound in `__cached_assert_return_type_implements_clone`
+  --> tests/ui/cached_return_type_requires_clone.rs:13:26
+   |
+13 | fn not_clone_return() -> NotClone {
+   |                          ^^^^^^^^ required by this bound in `__cached_assert_return_type_implements_clone`
+help: consider annotating `NotClone` with `#[derive(Clone)]`
+   |
+ 8 + #[derive(Clone)]
+ 9 | struct NotClone {
+   |
+
+error[E0308]: mismatched types
+  --> tests/ui/cached_return_type_requires_clone.rs:12:1
+   |
+12 | #[cached]
+   | ^^^^^^^^^ expected `NotClone`, found `&NotClone`
+13 | fn not_clone_return() -> NotClone {
+   |                          -------- expected `NotClone` because of return type
+   |
+   = note: this error originates in the attribute macro `cached` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0599]: no method named `clone` found for struct `NotClone` in the current scope
+  --> tests/ui/cached_return_type_requires_clone.rs:12:1
+   |
+ 8 | struct NotClone {
+   | --------------- method `clone` not found for this struct
+...
+12 | #[cached]
+   | ^^^^^^^^^ method not found in `NotClone`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `clone`, perhaps you need to implement it:
+           candidate #1: `Clone`
+   = note: this error originates in the attribute macro `cached` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/cached_with_cached_flag_return_type_requires_clone.rs
+++ b/tests/ui/cached_with_cached_flag_return_type_requires_clone.rs
@@ -1,0 +1,19 @@
+use cached::macros::cached;
+
+// Under `with_cached_flag = true` the cached value type is the `Return<T>`
+// wrapper (not the bare `T`): the generated code stores `Return<T>` and
+// `.clone()`s/`.to_owned()`s it, so `Return<T>` - and therefore its inner
+// `T` - must implement `Clone`. `cached::Return<T>` derives `Clone` with a
+// `T: Clone` bound, so a non-`Clone` inner type must still produce a clear
+// diagnostic spanned at the function's return type via the return-type
+// `Clone` assertion, rather than an opaque error inside macro internals.
+struct NotClone {
+    _value: u32,
+}
+
+#[cached(with_cached_flag = true)]
+fn not_clone_flag_return() -> cached::Return<NotClone> {
+    cached::Return::new(NotClone { _value: 0 })
+}
+
+fn main() {}

--- a/tests/ui/cached_with_cached_flag_return_type_requires_clone.stderr
+++ b/tests/ui/cached_with_cached_flag_return_type_requires_clone.stderr
@@ -1,0 +1,53 @@
+error[E0277]: the trait bound `NotClone: Clone` is not satisfied
+  --> tests/ui/cached_with_cached_flag_return_type_requires_clone.rs:15:31
+   |
+15 | fn not_clone_flag_return() -> cached::Return<NotClone> {
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `NotClone`
+   |
+   = note: required for `Return<NotClone>` to implement `Clone`
+note: required by a bound in `__cached_assert_return_type_implements_clone`
+  --> tests/ui/cached_with_cached_flag_return_type_requires_clone.rs:15:31
+   |
+15 | fn not_clone_flag_return() -> cached::Return<NotClone> {
+   |                               ^^^^^^ required by this bound in `__cached_assert_return_type_implements_clone`
+help: consider annotating `NotClone` with `#[derive(Clone)]`
+   |
+10 + #[derive(Clone)]
+11 | struct NotClone {
+   |
+
+error[E0308]: mismatched types
+  --> tests/ui/cached_with_cached_flag_return_type_requires_clone.rs:14:1
+   |
+14 | #[cached(with_cached_flag = true)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Return<NotClone>`, found `&Return<NotClone>`
+15 | fn not_clone_flag_return() -> cached::Return<NotClone> {
+   |                               ------------------------ expected `Return<NotClone>` because of return type
+   |
+   = note: expected struct `Return<NotClone>`
+           found reference `&Return<NotClone>`
+   = note: this error originates in the attribute macro `cached` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0599]: the method `clone` exists for struct `Return<NotClone>`, but its trait bounds were not satisfied
+  --> tests/ui/cached_with_cached_flag_return_type_requires_clone.rs:14:1
+   |
+10 | struct NotClone {
+   | --------------- doesn't satisfy `NotClone: Clone`
+...
+14 | #[cached(with_cached_flag = true)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method cannot be called on `Return<NotClone>` due to unsatisfied trait bounds
+   |
+  ::: cached_proc_macro_types/src/lib.rs
+   |
+   | pub struct Return<T> {
+   | -------------------- doesn't satisfy `Return<NotClone>: Clone`
+   |
+   = note: the following trait bounds were not satisfied:
+           `NotClone: Clone`
+           which is required by `Return<NotClone>: Clone`
+   = note: this error originates in the attribute macro `cached` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `NotClone` with `#[derive(Clone)]`
+   |
+10 + #[derive(Clone)]
+11 | struct NotClone {
+   |


### PR DESCRIPTION
- Emit a `Clone`-bound compile error spanned at the return type when a `#[cached]` function's return type is not `Clone`, ahead of the opaque errors from the generated internals. The assertion targets the cached value type (inner `T` of `Result`/`Option`, `Return<T>` under `with_cached_flag`). Trybuild tests cover the plain and `with_cached_flag` negative cases plus a generic-function positive case.
- Add the missing `doc(cfg(feature = "async_core"))` badges on the `CachedGetOrSetAsync` / `ConcurrentCachedAsync` impls for the in-memory and sharded stores and `HashMap`.
- Correct the changelog and `specs/store-lru.md` claim that `UnboundCache` has no `retain` (it shipped in #294); document its semantics (predicate filter, fires `on_evict`, no eviction counter).
- Migration guides: fix the `cache_peek_with_expiry_status` sibling name, reword the rc-era no-arg builder note, add human-guide sections for `CacheTtl`/`CacheEvict` removal from concurrent stores and the redis empty-prefix `InvalidValue` rejection.
- Specs: add LRU-5/TTL-5/EXPIRE-6 covering `iter_order`/`value_order`/`CacheValue`; mark design 0020 Declined in the index.
- Document the lookup-key difference between the trait families (`&Q where K: Borrow<Q>` on `Cached` vs `&K` on `ConcurrentCached`); README regenerated.