### PR TITLE
feat: `TtlSortedCache::set_with` builder, `ConcurrentCachePeek`, `ConcurrentCachedExt::try_get_or_set_with`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@
   `TtlSortedCache` set `Cached::Error = std::convert::Infallible`, so every built-in in-memory
   store is now infallible. Call sites binding `CacheSetError` or matching `TimeBounds` must
   drop the error handling.
-- `TtlSortedCache` `insert` / `insert_ttl` / `insert_evict` / `insert_ttl_evict` are renamed to
-  `set` / `set_with_ttl` / `set_evict` / `set_with_ttl_evict` and return `Option<V>` (the
-  displaced unexpired value) instead of `Result<Option<V>, CacheSetError>`.
+- `TtlSortedCache` `insert` / `insert_ttl` / `insert_evict` / `insert_ttl_evict` are replaced by
+  `set(k, v)` plus the `set_with(k, v)` entry-setter builder: chain `.ttl(Duration)` for a
+  per-entry TTL override and `.evict()` to opt into the post-insertion eviction sweep, then call
+  the terminal `.set() -> Option<V>` to insert and get back the displaced unexpired value.
+  `TtlSortedSetBuilder` is re-exported from the crate root. `Option<V>` replaces
+  `Result<Option<V>, CacheSetError>` on every one of these paths.
 - `iter_order` / `value_order` on `LruCache`, `LruTtlCache`, and `ExpiringLruCache` return
   `CacheValue`-wrapped values: `iter_order() -> Vec<(K, CacheValue<V, M>)>` and
   `value_order() -> Vec<CacheValue<V, M>>`, one shape across the LRU family. `M` is per-entry
@@ -27,7 +30,8 @@
   values, `value()` / `into_value()`, and `expires_at()` when `M = Option<Instant>`.
 - Inherent `peek(&self, &K) -> Option<V>` on all six sharded stores: returns a clone of the
   live value with no recency update, no TTL refresh, no hit/miss metrics, and no lazy removal
-  of expired entries. Takes call-site priority like the other inherent shims.
+  of expired entries. Takes call-site priority like the other inherent shims; the same contract
+  is also reachable generically through the new `ConcurrentCachePeek` trait below.
 - `Builder::new()` on the in-memory and sharded builders (all 13), equivalent to the store's
   `::builder()`, matching the IO builders' public constructors.
 - `CachedExt::capacity` / `CachedExt::evictions`: ergonomic aliases for `cache_capacity` /
@@ -38,7 +42,14 @@
 - `ConcurrentCached::cache_try_get_or_set_with` and
   `ConcurrentCachedAsync::async_cache_try_get_or_set_with` (both provided): fallible-init
   get-or-set returning `Result<Result<V, E>, Self::Error>`, store error outer, closure error
-  inner. On a closure `Err` nothing is stored.
+  inner. On a closure `Err` nothing is stored. `ConcurrentCachedExt::try_get_or_set_with` is the
+  short-alias form, delegating to `ConcurrentCached::cache_try_get_or_set_with`.
+- `ConcurrentCachePeek`: a side-effect-free `cache_peek(&self, &K) -> Result<Option<V>,
+  Self::Error>` (plus a defaulted `peek` alias) for concurrent stores. No recency/LRU promotion,
+  no TTL refresh, no hit/miss metrics, and no lazy removal of expired entries; an expired entry
+  reads as `None`. Implemented by the six sharded stores (`Self::Error = Infallible`);
+  `RedisCache`, `RedbCache`, and `AsyncRedisCache` deliberately do not implement it. In
+  `cached::prelude`.
 - `retain(keep)` on `UnboundCache`, `TtlCache`, and `ExpiringCache`, completing `retain`
   across the map stores. Each removed entry fires `on_evict`. On the expiry-aware stores
   expired entries are removed regardless of the predicate and every removal counts an

--- a/README.md
+++ b/README.md
@@ -283,8 +283,11 @@ Because LRU caches require updating access recency, `ShardedLruCache`, `ShardedL
 - Sharded stores implement `ConcurrentCached`/`ConcurrentCachedAsync` instead of
   `Cached`/`CachedGetOrSetAsync`. Generic code parameterized over `Cached<K, V>` cannot accept sharded
   stores; use a `ConcurrentCached<K, V>` bound or a concrete type instead.
-  Sharded stores also do not implement `CachedIter` or `CachedPeek`. Code that is generic over
-  `CachedIter<K, V>` or uses `.iter()` / `cache_peek` must use non-sharded stores instead.
+  Sharded stores do not implement the single-owner `CachedIter` or `CachedPeek` traits; code that
+  is generic over `CachedIter<K, V>` or uses `.iter()` must use a non-sharded store. They do,
+  however, provide a side-effect-free read via the [`ConcurrentCachePeek`] trait (`cache_peek`,
+  returning an owned `Option<V>`), with the inherent `peek` shim taking call-site priority on the
+  concrete sharded types.
   The four expiry-capable sharded stores ([`ShardedTtlCache`], [`ShardedLruTtlCache`],
   [`ShardedExpiringCache`], [`ShardedExpiringLruCache`]) implement [`ConcurrentCloneCached`],
   which provides `cache_get_with_expiry_status` for reading stale entries without evicting them, and

--- a/cached_proc_macro/src/helpers.rs
+++ b/cached_proc_macro/src/helpers.rs
@@ -405,7 +405,6 @@ pub(super) fn find_value_type(
 /// return type rather than macro-internal call-site code.
 pub(super) fn clone_return_assertion(value_ty: &TokenStream2, span: Span) -> TokenStream2 {
     quote_spanned! {span=>
-        #[allow(non_snake_case)]
         fn __cached_assert_return_type_implements_clone<__CachedAssertClone: ::std::clone::Clone>() {}
         __cached_assert_return_type_implements_clone::<#value_ty>();
     }

--- a/docs/migrations/2.0-to-3.0-human.md
+++ b/docs/migrations/2.0-to-3.0-human.md
@@ -401,16 +401,17 @@ impl Cached<K, V> for MyStore {
 Generic code that supports fallible custom stores should call `cache_try_set` and propagate
 `Self::Error`; `cache_set` is infallible.
 
-### `TtlSortedCache` `insert*` renamed to `set*` and made infallible
+### `TtlSortedCache` `insert*` replaced by `set` / `set_with` and made infallible
 
-`insert` / `insert_ttl` / `insert_evict` / `insert_ttl_evict` are now `set` / `set_with_ttl` /
-`set_evict` / `set_with_ttl_evict`, returning `Option<V>` (the displaced unexpired value)
-instead of `Result`:
+`insert` / `insert_ttl` / `insert_evict` / `insert_ttl_evict` are replaced by plain `set(k, v)`
+and the `set_with(k, v)` entry-setter builder, which covers the ttl/evict combinations via
+`.ttl(Duration)` and `.evict()`. Every path now returns `Option<V>` (the displaced unexpired
+value) instead of `Result`:
 ```rust
 // Before
 cache.insert_ttl(k, v, Duration::from_secs(5))?;
 // After
-cache.set_with_ttl(k, v, Duration::from_secs(5));
+cache.set_with(k, v).ttl(Duration::from_secs(5)).set();
 ```
 
 ### `iter_order` / `value_order` return `CacheValue`-wrapped values

--- a/docs/migrations/2.0-to-3.0.md
+++ b/docs/migrations/2.0-to-3.0.md
@@ -447,7 +447,7 @@ let _: Result<Option<V>, TtlSortedCacheError> = cache.try_set(k, v);
 // After
 let _: Result<Option<V>, std::convert::Infallible> = cache.try_set(k, v);
 ```
-The `insert*` methods are also renamed; see #75.
+The `insert*` methods are also replaced by `set` / `set_with`; see #75.
 
 ### 19. `unbound` macro attribute removed
 
@@ -1039,10 +1039,10 @@ in a hot path), recreate the cache with the same builder settings instead of cal
 - `RedisCache` / `AsyncRedisCache` now implement `cache_clear` / `async_cache_clear` (namespace-scoped `SCAN` + `DEL`); `cache_reset` / `async_cache_reset` delegate to them (redis tracks no in-memory metrics).
 - Reference arguments (`&T`, `Option<&T>`) now form the default macro key without a `convert`.
 - `Expires::expires_at(&self) -> Option<cached::time::Instant>` -- default trait method returning the value's expiry instant when tracked (`None` by default / when unknown). Advisory/observability only; `is_expired()` remains the authoritative liveness check. Existing `impl Expires` blocks (which provide only `is_expired`) get the default for free. The instant type is the crate's `time::Instant` (`web_time` on wasm, `std` elsewhere), not `std::time::Instant`; a custom override must use that type.
-- Inherent `peek(&self, &K) -> Option<V>` on the six sharded stores -- a clone of the live value with no recency update, no TTL refresh, no hit/miss metrics, and no lazy removal of expired entries.
+- Inherent `peek(&self, &K) -> Option<V>` on the six sharded stores -- a clone of the live value with no recency update, no TTL refresh, no hit/miss metrics, and no lazy removal of expired entries. The same contract is also reachable generically through the new `ConcurrentCachePeek` trait (`cache_peek` plus a defaulted `peek` alias, `Result<Option<V>, Self::Error>`, `Self::Error = Infallible` on the sharded stores); the inherent shim keeps call-site priority on the concrete types. `RedisCache` / `RedbCache` / `AsyncRedisCache` deliberately do not implement it. In `cached::prelude`.
 - `Builder::new()` on the in-memory and sharded builders -- equivalent to the store's `::builder()`.
 - `CachedExt::capacity` / `evictions` and `ConcurrentCachedExt::len` / `is_empty` / `hits` / `misses` / `capacity` / `evictions` -- ergonomic aliases for the corresponding `cache_*` accessors.
-- `ConcurrentCached::cache_try_get_or_set_with` / `ConcurrentCachedAsync::async_cache_try_get_or_set_with` -- fallible-init get-or-set returning `Result<Result<V, E>, Self::Error>` (store error outer, closure error inner; nothing stored on a closure `Err`). Provided defaults.
+- `ConcurrentCached::cache_try_get_or_set_with` / `ConcurrentCachedAsync::async_cache_try_get_or_set_with` -- fallible-init get-or-set returning `Result<Result<V, E>, Self::Error>` (store error outer, closure error inner; nothing stored on a closure `Err`). Provided defaults. `ConcurrentCachedExt::try_get_or_set_with` is the short-alias form, delegating to `ConcurrentCached::cache_try_get_or_set_with`.
 - `retain(keep)` on `UnboundCache`, `TtlCache`, and `ExpiringCache` -- completes retain across the map-backed single-owner stores. On the expiry-aware stores, expired entries are removed regardless of the predicate; on `UnboundCache` (no expiry dimension) an entry survives exactly when `keep` returns `true`. Every removed entry fires `on_evict`.
 - `TtlSortedCache::capacity() -> Option<usize>` -- the configured size bound, `None` when unbounded.
 
@@ -1618,23 +1618,32 @@ let vals: Vec<V> = cache.value_order().into_iter().map(|v| v.into_value()).colle
 let exp = cache.iter_order()[0].1.expires_at();
 ```
 
-### 75. `TtlSortedCache` `insert*` renamed to `set*` and made infallible
+### 75. `TtlSortedCache` `insert*` replaced by `set` / `set_with` and made infallible
 
-`insert` / `insert_ttl` / `insert_evict` / `insert_ttl_evict` are renamed to `set` /
-`set_with_ttl` / `set_evict` / `set_with_ttl_evict` and return `Option<V>` (the displaced
-unexpired value) instead of `Result<Option<V>, _>`; see #18 for the error removal.
+`insert` / `insert_ttl` / `insert_evict` / `insert_ttl_evict` are replaced by plain `set(k, v)`
+and the `set_with(k, v)` entry-setter builder (`.ttl(Duration)` for a per-entry TTL override,
+`.evict()` to opt into the post-insertion eviction sweep, terminal `.set() -> Option<V>`). Every
+path now returns `Option<V>` (the displaced unexpired value) instead of `Result<Option<V>, _>`;
+see #18 for the error removal.
 
-Detection: `no method named insert found for struct TtlSortedCache` (the compiler suggests
-`set`), or `.unwrap()` / `?` on the old `Result` return.
+Detection: grep for `insert_ttl_evict|insert_evict|insert_ttl|\.insert\(` on `TtlSortedCache`
+call sites, or `no method named insert found for struct TtlSortedCache` (the compiler suggests
+`set`).
 
 Action: rename the call and drop the error handling.
 ```rust
 // Before
 cache.insert(k, v).unwrap();
 cache.insert_ttl(k, v, Duration::from_secs(5)).unwrap();
+cache.insert_evict(k, v, true).unwrap();
+cache.insert_ttl_evict(k, v, Some(Duration::from_secs(5)), true).unwrap();
+cache.insert_ttl_evict(k, v, None, true).unwrap();
 // After
 cache.set(k, v);
-cache.set_with_ttl(k, v, Duration::from_secs(5));
+cache.set_with(k, v).ttl(Duration::from_secs(5)).set();
+cache.set_with(k, v).evict().set();
+cache.set_with(k, v).ttl(Duration::from_secs(5)).evict().set();
+cache.set_with(k, v).evict().set();
 ```
 
 ### Single-owner `contains` semantic change (rc surface only; no code change required)
@@ -1690,7 +1699,7 @@ has a breaking change this major, see #51).
   - `unused ... that must be used` on a `cache_size`/`cache_remove`/`metrics`/... call under `-D warnings` → bind with `let _ = ...` or use the value (see New APIs: `#[must_use]`).
   - `E0046` "not all trait items implemented, missing: Error" on a custom `Cached` impl → add `type Error = std::convert::Infallible;` (or your error type) to the impl (#33).
   - `TtlSortedCache`'s `cache_try_set`/`try_set` error type is `Infallible`, unified with `TtlCache`/`LruTtlCache`; a previous binding to `TtlSortedCacheError` or `ttl_sorted::Error` should be dropped (#18 / #43).
-  - `no method named insert`/`insert_ttl`/`insert_evict`/`insert_ttl_evict` on a `TtlSortedCache` → renamed to `set`/`set_with_ttl`/`set_evict`/`set_with_ttl_evict`, returning `Option<V>` (#75).
+  - `no method named insert`/`insert_ttl`/`insert_evict`/`insert_ttl_evict` on a `TtlSortedCache` → replaced by `set` and the `set_with(k, v).ttl(..).evict().set()` builder, returning `Option<V>` (#75).
   - a type mismatch `expected Vec<(K, V)>, found Vec<(K, CacheValue<V>)>` at an `iter_order`/`value_order` call site → the order methods return `CacheValue`-wrapped values; deref or `into_value()` (#74).
   - type mismatch `Result<Option<V>, Infallible>` where `Option<V>` is now expected from a sharded store's `get`/`set`/`remove`/`delete`/`reset` → remove the `Result` wrapper; call through the trait or use `cache_` prefix if `Result` is needed (#34).
   - `use of undeclared type TimedEntry` or `cannot find type TimedEntry in module cached` → remove the import; `TimedEntry` is no longer public (#35).

--- a/specs/store-sharded.md
+++ b/specs/store-sharded.md
@@ -30,7 +30,9 @@ methods. Each of the six concrete sharded types also exposes inherent shims that
 values and take call-site priority over the `ConcurrentCachedExt` aliases: `get`, `set`, `remove`,
 `remove_entry`, `delete`, `reset`, `contains`, and `peek` (`contains` and `peek` are peek-based,
 infallible, `&self`; `peek` returns a clone of the live value with no recency/TTL/metrics
-effects).
+effects). The same `peek` contract is also reachable generically through the `ConcurrentCachePeek`
+trait (`cache_peek` plus a defaulted `peek` alias, `Result<Option<V>, Infallible>` on these six
+stores); the inherent shim keeps call-site priority on the concrete types.
 Metrics are exposed through the trait per
 [design/0012-concurrent-metrics-trait.md](design/0012-concurrent-metrics-trait.md).
 See [traits-concurrent.md](traits-concurrent.md).

--- a/specs/store-ttl.md
+++ b/specs/store-ttl.md
@@ -29,7 +29,10 @@ These stores implement `CacheTtl` (`ttl()` / `set_ttl()` / `unset_ttl()` / `try_
 `TtlSortedCache` implements `CachedRead` (shared-ref reads / `unsync_reads`), `CacheTtl`,
 `CachedIter`, `CachedPeek`, and `CloneCached`; `TimedEntry<V>` is `pub(crate)` and not part of
 the public surface. Size/iter/evict semantics follow
-[design/0002-size-iter-evict-semantics.md](design/0002-size-iter-evict-semantics.md).
+[design/0002-size-iter-evict-semantics.md](design/0002-size-iter-evict-semantics.md). Insertion
+is `set(k, v)` for the plain path, or the `set_with(k, v) -> TtlSortedSetBuilder` entry-setter
+for a per-entry TTL override (`.ttl(Duration)`) and/or opt-in post-insertion eviction
+(`.evict()`); the terminal `.set() -> Option<V>` returns the displaced unexpired value.
 
 ## TTL-5
 

--- a/specs/traits-concurrent.md
+++ b/specs/traits-concurrent.md
@@ -28,18 +28,24 @@ required with no `V: Clone + Send` bound (its get-based implementors are `AsyncR
 `RedbCache`), and `async_cache_try_get_or_set_with` mirrors the sync default.
 `ConcurrentCachedExt` provides deduplicated short-name methods (`get`, `set`, `remove`,
 `remove_entry`, `delete`, `contains` (no `V: Clone` bound), `clear`, `reset`, `get_or_set_with`,
-`len`, `is_empty`, `hits`, `misses`, `capacity`, `evictions`); it does not forward
-`cache_reset_metrics` directly. The six sharded concrete types also expose inherent
-`contains(&self, &K) -> bool` and `peek(&self, &K) -> Option<V>` (both peek-based: no recency,
-TTL, or metrics effects; `peek` clones the live value) that take call-site priority over the
-ext-trait aliases, consistent with the other inherent shims (`get`, `set`, `reset`).
+`try_get_or_set_with`, `len`, `is_empty`, `hits`, `misses`, `capacity`, `evictions`); it does not
+forward `cache_reset_metrics` directly. `try_get_or_set_with` delegates to
+`ConcurrentCached::cache_try_get_or_set_with`. The six sharded concrete types also expose
+inherent `contains(&self, &K) -> bool` and `peek(&self, &K) -> Option<V>` (both peek-based: no
+recency, TTL, or metrics effects; `peek` clones the live value) that take call-site priority over
+the ext-trait aliases, consistent with the other inherent shims (`get`, `set`, `reset`).
 
 ## CTRAIT-3
 
 `ConcurrentCacheTtl` provides `&self` TTL control (`ttl()` / `set_ttl()` / `unset_ttl()` /
 `try_set_ttl()` / `refresh_on_hit()` / `set_refresh_on_hit()`) on concurrent TTL stores; the
 implementing stores expose these only through the trait, with no inherent duplicates.
-`ConcurrentCacheEvict` provides the concurrent `evict()`.
+`ConcurrentCacheEvict` provides the concurrent `evict()`. `ConcurrentCachePeek` provides
+`cache_peek(&self, &K) -> Result<Option<V>, Self::Error>` (plus a defaulted `peek` alias): a
+genuinely side-effect-free read (no recency, TTL refresh, hit/miss metrics, or lazy expiry
+removal). It is implemented only by the six sharded stores (`Self::Error = Infallible`);
+`RedisCache`, `RedbCache`, and `AsyncRedisCache` deliberately do not implement it. It is in
+`cached::prelude`.
 
 ## CTRAIT-4
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,8 +282,11 @@ Because LRU caches require updating access recency, `ShardedLruCache`, `ShardedL
 - Sharded stores implement `ConcurrentCached`/`ConcurrentCachedAsync` instead of
   `Cached`/`CachedGetOrSetAsync`. Generic code parameterized over `Cached<K, V>` cannot accept sharded
   stores; use a `ConcurrentCached<K, V>` bound or a concrete type instead.
-  Sharded stores also do not implement `CachedIter` or `CachedPeek`. Code that is generic over
-  `CachedIter<K, V>` or uses `.iter()` / `cache_peek` must use non-sharded stores instead.
+  Sharded stores do not implement the single-owner `CachedIter` or `CachedPeek` traits; code that
+  is generic over `CachedIter<K, V>` or uses `.iter()` must use a non-sharded store. They do,
+  however, provide a side-effect-free read via the [`ConcurrentCachePeek`] trait (`cache_peek`,
+  returning an owned `Option<V>`), with the inherent `peek` shim taking call-site priority on the
+  concrete sharded types.
   The four expiry-capable sharded stores ([`ShardedTtlCache`], [`ShardedLruTtlCache`],
   [`ShardedExpiringCache`], [`ShardedExpiringLruCache`]) implement [`ConcurrentCloneCached`],
   which provides `cache_get_with_expiry_status` for reading stale entries without evicting them, and
@@ -699,7 +702,7 @@ pub use stores::{HasEvict, NoEvict};
 pub use stores::{
     LruTtlCache, LruTtlCacheBuilder, ShardedLruTtlCache, ShardedLruTtlCacheBase,
     ShardedLruTtlCacheBuilder, ShardedTtlCache, ShardedTtlCacheBase, ShardedTtlCacheBuilder,
-    TtlCache, TtlCacheBuilder, TtlSortedCache, TtlSortedCacheBuilder,
+    TtlCache, TtlCacheBuilder, TtlSortedCache, TtlSortedCacheBuilder, TtlSortedSetBuilder,
 };
 #[cfg(feature = "redb_store")]
 #[cfg_attr(docsrs, doc(cfg(feature = "redb_store")))]
@@ -838,8 +841,9 @@ impl<C, B> std::ops::Deref for KeyedCache<C, B> {
 pub mod prelude {
     pub use crate::{
         CacheEvict, CacheMetrics, Cached, CachedExt, CachedIter, CachedPeek, CachedRead,
-        CloneCached, ConcurrentCacheBase, ConcurrentCacheEvict, ConcurrentCacheTtl,
-        ConcurrentCached, ConcurrentCachedExt, ConcurrentCloneCached, Expires, SerializeCached,
+        CloneCached, ConcurrentCacheBase, ConcurrentCacheEvict, ConcurrentCachePeek,
+        ConcurrentCacheTtl, ConcurrentCached, ConcurrentCachedExt, ConcurrentCloneCached, Expires,
+        SerializeCached,
     };
 
     // Unconditional, like `ConcurrentCacheTtl` above: the trait itself is not
@@ -2067,6 +2071,58 @@ pub trait ConcurrentCacheTtl {
     fn set_refresh_on_hit(&self, refresh: bool) -> bool;
 }
 
+/// Side-effect-free cache lookup for concurrent stores that can expose a value cheaply.
+///
+/// This is the concurrent analogue of the single-owner [`CachedPeek`] trait: a genuinely
+/// side-effect-free read through a shared (`&self`) reference. A peek does **not** update
+/// recency / LRU promotion, does **not** refresh any TTL, does **not** increment hit/miss
+/// metrics, and does **not** lazily remove expired entries. An entry whose TTL or per-value
+/// expiry has elapsed reads as `None` (it is left in place for a later `cache_get`, an
+/// explicit removal, or an `evict()` to reap).
+///
+/// Unlike [`CachedPeek`], which returns a borrowed `&V`, this trait returns an owned
+/// `Option<V>`: on the sharded stores the value lives behind a per-shard lock, so a peek
+/// clones it out rather than lending a reference across the lock boundary.
+///
+/// Only stores that can satisfy these guarantees cheaply implement it: the six in-memory
+/// sharded stores (`ShardedUnboundCache`, `ShardedLruCache`, `ShardedTtlCache`,
+/// `ShardedLruTtlCache`, `ShardedExpiringCache`, `ShardedExpiringLruCache`). The IO stores
+/// (`RedisCache` / `RedbCache` / `AsyncRedisCache`) deliberately do **not** implement it — a
+/// server-side or on-disk read cannot promise the no-metrics / no-expiry-sweep semantics
+/// without an extra round trip, so peeking is not offered for them.
+///
+/// This trait is **not** feature-gated (like [`ConcurrentCacheEvict`] and
+/// [`ConcurrentCacheTtl`]); only the built-in stores implementing it for expiry-capable
+/// variants require `time_stores`.
+pub trait ConcurrentCachePeek<K, V>: ConcurrentCacheBase {
+    /// Retrieve a clone of the cached value for `k` without any observable side effect.
+    ///
+    /// No recency/LRU promotion, no TTL refresh, no hit/miss metrics, and no lazy removal of
+    /// expired entries; an expired entry reads as `None`.
+    ///
+    /// # Errors
+    ///
+    /// Should return `Self::Error` if the operation fails. The sharded implementors are
+    /// infallible (`Self::Error = Infallible`), so the outer `Result` is always `Ok`.
+    fn cache_peek(&self, k: &K) -> Result<Option<V>, Self::Error>;
+
+    /// Ergonomic alias for [`cache_peek`](Self::cache_peek), mirroring
+    /// [`CachedPeek::peek`].
+    ///
+    /// On the concrete sharded types the inherent `peek(&self, &K) -> Option<V>` takes
+    /// call-site priority (like the other inherent shims such as `get`/`set`), so this trait
+    /// spelling is intended for generic code over a `ConcurrentCachePeek` bound; use
+    /// fully-qualified syntax (`ConcurrentCachePeek::peek(&store, &k)`) to reach it on a
+    /// concrete store.
+    ///
+    /// # Errors
+    ///
+    /// Should return `Self::Error` if the operation fails.
+    fn peek(&self, k: &K) -> Result<Option<V>, Self::Error> {
+        self.cache_peek(k)
+    }
+}
+
 /// Cache operations on a store that manages its own synchronization (a shared,
 /// `&self` API with owned return values and a fallible `Error`). Implemented by the
 /// six in-memory sharded stores (`ShardedUnboundCache`, `ShardedLruCache`,
@@ -2433,6 +2489,19 @@ pub trait ConcurrentCachedExt<K, V>: ConcurrentCached<K, V> {
     where
         V: Clone;
 
+    /// Return the cached value for `k`, or compute and store `f()`, propagating a closure
+    /// failure. Delegates to
+    /// [`cache_try_get_or_set_with`](ConcurrentCached::cache_try_get_or_set_with). The outer
+    /// `Result` carries the store's `Self::Error`; the inner `Result` carries the closure's
+    /// `E` (on `Err` nothing is stored).
+    fn try_get_or_set_with<F: FnOnce() -> Result<V, E>, E>(
+        &self,
+        k: K,
+        f: F,
+    ) -> Result<Result<V, E>, Self::Error>
+    where
+        V: Clone;
+
     /// Return the number of entries currently in the cache, if cheaply available.
     /// Delegates to [`cache_size`](ConcurrentCacheBase::cache_size).
     ///
@@ -2503,6 +2572,17 @@ impl<K, V, T: ConcurrentCached<K, V>> ConcurrentCachedExt<K, V> for T {
         V: Clone,
     {
         self.cache_get_or_set_with(k, f)
+    }
+
+    fn try_get_or_set_with<F: FnOnce() -> Result<V, E>, E>(
+        &self,
+        k: K,
+        f: F,
+    ) -> Result<Result<V, E>, Self::Error>
+    where
+        V: Clone,
+    {
+        self.cache_try_get_or_set_with(k, f)
     }
 
     fn len(&self) -> Result<Option<usize>, Self::Error> {

--- a/src/stores/mod.rs
+++ b/src/stores/mod.rs
@@ -349,7 +349,7 @@ pub use lru_ttl::{HasEvict, LruTtlCache, LruTtlCacheBuilder, NoEvict};
 pub use ttl::{TtlCache, TtlCacheBuilder};
 #[cfg(feature = "time_stores")]
 #[cfg_attr(docsrs, doc(cfg(feature = "time_stores")))]
-pub use ttl_sorted::{TtlSortedCache, TtlSortedCacheBuilder};
+pub use ttl_sorted::{TtlSortedCache, TtlSortedCacheBuilder, TtlSortedSetBuilder};
 pub use unbound::{UnboundCache, UnboundCacheBuilder};
 
 pub use sharded::{

--- a/src/stores/sharded/expiring.rs
+++ b/src/stores/sharded/expiring.rs
@@ -11,7 +11,10 @@ use std::collections::HashMap;
 
 #[cfg(feature = "async_core")]
 use crate::ConcurrentCachedAsync;
-use crate::{CacheMetrics, ConcurrentCacheBase, ConcurrentCached, ConcurrentCloneCached, Expires};
+use crate::{
+    CacheMetrics, ConcurrentCacheBase, ConcurrentCachePeek, ConcurrentCached,
+    ConcurrentCloneCached, Expires,
+};
 #[cfg(feature = "async_core")]
 use core::future::Future;
 
@@ -579,6 +582,17 @@ where
     {
         let shard = self.shard_of(k);
         Ok(shard.lock.read().get(k).is_some_and(|v| !v.is_expired()))
+    }
+}
+
+impl<K, V, H> ConcurrentCachePeek<K, V> for ShardedExpiringCacheBase<K, V, H>
+where
+    K: Hash + Eq,
+    V: Clone + Expires,
+    H: ShardHasher<K>,
+{
+    fn cache_peek(&self, k: &K) -> Result<Option<V>, Self::Error> {
+        Ok(self.peek(k))
     }
 }
 

--- a/src/stores/sharded/expiring_lru.rs
+++ b/src/stores/sharded/expiring_lru.rs
@@ -5,8 +5,8 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 #[cfg(feature = "async_core")]
 use crate::ConcurrentCachedAsync;
 use crate::{
-    CacheMetrics, CachedIter, CachedPeek, ConcurrentCacheBase, ConcurrentCached,
-    ConcurrentCloneCached, Expires,
+    CacheMetrics, CachedIter, CachedPeek, ConcurrentCacheBase, ConcurrentCachePeek,
+    ConcurrentCached, ConcurrentCloneCached, Expires,
 };
 #[cfg(feature = "async_core")]
 use core::future::Future;
@@ -699,6 +699,17 @@ where
             .read()
             .cache_peek(k)
             .is_some_and(|v| !v.is_expired()))
+    }
+}
+
+impl<K, V, H> ConcurrentCachePeek<K, V> for ShardedExpiringLruCacheBase<K, V, H>
+where
+    K: Hash + Eq + Clone,
+    V: Clone + Expires,
+    H: ShardHasher<K>,
+{
+    fn cache_peek(&self, k: &K) -> Result<Option<V>, Self::Error> {
+        Ok(self.peek(k))
     }
 }
 

--- a/src/stores/sharded/lru.rs
+++ b/src/stores/sharded/lru.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
 #[cfg(feature = "async_core")]
 use crate::ConcurrentCachedAsync;
-use crate::{CacheMetrics, CachedIter, ConcurrentCacheBase, ConcurrentCached};
+use crate::{CacheMetrics, CachedIter, ConcurrentCacheBase, ConcurrentCachePeek, ConcurrentCached};
 #[cfg(feature = "async_core")]
 use core::future::Future;
 
@@ -587,6 +587,17 @@ where
         use crate::CachedPeek;
         let shard = self.shard_of(k);
         Ok(shard.lock.read().cache_peek(k).is_some())
+    }
+}
+
+impl<K, V, H> ConcurrentCachePeek<K, V> for ShardedLruCacheBase<K, V, H>
+where
+    K: Hash + Eq + Clone,
+    V: Clone,
+    H: ShardHasher<K>,
+{
+    fn cache_peek(&self, k: &K) -> Result<Option<V>, Self::Error> {
+        Ok(self.peek(k))
     }
 }
 

--- a/src/stores/sharded/lru_ttl.rs
+++ b/src/stores/sharded/lru_ttl.rs
@@ -7,8 +7,8 @@ use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use crate::ConcurrentCachedAsync;
 use crate::time::{Duration, Instant};
 use crate::{
-    CacheMetrics, ConcurrentCacheBase, ConcurrentCacheEvict, ConcurrentCacheTtl, ConcurrentCached,
-    ConcurrentCloneCached,
+    CacheMetrics, ConcurrentCacheBase, ConcurrentCacheEvict, ConcurrentCachePeek,
+    ConcurrentCacheTtl, ConcurrentCached, ConcurrentCloneCached,
 };
 #[cfg(feature = "async_core")]
 use core::future::Future;
@@ -833,6 +833,17 @@ where
         Ok(guard
             .cache_peek(k)
             .is_some_and(|entry| entry.expires_at.is_none_or(|t| Instant::now() < t)))
+    }
+}
+
+impl<K, V, H> ConcurrentCachePeek<K, V> for ShardedLruTtlCacheBase<K, V, H>
+where
+    K: Hash + Eq + Clone,
+    V: Clone,
+    H: ShardHasher<K>,
+{
+    fn cache_peek(&self, k: &K) -> Result<Option<V>, Self::Error> {
+        Ok(self.peek(k))
     }
 }
 

--- a/src/stores/sharded/ttl.rs
+++ b/src/stores/sharded/ttl.rs
@@ -13,8 +13,8 @@ use std::collections::HashMap;
 use crate::ConcurrentCachedAsync;
 use crate::time::{Duration, Instant};
 use crate::{
-    CacheMetrics, ConcurrentCacheBase, ConcurrentCacheEvict, ConcurrentCacheTtl, ConcurrentCached,
-    ConcurrentCloneCached,
+    CacheMetrics, ConcurrentCacheBase, ConcurrentCacheEvict, ConcurrentCachePeek,
+    ConcurrentCacheTtl, ConcurrentCached, ConcurrentCloneCached,
 };
 #[cfg(feature = "async_core")]
 use core::future::Future;
@@ -701,6 +701,17 @@ where
         let shard = self.shard_of(k);
         let guard = shard.lock.read();
         Ok(guard.get(k).is_some_and(|entry| !self.is_expired(entry)))
+    }
+}
+
+impl<K, V, H> ConcurrentCachePeek<K, V> for ShardedTtlCacheBase<K, V, H>
+where
+    K: Hash + Eq,
+    V: Clone,
+    H: ShardHasher<K>,
+{
+    fn cache_peek(&self, k: &K) -> Result<Option<V>, Self::Error> {
+        Ok(self.peek(k))
     }
 }
 

--- a/src/stores/sharded/unbound.rs
+++ b/src/stores/sharded/unbound.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 
 #[cfg(feature = "async_core")]
 use crate::ConcurrentCachedAsync;
-use crate::{CacheMetrics, ConcurrentCacheBase, ConcurrentCached};
+use crate::{CacheMetrics, ConcurrentCacheBase, ConcurrentCachePeek, ConcurrentCached};
 #[cfg(feature = "async_core")]
 use core::future::Future;
 
@@ -450,6 +450,17 @@ where
     {
         let shard = self.shard_of(k);
         Ok(shard.lock.read().contains_key(k))
+    }
+}
+
+impl<K, V, H> ConcurrentCachePeek<K, V> for ShardedUnboundCacheBase<K, V, H>
+where
+    K: Hash + Eq,
+    V: Clone,
+    H: ShardHasher<K>,
+{
+    fn cache_peek(&self, k: &K) -> Result<Option<V>, Self::Error> {
+        Ok(self.peek(k))
     }
 }
 

--- a/src/stores/ttl_sorted.rs
+++ b/src/stores/ttl_sorted.rs
@@ -628,40 +628,43 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> TtlSortedCache<K, V, S> {
         count
     }
 
-    /// Set k/v pair without running eviction logic. See `.set_with_ttl_evict`
-    pub fn set(&mut self, key: K, value: V) -> Option<V> {
-        self.set_with_ttl_evict(key, value, None, false)
-    }
-
-    /// Set k/v pair with explicit ttl. See `.set_with_ttl_evict`
-    pub fn set_with_ttl(&mut self, key: K, value: V, ttl: Duration) -> Option<V> {
-        self.set_with_ttl_evict(key, value, Some(ttl), false)
-    }
-
-    /// Set k/v pair and run eviction logic. See `.set_with_ttl_evict`
-    pub fn set_evict(&mut self, key: K, value: V, evict: bool) -> Option<V> {
-        self.set_with_ttl_evict(key, value, None, evict)
-    }
-
-    /// Set a k/v pair with an optional explicit TTL, then optionally run eviction logic.
+    /// Set k/v pair without running eviction logic, using the cache's default TTL.
+    ///
     /// The entry is inserted first. If a `size_limit` was specified and capacity is exceeded,
-    /// the next-to-expire entry is dropped after insertion. The eviction callback fires after
-    /// insertion, not before. Returns any existing unexpired value that was replaced.
+    /// the next-to-expire entry is dropped after insertion, but only if `.set_with(..).evict()`
+    /// was used — plain `set` never runs eviction logic itself; see
+    /// [`set_with`](Self::set_with) for per-entry TTL overrides and opt-in eviction.
     ///
     /// If computing the expiry instant overflows (a TTL on the order of hundreds of
     /// years), the entry is stored with no expiry (never expires), matching
     /// [`cache_set`](crate::Cached::cache_set) on the other TTL stores.
-    pub fn set_with_ttl_evict(
-        &mut self,
-        key: K,
-        value: V,
-        ttl: Option<Duration>,
-        evict: bool,
-    ) -> Option<V> {
-        self.set_inner(key, value, ttl, evict, false)
+    pub fn set(&mut self, key: K, value: V) -> Option<V> {
+        self.set_inner(key, value, None, false, false)
     }
 
-    /// Shared insertion routine for [`set_with_ttl_evict`](Self::set_with_ttl_evict) and the
+    /// Start building a `set` call with an optional per-entry TTL override and/or
+    /// opt-in eviction, e.g. `cache.set_with(k, v).ttl(Duration::from_secs(5)).evict().set()`.
+    ///
+    /// The entry is inserted first. If a `size_limit` was specified and capacity is exceeded,
+    /// the next-to-expire entry is dropped after insertion. The eviction callback fires after
+    /// insertion, not before. The terminal [`.set()`](TtlSortedSetBuilder::set) returns any
+    /// existing unexpired value that was replaced.
+    ///
+    /// If computing the expiry instant overflows (a TTL on the order of hundreds of
+    /// years), the entry is stored with no expiry (never expires), matching
+    /// [`cache_set`](crate::Cached::cache_set) on the other TTL stores.
+    #[must_use = "set_with does nothing until .set() is called"]
+    pub fn set_with(&mut self, key: K, value: V) -> TtlSortedSetBuilder<'_, K, V, S> {
+        TtlSortedSetBuilder {
+            cache: self,
+            key,
+            value,
+            ttl: None,
+            evict: false,
+        }
+    }
+
+    /// Shared insertion routine for [`set_with`](Self::set_with) / [`set`](Self::set) and the
     /// `cache_get_or_set_with_mut` paths.
     ///
     /// When the effective TTL (explicit `ttl` arg or `self.ttl`) is zero, the entry is
@@ -809,6 +812,52 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> TtlSortedCache<K, V, S> {
                 on_evict(entry.key.0.as_ref(), &entry.value);
             }
         }
+    }
+}
+
+/// Builder returned by [`TtlSortedCache::set_with`] for chaining a per-entry TTL override
+/// and/or opt-in eviction before performing the insertion.
+///
+/// Nothing is inserted until the terminal [`.set()`](Self::set) is called — the `#[must_use]`
+/// attribute flags a builder that is constructed and dropped without ever calling it.
+#[cfg_attr(docsrs, doc(cfg(feature = "time_stores")))]
+#[must_use = "set_with does nothing until .set() is called"]
+pub struct TtlSortedSetBuilder<'a, K, V, S = DefaultHashBuilder> {
+    cache: &'a mut TtlSortedCache<K, V, S>,
+    key: K,
+    value: V,
+    ttl: Option<Duration>,
+    evict: bool,
+}
+
+impl<'a, K: Hash + Eq + Ord + Clone, V, S: BuildHasher> TtlSortedSetBuilder<'a, K, V, S> {
+    /// Override the store's default TTL for this entry only.
+    ///
+    /// If computing the expiry instant overflows (a TTL on the order of hundreds of
+    /// years), the entry is stored with no expiry (never expires), matching
+    /// [`cache_set`](crate::Cached::cache_set) on the other TTL stores. A `Duration::ZERO`
+    /// TTL also means "never expires" for this entry, matching the store's zero-TTL
+    /// convention.
+    pub fn ttl(mut self, ttl: Duration) -> Self {
+        self.ttl = Some(ttl);
+        self
+    }
+
+    /// Opt into running eviction logic after this insertion.
+    ///
+    /// The entry is inserted first. If a `size_limit` was specified and capacity is
+    /// exceeded, the next-to-expire entry is dropped after insertion, firing `on_evict`
+    /// and counting an eviction.
+    pub fn evict(mut self) -> Self {
+        self.evict = true;
+        self
+    }
+
+    /// Perform the insertion. Returns any existing unexpired value that was replaced,
+    /// or `None` if the key was absent or the replaced entry had already expired.
+    pub fn set(self) -> Option<V> {
+        self.cache
+            .set_inner(self.key, self.value, self.ttl, self.evict, false)
     }
 }
 
@@ -1299,15 +1348,15 @@ mod test {
 
     #[test]
     fn set_with_ttl_overflow_stores_never_expiring_entry() {
-        // set_with_ttl with a Duration that would overflow Instant bounds stores the
-        // entry with no expiry (never expires), matching cache_set on the other TTL
+        // set_with(..).ttl(..) with a Duration that would overflow Instant bounds stores
+        // the entry with no expiry (never expires), matching cache_set on the other TTL
         // stores. No error surface: TtlSortedCache's Cached::Error is Infallible.
         let mut cache = TtlSortedCache::<u32, u32>::builder()
             .ttl(Duration::from_secs(60))
             .build()
             .unwrap();
         // Duration::MAX overflows Instant::now().checked_add -> None -> never expires.
-        let prev = cache.set_with_ttl(1u32, 42u32, Duration::MAX);
+        let prev = cache.set_with(1u32, 42u32).ttl(Duration::MAX).set();
         assert_eq!(prev, None);
         assert_eq!(cache.cache_size(), 1);
         assert_eq!(cache.cache_get(&1u32), Some(&42u32));
@@ -1477,7 +1526,10 @@ mod test {
             .expect("cache should build");
 
         // Use a very short but non-zero TTL (zero now means "never expires").
-        cache.set_with_ttl("expired", 10, Duration::from_millis(1));
+        cache
+            .set_with("expired", 10)
+            .ttl(Duration::from_millis(1))
+            .set();
         assert_eq!(cache.cache_size(), 1);
         assert_eq!(cache.keys.len(), 1);
 
@@ -1509,7 +1561,10 @@ mod test {
             .expect("cache should build");
 
         // Use a very short but non-zero TTL (zero now means "never expires").
-        cache.set_with_ttl("expired-mut", 20, Duration::from_millis(1));
+        cache
+            .set_with("expired-mut", 20)
+            .ttl(Duration::from_millis(1))
+            .set();
         assert_eq!(cache.cache_size(), 1);
         assert_eq!(cache.keys.len(), 1);
 
@@ -1599,18 +1654,20 @@ mod test {
         assert_eq!(0, cache.len());
 
         // default ttl is 100ms
-        cache.set_with_ttl("a".to_string(), "a".to_string(), Duration::from_millis(300));
+        cache
+            .set_with("a".to_string(), "a".to_string())
+            .ttl(Duration::from_millis(300))
+            .set();
         std::thread::sleep(Duration::from_millis(200));
         assert_eq!(cache.get("a"), Some("a".to_string()).as_ref());
         assert_eq!(1, cache.len());
 
         std::thread::sleep(Duration::from_millis(200));
-        cache.set_with_ttl_evict(
-            "b".to_string(),
-            "b".to_string(),
-            Some(Duration::from_millis(300)),
-            true,
-        );
+        cache
+            .set_with("b".to_string(), "b".to_string())
+            .ttl(Duration::from_millis(300))
+            .evict()
+            .set();
         // a should now be evicted
         assert_eq!(1, cache.len());
         assert_eq!(cache.get("a"), None);
@@ -1785,7 +1842,10 @@ mod test {
             .build()
             .unwrap();
         cache.set_max_size(1);
-        cache.set_with_ttl("long", 1u32, Duration::from_secs(60));
+        cache
+            .set_with("long", 1u32)
+            .ttl(Duration::from_secs(60))
+            .set();
         // Must not panic; "long" should be evicted to make room for "short".
         let v = cache.cache_get_or_set_with("short", || 2u32);
         assert_eq!(*v, 2);
@@ -1805,7 +1865,10 @@ mod test {
             .build()
             .unwrap();
         cache.set_max_size(1);
-        cache.set_with_ttl("long", 1u32, Duration::from_secs(60));
+        cache
+            .set_with("long", 1u32)
+            .ttl(Duration::from_secs(60))
+            .set();
         let v: &mut u32 = cache
             .cache_try_get_or_set_with_mut("short", || Ok::<u32, ()>(2))
             .unwrap();
@@ -1847,7 +1910,10 @@ mod test {
             .build()
             .unwrap();
         cache.set_max_size(1);
-        cache.set_with_ttl("long", 1u32, Duration::from_secs(60));
+        cache
+            .set_with("long", 1u32)
+            .ttl(Duration::from_secs(60))
+            .set();
         let v = cache
             .async_cache_get_or_set_with("short", || async { 2u32 })
             .await;
@@ -2245,7 +2311,7 @@ mod test {
         assert_eq!(cache.cache_get(&2u32), Some(&20u32));
     }
 
-    /// `set_with_ttl` called with an EXPLICIT `Duration::ZERO` (not the cache-level
+    /// `set_with(..).ttl(..)` called with an EXPLICIT `Duration::ZERO` (not the cache-level
     /// `set_ttl`) must store `expiry = None` (never expires), not `Some(now)`
     /// (immediate). The cache's default TTL stays finite the whole time.
     #[test]
@@ -2255,7 +2321,7 @@ mod test {
             .build()
             .unwrap();
         // Explicit zero TTL on this one entry — default ttl remains 20ms.
-        cache.set_with_ttl(1u32, 10u32, Duration::ZERO);
+        cache.set_with(1u32, 10u32).ttl(Duration::ZERO).set();
         // The entry's internal expiry must be None (never), not Some(now).
         assert!(
             cache
@@ -2284,7 +2350,7 @@ mod test {
         assert_eq!(cache.cache_get(&1u32), Some(&10u32));
     }
 
-    /// `set_with_ttl_evict` with explicit `Duration::ZERO` also stores `None`,
+    /// `set_with(..).ttl(..).evict()` with explicit `Duration::ZERO` also stores `None`,
     /// and the never-expiring entry is not swept by the eviction pass it triggers.
     #[test]
     fn set_with_ttl_evict_explicit_zero_never_expires_and_survives_evict() {
@@ -2296,7 +2362,11 @@ mod test {
         cache.cache_set(1u32, 10u32);
         std::thread::sleep(std::time::Duration::from_millis(40));
         // Insert a never-expiring entry AND run the eviction pass in the same call.
-        cache.set_with_ttl_evict(2u32, 20u32, Some(Duration::ZERO), true);
+        cache
+            .set_with(2u32, 20u32)
+            .ttl(Duration::ZERO)
+            .evict()
+            .set();
         assert!(
             cache
                 .map
@@ -2313,6 +2383,145 @@ mod test {
             Some(&20u32),
             "never-expiring entry must survive its own evict pass"
         );
+    }
+
+    /// `set_with(k, v).set()` with no `.ttl()`/`.evict()` calls must behave exactly like
+    /// plain `set`: same default TTL, same displaced-value return, no eviction sweep.
+    #[test]
+    fn set_with_default_matches_plain_set() {
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_millis(200))
+            .build()
+            .unwrap();
+
+        // First insert via the builder with no overrides: no previous value.
+        assert_eq!(cache.set_with(1u32, 10u32).set(), None);
+        assert_eq!(cache.cache_get(&1u32), Some(&10u32));
+
+        // Overwriting the still-live entry returns the displaced value, matching `set`.
+        assert_eq!(cache.set_with(1u32, 11u32).set(), Some(10u32));
+        assert_eq!(cache.cache_get(&1u32), Some(&11u32));
+
+        // The entry uses the cache's default TTL (no override was applied): it expires
+        // after the configured 200ms, exactly like a plain `set`.
+        std::thread::sleep(std::time::Duration::from_millis(260));
+        assert_eq!(
+            cache.cache_get(&1u32),
+            None,
+            "set_with with no .ttl() override must use the cache's default TTL"
+        );
+    }
+
+    /// `.ttl(d)` overrides the store's default TTL for that single entry: a shorter
+    /// override expires before the cache default would, and a longer override survives
+    /// past the point a default-TTL sibling has already expired.
+    #[test]
+    fn set_with_ttl_overrides_default_ttl() {
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_millis(500))
+            .build()
+            .unwrap();
+
+        // Shorter override: expires well before the 500ms default would.
+        cache
+            .set_with(1u32, 10u32)
+            .ttl(Duration::from_millis(20))
+            .set();
+        std::thread::sleep(std::time::Duration::from_millis(80));
+        assert_eq!(
+            cache.cache_get(&1u32),
+            None,
+            "a shorter .ttl() override must expire before the cache default TTL"
+        );
+
+        // Longer override: still live after the cache's own default would have expired
+        // a plain entry (proving the per-entry override, not the default, is in effect).
+        cache
+            .set_with(2u32, 20u32)
+            .ttl(Duration::from_secs(60))
+            .set();
+        cache.cache_set(3u32, 30u32); // default-TTL sibling, 500ms
+        std::thread::sleep(std::time::Duration::from_millis(600));
+        assert_eq!(
+            cache.cache_get(&3u32),
+            None,
+            "default-TTL sibling must have expired by now"
+        );
+        assert_eq!(
+            cache.cache_get(&2u32),
+            Some(&20u32),
+            "a longer .ttl() override must survive past the default TTL window"
+        );
+    }
+
+    /// `.evict()` opts into running the size-limit eviction pass after insertion: once the
+    /// bound is exceeded, the next-to-expire entry is dropped as part of the `.set()` call
+    /// that requested it. Without `.evict()`, `set_with` still enforces `size_limit`
+    /// (size-limit enforcement is unconditional in `set_inner`; `.evict()` only affects the
+    /// TTL-sweep-when-no-size-limit path), so this test also checks the no-size-limit case
+    /// via `evict()` triggering a plain expiry sweep.
+    #[test]
+    fn set_with_evict_triggers_eviction() {
+        // Case 1: no size_limit configured — `.evict()` runs a TTL sweep as part of `.set()`.
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_millis(10))
+            .build()
+            .unwrap();
+        cache.cache_set(1u32, 10u32);
+        std::thread::sleep(std::time::Duration::from_millis(40));
+        assert_eq!(cache.cache_evictions(), Some(0));
+        // Insert a second entry and opt into eviction: the expired entry (key 1) must be
+        // swept as part of this call.
+        cache.set_with(2u32, 20u32).evict().set();
+        assert_eq!(
+            cache.cache_evictions(),
+            Some(1),
+            ".evict() must run the TTL sweep as part of set_with(..).set()"
+        );
+
+        // Case 2: with a size_limit configured, exceeding it evicts the next-to-expire
+        // entry regardless of `.evict()`; migrated from the historical `set_evict` coverage
+        // (kitchen_sink's "a"/"b" scenario), isolated here for the builder specifically.
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .max_size(1)
+            .build()
+            .unwrap();
+        cache.set_with(1u32, 10u32).set();
+        assert_eq!(cache.cache_size(), 1);
+        cache.set_with(2u32, 20u32).evict().set();
+        assert_eq!(
+            cache.cache_size(),
+            1,
+            "size_limit must still cap entries when inserting via set_with(..).evict()"
+        );
+        assert_eq!(cache.cache_get(&1u32), None, "next-to-expire entry evicted");
+        assert_eq!(cache.cache_get(&2u32), Some(&20u32));
+    }
+
+    /// The terminal `.set()` returns the displaced unexpired value on overwrite (`Some`),
+    /// and `None` when the previous entry was absent or had already expired.
+    #[test]
+    fn set_with_set_returns_displaced_value() {
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_millis(50))
+            .build()
+            .unwrap();
+
+        // Absent key: None.
+        assert_eq!(cache.set_with(1u32, 10u32).set(), None);
+
+        // Overwrite of a live entry: Some(previous value).
+        assert_eq!(cache.set_with(1u32, 11u32).set(), Some(10u32));
+
+        // Let the entry expire, then overwrite: the expired value is filtered to None.
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        assert_eq!(
+            cache.set_with(1u32, 12u32).set(),
+            None,
+            "overwriting an expired entry must return None, not the stale value"
+        );
+        assert_eq!(cache.cache_get(&1u32), Some(&12u32));
     }
 
     /// `retain_latest` over a MIX of never-expires (`None`) and finite (`Some`) entries:
@@ -2534,5 +2743,205 @@ mod test {
             .unwrap();
         // The backing map must have at least the requested capacity.
         assert!(cache.map.capacity() >= 32);
+    }
+
+    // ── Adversarial coverage for the `set_with` builder (outside-in review) ─────
+
+    /// `.ttl()` combined with a size cap: a shorter per-entry override moves an entry
+    /// to the FRONT of the eviction order even though it was inserted after entries using
+    /// the (longer) cache default TTL. This proves eviction ordering is driven by the
+    /// effective (overridden) expiry, not by the cache-level default or insertion order.
+    #[test]
+    fn set_with_ttl_override_shorter_than_existing_evicts_first_under_size_cap() {
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .max_size(2)
+            .build()
+            .unwrap();
+
+        // key 1: very short override, inserted FIRST.
+        cache
+            .set_with(1u32, 10u32)
+            .ttl(Duration::from_millis(5))
+            .set();
+        // key 2: cache default (60s), inserted SECOND.
+        cache.set_with(2u32, 20u32).set();
+        assert_eq!(cache.cache_size(), 2, "at cap, no eviction yet");
+
+        // key 3: also cache default. Exceeding the cap must evict the entry with the
+        // soonest effective expiry — key 1 (short override) — not key 2, even though
+        // key 1 was inserted earlier and key 2 uses the (longer) cache default.
+        cache.set_with(3u32, 30u32).evict().set();
+        assert_eq!(cache.cache_size(), 2, "size cap must still be enforced");
+        assert_eq!(
+            cache.cache_get(&1u32),
+            None,
+            "shorter .ttl() override must be evicted first despite earlier insertion"
+        );
+        assert_eq!(cache.cache_get(&2u32), Some(&20u32));
+        assert_eq!(cache.cache_get(&3u32), Some(&30u32));
+    }
+
+    /// `.ttl(Duration::ZERO)` (never-expires) interacts with size-cap eviction ordering
+    /// through the BUILDER path specifically (not `set_ttl` + plain `set`): a never-expiring
+    /// entry set via `.ttl(Duration::ZERO)` must be evicted LAST, after finite entries —
+    /// even a finite entry using a *shorter-than-default* override inserted later.
+    #[test]
+    fn set_with_ttl_zero_vs_dated_entries_eviction_order_under_size_cap() {
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .max_size(2)
+            .build()
+            .unwrap();
+
+        // key 1: never-expires, via the builder's `.ttl(Duration::ZERO)`.
+        cache.set_with(1u32, 10u32).ttl(Duration::ZERO).set();
+        // key 2: finite, shorter than the cache default.
+        cache
+            .set_with(2u32, 20u32)
+            .ttl(Duration::from_secs(30))
+            .set();
+        // key 3: finite, cache default (60s) — plain `set_with` with no `.ttl()` override.
+        // This unconditionally trims to the cap (size-limit enforcement is unconditional
+        // in `set_inner`), evicting the soonest-to-expire live entry: key 2.
+        cache.set_with(3u32, 30u32).set();
+
+        assert_eq!(cache.cache_size(), 2, "size cap must be enforced");
+        assert_eq!(
+            cache.cache_get(&1u32),
+            Some(&10u32),
+            "never-expiring entry set via the builder must survive size eviction"
+        );
+        assert_eq!(
+            cache.cache_get(&2u32),
+            None,
+            "the shorter finite entry must be evicted before the never-expiring one"
+        );
+        assert_eq!(cache.cache_get(&3u32), Some(&30u32));
+    }
+
+    /// Displaced-value semantics of the terminal `.set()` across every entry state
+    /// (absent, live, expired), each exercised WITH `.evict()` chained. The eviction
+    /// pass must not change what `.set()` returns for the just-overwritten key — that
+    /// return value reflects only the entry displaced at THIS key, computed before the
+    /// (possibly unrelated) eviction sweep runs.
+    #[test]
+    fn set_with_evict_returns_displaced_value_in_all_states() {
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_millis(50))
+            .build()
+            .unwrap();
+
+        // Absent key, `.evict()` chained: None, and the (no-op) eviction pass does not error.
+        assert_eq!(cache.set_with(1u32, 10u32).evict().set(), None);
+
+        // Live key, `.evict()` chained: displaced value returned regardless of the sweep.
+        assert_eq!(cache.set_with(1u32, 11u32).evict().set(), Some(10u32));
+        assert_eq!(cache.cache_get(&1u32), Some(&11u32));
+
+        // Let it expire, then overwrite with `.evict()` chained: displaced value is
+        // filtered to None (matching the non-evict path), not the stale value.
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        assert_eq!(
+            cache.set_with(1u32, 12u32).evict().set(),
+            None,
+            "overwriting an expired entry must return None even with .evict() chained"
+        );
+        assert_eq!(cache.cache_get(&1u32), Some(&12u32));
+    }
+
+    /// A just-inserted entry can itself be selected for size-limit eviction if it is the
+    /// soonest-to-expire entry once the cap is exceeded — proving eviction runs strictly
+    /// AFTER insertion (the code checks `map.len() > size_limit` post-insert), not before.
+    /// If eviction ran before insertion, the cap would be violated (2 entries with a
+    /// cap of 1). `.set()`'s displaced-value return (`None`, a new key) does not reflect
+    /// this immediate self-eviction — a real gotcha for callers relying on the return value
+    /// alone to know whether their write "stuck".
+    #[test]
+    fn set_with_evict_may_evict_the_entry_just_inserted() {
+        let events = Arc::new(std::sync::Mutex::new(Vec::<(u32, u32)>::new()));
+        let events2 = events.clone();
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .max_size(1)
+            .on_evict(move |k: &u32, v: &u32| {
+                events2.lock().unwrap().push((*k, *v));
+            })
+            .build()
+            .unwrap();
+
+        // Long-lived entry occupies the sole capacity slot.
+        cache.set_with(1u32, 100u32).set();
+        assert_eq!(cache.cache_size(), 1);
+        assert_eq!(cache.cache_evictions(), Some(0));
+
+        // Insert a NEW key with a much shorter TTL than the existing entry. Post-insert the
+        // map has 2 entries against a cap of 1; the soonest-to-expire (the entry just
+        // inserted) is evicted immediately — its own insertion is what triggered the check.
+        let displaced = cache
+            .set_with(2u32, 200u32)
+            .ttl(Duration::from_millis(1))
+            .evict()
+            .set();
+        assert_eq!(
+            displaced, None,
+            "the terminal .set() return reflects only same-key displacement, not self-eviction"
+        );
+
+        assert_eq!(cache.cache_size(), 1, "size cap must still be enforced");
+        assert_eq!(
+            cache.cache_get(&1u32),
+            Some(&100u32),
+            "the long-lived entry must survive"
+        );
+        assert_eq!(
+            cache.cache_get(&2u32),
+            None,
+            "the just-inserted, soonest-to-expire entry must have been evicted"
+        );
+
+        // on_evict fired exactly once, for the evicted key/value — proving the callback
+        // observes the entry as already inserted-and-then-removed, not skipped pre-insert.
+        let fired = events.lock().unwrap().clone();
+        assert_eq!(
+            fired,
+            vec![(2u32, 200u32)],
+            "on_evict must fire exactly once, for the just-inserted key that was evicted"
+        );
+        assert_eq!(cache.cache_evictions(), Some(1));
+    }
+
+    /// `on_evict` fires via the builder path for a size-limit eviction with the correct
+    /// (k, v) of the evicted (displaced-by-cap) entry, and the eviction counter reflects
+    /// exactly one eviction — isolating the callback-content assertion (as distinct from
+    /// `set_with_evict_triggers_eviction`, which only checks the counter/survivorship).
+    #[test]
+    fn set_with_evict_on_evict_fires_with_correct_kv_for_size_eviction() {
+        let events = Arc::new(std::sync::Mutex::new(Vec::<(u32, u32)>::new()));
+        let events2 = events.clone();
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .max_size(1)
+            .on_evict(move |k: &u32, v: &u32| {
+                events2.lock().unwrap().push((*k, *v));
+            })
+            .build()
+            .unwrap();
+
+        cache.set_with(1u32, 111u32).set();
+        assert!(events.lock().unwrap().is_empty());
+
+        // key 2 uses the default (longer-lived by construction order) TTL; key 1 is the
+        // sole occupant and thus the only candidate to evict when the cap is exceeded.
+        cache.set_with(2u32, 222u32).evict().set();
+
+        let fired = events.lock().unwrap().clone();
+        assert_eq!(
+            fired,
+            vec![(1u32, 111u32)],
+            "on_evict must report the evicted entry's own key/value, not the new one"
+        );
+        assert_eq!(cache.cache_evictions(), Some(1));
+        assert_eq!(cache.cache_get(&2u32), Some(&222u32));
     }
 }

--- a/tests/v3_additive_parity.rs
+++ b/tests/v3_additive_parity.rs
@@ -292,6 +292,352 @@ async fn concurrent_async_try_get_or_set_with_ok_err_and_hit() {
     assert_eq!(r, Ok(10), "hit returns the cached value");
 }
 
+// ── ConcurrentCachePeek trait ────────────────────────────────────────────────
+
+// Generic over the trait: only compiles/works for stores that implement
+// `ConcurrentCachePeek`, exercising the trait method (not an inherent shim).
+fn peek_via_trait<S: cached::ConcurrentCachePeek<u32, String>>(s: &S, k: u32) -> Option<String> {
+    s.cache_peek(&k).expect("sharded peek is infallible")
+}
+
+// Value-generic version of the above so expiring stores (whose values impl
+// `Expires`) can be peeked through the trait rather than an inherent shim.
+fn peek_trait_val<V, S>(s: &S, k: u32) -> Option<V>
+where
+    S: cached::ConcurrentCachePeek<u32, V>,
+    S::Error: std::fmt::Debug,
+{
+    s.cache_peek(&k).expect("sharded peek is infallible")
+}
+
+#[test]
+fn concurrent_peek_trait_returns_value_and_ignores_metrics() {
+    let c: ShardedUnboundCache<u32, String> = ShardedUnboundCache::new();
+    c.set(1, "ten".to_string());
+    let hits_before = c.metrics().hits;
+    let misses_before = c.metrics().misses;
+
+    assert_eq!(peek_via_trait(&c, 1), Some("ten".to_string()));
+    assert_eq!(peek_via_trait(&c, 2), None, "missing key peeks as None");
+
+    let m = c.metrics();
+    assert_eq!(m.hits, hits_before, "trait peek must not count a hit");
+    assert_eq!(m.misses, misses_before, "trait peek must not count a miss");
+}
+
+#[test]
+fn concurrent_peek_trait_does_not_promote_lru_recency() {
+    use cached::ShardedLruCache;
+    // shards = 1 so all keys share one LRU order.
+    let c: ShardedLruCache<u32, String> = ShardedLruCache::builder()
+        .max_size(2)
+        .shards(1)
+        .build()
+        .unwrap();
+    c.set(1, "ten".to_string());
+    c.set(2, "twenty".to_string());
+    // A trait peek of key 1 must NOT promote it; inserting key 3 evicts key 1.
+    assert_eq!(peek_via_trait(&c, 1), Some("ten".to_string()));
+    c.set(3, "thirty".to_string());
+    assert_eq!(
+        peek_via_trait(&c, 1),
+        None,
+        "peeked key must still be evicted first"
+    );
+    assert_eq!(peek_via_trait(&c, 2), Some("twenty".to_string()));
+    assert_eq!(peek_via_trait(&c, 3), Some("thirty".to_string()));
+}
+
+#[test]
+fn concurrent_peek_trait_alias_matches_cache_peek() {
+    use cached::ConcurrentCachePeek;
+    let c: ShardedUnboundCache<u32, String> = ShardedUnboundCache::new();
+    c.set(1, "ten".to_string());
+    // Fully-qualified so the defaulted trait alias is reached rather than the
+    // inherent `peek` shim, which wins on method-call syntax.
+    let via_alias = ConcurrentCachePeek::peek(&c, &1).unwrap();
+    let via_core = ConcurrentCachePeek::cache_peek(&c, &1).unwrap();
+    assert_eq!(via_alias, via_core);
+    assert_eq!(via_alias, Some("ten".to_string()));
+    assert_eq!(ConcurrentCachePeek::peek(&c, &2).unwrap(), None);
+}
+
+#[cfg(feature = "time_stores")]
+#[test]
+fn concurrent_peek_trait_expired_reads_none() {
+    use cached::ShardedTtlCache;
+    let c: ShardedTtlCache<u32, String> = ShardedTtlCache::new(Duration::from_millis(20));
+    c.set(1, "ten".to_string());
+    assert_eq!(peek_via_trait(&c, 1), Some("ten".to_string()));
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    assert_eq!(
+        peek_via_trait(&c, 1),
+        None,
+        "expired entry must peek as None through the trait"
+    );
+}
+
+#[cfg(feature = "time_stores")]
+#[test]
+fn concurrent_peek_trait_lru_ttl_expired_and_no_refresh() {
+    use cached::{ConcurrentCachePeek, ShardedLruTtlCache};
+
+    // (1) Expired-by-TTL reads None through the trait (ShardedLruTtlCache was
+    // uncovered at the trait level; only ShardedTtlCache was exercised before).
+    let c: ShardedLruTtlCache<u32, String> = ShardedLruTtlCache::new(8, Duration::from_millis(20));
+    c.set(1, "ten".to_string());
+    assert_eq!(peek_trait_val::<String, _>(&c, 1), Some("ten".to_string()));
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    assert_eq!(
+        peek_trait_val::<String, _>(&c, 1),
+        None,
+        "expired LruTtl entry must peek None through the trait"
+    );
+
+    // (2) With refresh_on_hit enabled, the trait `cache_peek` must NOT renew the
+    // TTL. Peek repeatedly across a span well beyond the TTL; a correct peek never
+    // extends expiry, so the entry dies despite the peeks. A buggy peek that
+    // refreshed would keep it alive indefinitely.
+    let c: ShardedLruTtlCache<u32, String> = ShardedLruTtlCache::builder()
+        .refresh_on_hit(true)
+        .max_size(64)
+        .ttl(Duration::from_millis(40))
+        .shards(1)
+        .build()
+        .unwrap();
+    c.set(1, "live".to_string());
+    assert_eq!(
+        ConcurrentCachePeek::cache_peek(&c, &1).unwrap(),
+        Some("live".to_string()),
+        "live entry must peek through the trait"
+    );
+    for _ in 0..6 {
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        // Each peek would renew a buggy refresh_on_hit impl; a correct one never does.
+        let _ = ConcurrentCachePeek::cache_peek(&c, &1).unwrap();
+    }
+    assert_eq!(
+        ConcurrentCachePeek::cache_peek(&c, &1).unwrap(),
+        None,
+        "trait peek must not renew TTL under refresh_on_hit; entry must expire"
+    );
+}
+
+#[test]
+fn concurrent_peek_trait_expiring_reads_none_when_expired() {
+    use cached::{Expires, ShardedExpiringCache, ShardedExpiringLruCache};
+
+    #[derive(Clone, PartialEq, Debug)]
+    struct Val {
+        id: u32,
+        expired: bool,
+    }
+    impl Expires for Val {
+        fn is_expired(&self) -> bool {
+            self.expired
+        }
+    }
+
+    // ShardedExpiringCache: an `is_expired()` value must read None through the trait.
+    let c: ShardedExpiringCache<u32, Val> = ShardedExpiringCache::new();
+    c.set(
+        1,
+        Val {
+            id: 1,
+            expired: false,
+        },
+    );
+    c.set(
+        2,
+        Val {
+            id: 2,
+            expired: true,
+        },
+    );
+    assert_eq!(peek_trait_val::<Val, _>(&c, 1).map(|v| v.id), Some(1));
+    assert_eq!(
+        peek_trait_val::<Val, _>(&c, 2),
+        None,
+        "expired value must peek None through the trait"
+    );
+
+    // ShardedExpiringLruCache: same expiry guarantee through the trait.
+    let c: ShardedExpiringLruCache<u32, Val> = ShardedExpiringLruCache::new(8);
+    c.set(
+        1,
+        Val {
+            id: 1,
+            expired: false,
+        },
+    );
+    c.set(
+        2,
+        Val {
+            id: 2,
+            expired: true,
+        },
+    );
+    assert_eq!(peek_trait_val::<Val, _>(&c, 1).map(|v| v.id), Some(1));
+    assert_eq!(
+        peek_trait_val::<Val, _>(&c, 2),
+        None,
+        "expired value must peek None through the trait"
+    );
+}
+
+#[test]
+fn concurrent_peek_trait_expiring_lru_does_not_promote_recency() {
+    use cached::{ConcurrentCachePeek, Expires, ShardedExpiringLruCache};
+
+    #[derive(Clone, PartialEq, Debug)]
+    struct Val(u32);
+    impl Expires for Val {
+        fn is_expired(&self) -> bool {
+            false
+        }
+    }
+
+    // shards = 1 so all keys share one LRU order; a trait peek must not promote.
+    let c: ShardedExpiringLruCache<u32, Val> = ShardedExpiringLruCache::builder()
+        .max_size(2)
+        .shards(1)
+        .build()
+        .unwrap();
+    c.set(1, Val(10));
+    c.set(2, Val(20));
+    // Peek key 1 through the trait; it must NOT be promoted, so inserting key 3
+    // evicts key 1.
+    assert_eq!(
+        ConcurrentCachePeek::cache_peek(&c, &1)
+            .unwrap()
+            .map(|v| v.0),
+        Some(10)
+    );
+    c.set(3, Val(30));
+    assert_eq!(
+        ConcurrentCachePeek::cache_peek(&c, &1).unwrap(),
+        None,
+        "peeked key must still be evicted first"
+    );
+    assert_eq!(
+        ConcurrentCachePeek::cache_peek(&c, &2)
+            .unwrap()
+            .map(|v| v.0),
+        Some(20)
+    );
+    assert_eq!(
+        ConcurrentCachePeek::cache_peek(&c, &3)
+            .unwrap()
+            .map(|v| v.0),
+        Some(30)
+    );
+}
+
+#[test]
+fn prelude_exports_concurrent_cache_peek() {
+    // Proves `ConcurrentCachePeek` is reachable via the prelude glob: the generic
+    // bound below names the trait imported only through `cached::prelude::*`.
+    use cached::ShardedUnboundCache;
+    use cached::prelude::*;
+
+    fn peek_generic<S>(s: &S, k: u32) -> Option<u32>
+    where
+        S: ConcurrentCachePeek<u32, u32>,
+        S::Error: std::fmt::Debug,
+    {
+        s.cache_peek(&k).expect("infallible")
+    }
+
+    let c: ShardedUnboundCache<u32, u32> = ShardedUnboundCache::new();
+    c.set(1, 10);
+    assert_eq!(peek_generic(&c, 1), Some(10));
+    assert_eq!(peek_generic(&c, 2), None);
+}
+
+// ── ConcurrentCachedExt::try_get_or_set_with ─────────────────────────────────
+
+// Generic over the ext trait so the alias (not the inherent shim) is exercised.
+fn ext_try_get_or_set_with<S, F>(s: &S, k: u32, f: F) -> Result<u32, &'static str>
+where
+    S: cached::ConcurrentCachedExt<u32, u32>,
+    F: FnOnce() -> Result<u32, &'static str>,
+{
+    s.try_get_or_set_with(k, f)
+        .expect("sharded store is infallible")
+}
+
+#[test]
+fn concurrent_ext_try_get_or_set_with_alias() {
+    let c: ShardedUnboundCache<u32, u32> = ShardedUnboundCache::new();
+
+    // Miss + Err: nothing stored, inner Err returned.
+    assert_eq!(ext_try_get_or_set_with(&c, 1, || Err("nope")), Err("nope"));
+    assert_eq!(c.get(&1), None, "failed init must not store");
+
+    // Miss + Ok: stored and returned.
+    assert_eq!(ext_try_get_or_set_with(&c, 1, || Ok(10)), Ok(10));
+    assert_eq!(c.get(&1), Some(10));
+
+    // Hit: closure must not run.
+    let ran = Arc::new(AtomicUsize::new(0));
+    let ran2 = ran.clone();
+    let r = ext_try_get_or_set_with(&c, 1, move || {
+        ran2.fetch_add(1, Ordering::Relaxed);
+        Ok(99)
+    });
+    assert_eq!(r, Ok(10), "hit returns the cached value");
+    assert_eq!(
+        ran.load(Ordering::Relaxed),
+        0,
+        "hit must not run the closure"
+    );
+}
+
+#[test]
+fn concurrent_ext_try_get_or_set_with_on_bounded_lru() {
+    // Probe the alias on a bounded (LRU) store, not just the unbounded one. The
+    // hit path clones the stored value (V: Clone) and must not run the closure;
+    // the miss+Err path must store nothing; a stored value participates in the
+    // LRU bound.
+    use cached::ConcurrentCachedExt;
+
+    let c: ShardedLruCache<u32, u32> = ShardedLruCache::builder()
+        .max_size(2)
+        .shards(1)
+        .build()
+        .unwrap();
+
+    // Miss + Err: nothing stored.
+    assert_eq!(ext_try_get_or_set_with(&c, 1, || Err("nope")), Err("nope"));
+    assert_eq!(c.get(&1), None, "failed init must not store");
+
+    // Miss + Ok on a bounded store: stored and returned.
+    assert_eq!(ext_try_get_or_set_with(&c, 1, || Ok(10)), Ok(10));
+    assert_eq!(ext_try_get_or_set_with(&c, 2, || Ok(20)), Ok(20));
+
+    // Hit: closure must not run; cached value returned.
+    let ran = Arc::new(AtomicUsize::new(0));
+    let ran2 = ran.clone();
+    let r = ext_try_get_or_set_with(&c, 1, move || {
+        ran2.fetch_add(1, Ordering::Relaxed);
+        Ok(99)
+    });
+    assert_eq!(r, Ok(10), "hit returns the cached value");
+    assert_eq!(
+        ran.load(Ordering::Relaxed),
+        0,
+        "hit must not run the closure"
+    );
+
+    // A third distinct key stays within the size-2 bound (eviction happened).
+    assert_eq!(ext_try_get_or_set_with(&c, 3, || Ok(30)), Ok(30));
+    assert_eq!(
+        ConcurrentCachedExt::len(&c).unwrap(),
+        Some(2),
+        "bounded LRU store keeps at most max_size entries"
+    );
+}
+
 // ── retain on the map-backed stores ──────────────────────────────────────────
 
 #[test]

--- a/tests/v3_ttl_sorted_set_with.rs
+++ b/tests/v3_ttl_sorted_set_with.rs
@@ -1,0 +1,123 @@
+//! Consumer-shaped coverage for `TtlSortedCache::set_with`, exercised only through the
+//! crate's public API (as an external downstream consumer would use it).
+//!
+//! `TtlSortedSetBuilder` is re-exported at the crate root and from `cached::stores`
+//! (`time_stores`-gated, like `TtlSortedCacheBuilder`), so a consumer can both chain the
+//! returned value fluently and name the type in a signature. This file certifies both usage
+//! patterns actually compile and work from outside the crate, which the in-crate
+//! `#[cfg(test)]` module (same crate, same module privileges) cannot certify on its own.
+
+#![cfg(feature = "time_stores")]
+
+use cached::stores::TtlSortedCache;
+use cached::time::Duration;
+use cached::{CacheEvict, Cached};
+
+/// The full one-line chain `set_with(k, v).ttl(..).evict().set()` compiles and behaves
+/// correctly from outside the crate, using only `cached::{...}` public imports.
+#[test]
+fn chained_set_with_call_is_usable_from_the_public_api() {
+    let mut cache: TtlSortedCache<u32, u32> = TtlSortedCache::builder()
+        .ttl(Duration::from_secs(60))
+        .max_size(1)
+        .build()
+        .unwrap();
+
+    let displaced = cache
+        .set_with(1u32, 10u32)
+        .ttl(Duration::from_secs(5))
+        .evict()
+        .set();
+    assert_eq!(displaced, None);
+    assert_eq!(cache.cache_get(&1u32), Some(&10u32));
+
+    // Exceeding the cap evicts the sole existing entry.
+    let displaced = cache.set_with(2u32, 20u32).evict().set();
+    assert_eq!(displaced, None);
+    assert_eq!(cache.cache_size(), 1);
+    assert_eq!(cache.cache_get(&1u32), None);
+    assert_eq!(cache.cache_get(&2u32), Some(&20u32));
+}
+
+/// The builder value returned by `set_with` can be bound to a local — nameable via the
+/// crate-root re-export `cached::TtlSortedSetBuilder` — and its setter methods called
+/// across separate statements before the terminal `.set()`, not just as a single fluent
+/// one-liner. A helper function taking the builder by name proves the type is nameable
+/// in a downstream signature.
+#[test]
+fn set_with_builder_can_be_bound_and_configured_across_statements() {
+    fn extend_ttl<'a, K: std::hash::Hash + Eq + Ord + Clone, V>(
+        b: cached::TtlSortedSetBuilder<'a, K, V>,
+    ) -> cached::TtlSortedSetBuilder<'a, K, V> {
+        b.ttl(Duration::from_secs(60))
+    }
+
+    let mut cache: TtlSortedCache<&str, u32> = TtlSortedCache::builder()
+        .ttl(Duration::from_millis(30))
+        .build()
+        .unwrap();
+
+    let builder = cache.set_with("a", 1u32);
+    let builder = extend_ttl(builder);
+    let builder = builder.evict();
+    let displaced = builder.set();
+
+    assert_eq!(displaced, None);
+    assert_eq!(cache.cache_get("a"), Some(&1u32));
+
+    // The long .ttl() override means the entry outlives the cache's own short default TTL.
+    std::thread::sleep(std::time::Duration::from_millis(60));
+    assert_eq!(
+        cache.cache_get("a"),
+        Some(&1u32),
+        "the builder-configured override must have taken effect"
+    );
+}
+
+/// `set_with(..).set()` with no `.ttl()`/`.evict()` calls, from the public API, behaves
+/// identically to plain `set` (the default-path parity guarantee, exercised as an external
+/// consumer rather than via the in-crate unit test).
+#[test]
+fn set_with_default_path_matches_plain_set_via_public_api() {
+    let mut cache: TtlSortedCache<u32, u32> = TtlSortedCache::builder()
+        .ttl(Duration::from_millis(200))
+        .build()
+        .unwrap();
+
+    assert_eq!(cache.set_with(1u32, 10u32).set(), None);
+    assert_eq!(cache.set(2u32, 20u32), None);
+    assert_eq!(cache.cache_get(&1u32), Some(&10u32));
+    assert_eq!(cache.cache_get(&2u32), Some(&20u32));
+
+    // Both use the cache's default TTL and expire together.
+    std::thread::sleep(std::time::Duration::from_millis(260));
+    assert_eq!(cache.cache_get(&1u32), None);
+    assert_eq!(cache.cache_get(&2u32), None);
+}
+
+/// `set_with(..).evict()` with no size limit configured runs a plain TTL sweep as part of
+/// `.set()`, observable through the `CacheEvict`-independent `cache_evictions()` counter from
+/// the public API (mirrors the in-crate `set_with_evict_triggers_eviction` case 1, exercised
+/// here purely through public types/traits).
+#[test]
+fn set_with_evict_sweeps_expired_entries_via_public_api() {
+    let mut cache: TtlSortedCache<u32, u32> = TtlSortedCache::builder()
+        .ttl(Duration::from_millis(10))
+        .build()
+        .unwrap();
+    cache.set(1u32, 10u32);
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    assert_eq!(cache.cache_evictions(), Some(0));
+
+    cache.set_with(2u32, 20u32).evict().set();
+    assert_eq!(cache.cache_evictions(), Some(1));
+    assert_eq!(cache.cache_get(&1u32), None);
+    assert_eq!(cache.cache_get(&2u32), Some(&20u32));
+
+    // The `CacheEvict::evict` trait method (also public) still works independently.
+    assert_eq!(
+        CacheEvict::evict(&mut cache),
+        0,
+        "already swept, nothing left to evict"
+    );
+}


### PR DESCRIPTION
Three v3 API changes plus a macro cleanup.

- Replace the `TtlSortedCache` inherent setters `set_with_ttl` / `set_evict` / `set_with_ttl_evict` with an entry-setter builder: `cache.set_with(k, v).ttl(d).evict().set()`. `set_with_ttl_evict` took `Option<Duration>` while `set_with_ttl` took a bare `Duration`; the builder makes each option independent and gives one spelling per combination. Plain `set(k, v)` and `Cached::cache_set` are unchanged. `TtlSortedSetBuilder` is re-exported at the crate root and from `cached::stores`, gated on `time_stores`.
- Add `ConcurrentCachePeek<K, V>`, moving the sharded `peek` onto a trait so generic code over a concurrent store can read without side effects: no recency promotion, no TTL refresh, no hit/miss metrics, no lazy removal of expired entries. Implemented by the six sharded stores only (`Error = Infallible`); the IO stores are excluded because they cannot peek without a full read. The concrete sharded types keep their inherent `peek`, which retains call-site priority. Exported from the prelude.
- Add `ConcurrentCachedExt::try_get_or_set_with`, completing the short-alias set for `ConcurrentCached::cache_try_get_or_set_with` to match `CachedExt`.
- Remove a no-op `#[allow(non_snake_case)]` from the `#[cached]` `Clone` assertion expansion.

Breaking changes are covered in the changelog and both migration guides. New coverage is in `tests/v3_ttl_sorted_set_with.rs` and `tests/v3_additive_parity.rs`.
