### PR TITLE
perf: in-memory and sharded store speedups; promote on `cache_set` overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,11 +98,11 @@
   payload; it also removes an unconditional key clone from every set.
 - `TtlSortedCache::retain_latest` counts an eviction before firing `on_evict`, so a panicking
   callback can no longer remove an entry without counting it. Matches `evict` and `retain`.
-- `ShardedTtlCache` decides expiry against a clock sample taken before the shard lock is
-  acquired. Under contention, an entry that crosses its expiry while the caller queues for the
-  lock is judged live: `cache_set` returns `Some(old)` with no eviction and no `on_evict`,
-  where previously the clock was re-read under the lock. This stays within the documented
-  lazy-expiry contract, which makes no promise of prompt removal.
+- `ShardedTtlCache` and `ShardedLruTtlCache` decide expiry against a clock sample taken before
+  the shard lock is acquired. Under contention, an entry that crosses its expiry while the
+  caller queues for the lock is judged live: `cache_set` returns `Some(old)` with no eviction
+  and no `on_evict`, where previously the clock was re-read under the lock. This stays within
+  the documented lazy-expiry contract, which makes no promise of prompt removal.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,24 @@
   `cache_peek`, `cache_peek_with_expiry_status`, and `cache_contains` remain non-promoting, and
   inserting a new key is unchanged. There is no direct substitute for the old behavior: no
   public API writes a value without touching recency.
+- `TtlSortedCache`'s `get_or_set` family (sync infallible, sync try, async infallible, async
+  try) no longer removes an expired entry before running the initializer. A cancelled or
+  panicking initializer now leaves the expired entry in place and fires no `on_evict`; on
+  success `on_evict` fires after the initializer rather than before. All four variants now
+  agree with each other and with `TtlCache` / `LruTtlCache`.
+- `TtlSortedCache` reuses the stored key when overwriting an existing entry, so `on_evict` and
+  `cache_remove_entry` report the first-inserted key rather than the most recent one. Matches
+  `HashMap::insert`. Observable only for key types whose `Eq` ignores part of the payload.
+- `ExpiringLruCache::cache_set` fires `on_evict` with the stored key rather than the caller's
+  key, matching `LruTtlCache`. Observable only for key types whose `Eq` ignores part of the
+  payload; it also removes an unconditional key clone from every set.
+- `TtlSortedCache::retain_latest` counts an eviction before firing `on_evict`, so a panicking
+  callback can no longer remove an entry without counting it. Matches `evict` and `retain`.
+- `ShardedTtlCache` and `ShardedLruTtlCache` decide expiry against a clock sample taken before
+  the shard lock is acquired. Under contention, an entry that crosses its expiry while the
+  caller queues for the lock is judged live: `cache_set` returns `Some(old)` with no eviction
+  and no `on_evict`, where previously the clock was re-read under the lock. This stays within
+  the documented lazy-expiry contract, which makes no promise of prompt removal.
 
 ### Added
 
@@ -79,30 +97,12 @@
 ### Changed
 
 - The in-memory and sharded stores are faster, with no change to the documented contracts
-  beyond the items below. The sharded stores resolve a read hit in one hash lookup instead of
-  two, count evictions per shard rather than through a shared striped counter, and cache the
-  host's CPU topology instead of probing it on every construction. The LRU-family and
-  expiry-aware stores sweep in one pass instead of collecting keys first, and the TTL stores
-  sample the clock once per operation instead of once per entry examined. `ExpiringCache` is
-  48 bytes plus two heap buffers smaller per instance.
-- `TtlSortedCache`'s `get_or_set` family (sync infallible, sync try, async infallible, async
-  try) no longer removes an expired entry before running the initializer. A cancelled or
-  panicking initializer now leaves the expired entry in place and fires no `on_evict`; on
-  success `on_evict` fires after the initializer rather than before. All four variants now
-  agree with each other and with `TtlCache` / `LruTtlCache`.
-- `TtlSortedCache` reuses the stored key when overwriting an existing entry, so `on_evict` and
-  `cache_remove_entry` report the first-inserted key rather than the most recent one. Matches
-  `HashMap::insert`. Observable only for key types whose `Eq` ignores part of the payload.
-- `ExpiringLruCache::cache_set` fires `on_evict` with the stored key rather than the caller's
-  key, matching `LruTtlCache`. Observable only for key types whose `Eq` ignores part of the
-  payload; it also removes an unconditional key clone from every set.
-- `TtlSortedCache::retain_latest` counts an eviction before firing `on_evict`, so a panicking
-  callback can no longer remove an entry without counting it. Matches `evict` and `retain`.
-- `ShardedTtlCache` and `ShardedLruTtlCache` decide expiry against a clock sample taken before
-  the shard lock is acquired. Under contention, an entry that crosses its expiry while the
-  caller queues for the lock is judged live: `cache_set` returns `Some(old)` with no eviction
-  and no `on_evict`, where previously the clock was re-read under the lock. This stays within
-  the documented lazy-expiry contract, which makes no promise of prompt removal.
+  beyond the behavior changes listed under Breaking Changes above. The sharded stores resolve
+  a read hit in one hash lookup instead of two, count evictions per shard rather than through a
+  shared striped counter, and cache the host's CPU topology instead of probing it on every
+  construction. The LRU-family and expiry-aware stores sweep in one pass instead of collecting
+  keys first, and the TTL stores sample the clock once per operation instead of once per entry
+  examined. `ExpiringCache` is 48 bytes plus two heap buffers smaller per instance.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@
   metadata: `()` for `LruCache` / `ExpiringLruCache`, `Option<Instant>` for `LruTtlCache`
   (exposed via `CacheValue::expires_at`; `None` means never expires). `LruTtlCache` no longer
   leaks bare `(Option<Instant>, V)` tuples. `key_order` is unchanged.
+- `cache_set` over an existing key now promotes that key to most-recently-used. Previously the
+  value was replaced in place and the entry kept its position in the eviction order. This
+  affects `LruCache`, `LruTtlCache`, `ExpiringLruCache`, `ShardedLruCache`, `ShardedLruTtlCache`,
+  and `ShardedExpiringLruCache`, and it changes which entry a capacity eviction selects in
+  overwrite-heavy workloads: the overwritten key survives longer and another key becomes the
+  victim. It also resolves a divergence on `ShardedLruTtlCache` / `ShardedExpiringLruCache`,
+  where configuring an `on_evict` callback changed eviction order because the callback branch
+  promoted an overwritten entry and the no-callback branch did not; both branches now promote.
+  `cache_peek`, `cache_peek_with_expiry_status`, and `cache_contains` remain non-promoting, and
+  inserting a new key is unchanged. There is no direct substitute for the old behavior: no
+  public API writes a value without touching recency.
 
 ### Added
 
@@ -64,6 +75,34 @@
   trait method) -- see `specs/traits-concurrent.md`.
 - `TtlSortedCache::capacity() -> Option<usize>`: the configured size bound (`None` when
   unbounded), plus the missing `doc(alias = "capacity")` on `TtlSortedCacheBuilder::max_size`.
+
+### Changed
+
+- The in-memory and sharded stores are faster, with no change to the documented contracts
+  beyond the items below. The sharded stores resolve a read hit in one hash lookup instead of
+  two, count evictions per shard rather than through a shared striped counter, and cache the
+  host's CPU topology instead of probing it on every construction. The LRU-family and
+  expiry-aware stores sweep in one pass instead of collecting keys first, and the TTL stores
+  sample the clock once per operation instead of once per entry examined. `ExpiringCache` is
+  48 bytes plus two heap buffers smaller per instance.
+- `TtlSortedCache`'s `get_or_set` family (sync infallible, sync try, async infallible, async
+  try) no longer removes an expired entry before running the initializer. A cancelled or
+  panicking initializer now leaves the expired entry in place and fires no `on_evict`; on
+  success `on_evict` fires after the initializer rather than before. All four variants now
+  agree with each other and with `TtlCache` / `LruTtlCache`.
+- `TtlSortedCache` reuses the stored key when overwriting an existing entry, so `on_evict` and
+  `cache_remove_entry` report the first-inserted key rather than the most recent one. Matches
+  `HashMap::insert`. Observable only for key types whose `Eq` ignores part of the payload.
+- `ExpiringLruCache::cache_set` fires `on_evict` with the stored key rather than the caller's
+  key, matching `LruTtlCache`. Observable only for key types whose `Eq` ignores part of the
+  payload; it also removes an unconditional key clone from every set.
+- `TtlSortedCache::retain_latest` counts an eviction before firing `on_evict`, so a panicking
+  callback can no longer remove an entry without counting it. Matches `evict` and `retain`.
+- `ShardedTtlCache` decides expiry against a clock sample taken before the shard lock is
+  acquired. Under contention, an entry that crosses its expiry while the caller queues for the
+  lock is judged live: `cache_set` returns `Some(old)` with no eviction and no `on_evict`,
+  where previously the clock was re-read under the lock. This stays within the documented
+  lazy-expiry contract, which makes no promise of prompt removal.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -297,17 +297,20 @@ Because LRU caches require updating access recency, `ShardedLruCache`, `ShardedL
 **Performance**
 
 v3 reworks the hot paths of the in-memory and sharded stores. Steady-state `O(1)` reads and
-capacity-bounded inserts are unchanged; the wins concentrate in a few paths (measured with
-`cargo bench --bench cache_benches`, so the exact figures are hardware- and workload-dependent):
+capacity-bounded inserts are unchanged; the wins concentrate in a few paths (figures are
+hardware- and workload-dependent; see `benches/cache_benches.rs` for the paths measured):
 
-- Overwriting an existing key with `cache_set` reuses the stored key instead of re-cloning it.
-  On the timed stores this is roughly 10-30% faster, and the gain grows with key clone cost, so
-  `String`-keyed caches benefit most.
+- Overwriting an existing key with `cache_set` on the map-backed stores (`TtlCache`,
+  `TtlSortedCache`, `ExpiringCache`) reuses the stored key instead of cloning the caller's key.
+  The gain grows with key clone cost, so caches with expensive keys benefit most. The LRU-family
+  stores instead rebind the slot to the caller's key (see the recency note below).
 - Bulk eviction and retention (`evict`, `retain`, `retain_latest`) and the key/iteration order
-  helpers now sweep in a single pass instead of collecting keys first, up to about 2x faster at
-  10k entries. TTL stores also sample the clock once per operation rather than once per entry.
-- Single-threaded `cache_get` hits on the sharded LRU and expiring-LRU variants resolve in one
-  hash lookup instead of two, about 5-15% faster.
+  helpers on the single-owner in-memory and TTL stores now sweep in a single pass instead of
+  collecting keys first, up to about 2x faster at 10k entries. TTL stores also sample the clock
+  once per operation rather than once per entry.
+- Single-threaded `cache_get` hits on the expiring-LRU and sharded LRU-TTL variants resolve in
+  one hash lookup instead of two, about 5-15% faster. The plain sharded LRU releases the shard
+  lock before updating its counters.
 
 One deliberate tradeoff comes with the `cache_set` recency change (see the migration guide): an
 overwrite now promotes the key to most-recently-used, which adds a small cost on stores with cheap

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ lru.set("key1", Response {
 
 The basic usage looks like:
 
-```rust,no_run,ignore
+```rust
 use cached::macros::cached;
 
 /// Defines a function named `fib` that uses a cache implicitly named `FIB`.
@@ -393,12 +393,11 @@ fn fib(n: u64) -> u64 {
     if n == 0 || n == 1 { return n }
     fib(n-1) + fib(n-2)
 }
-# pub fn main() { }
 ```
 
 ----
 
-```rust,no_run,ignore
+```rust
 use std::thread::sleep;
 use cached::time::Duration;
 use cached::macros::cached;
@@ -415,12 +414,11 @@ fn keyed(a: &str, b: &str) -> usize {
     sleep(Duration::new(size as u64, 0));
     size
 }
-# pub fn main() { }
 ```
 
 ----
 
-```rust,no_run,ignore
+```rust
 use cached::macros::once;
 
 /// Only cache the initial function call.
@@ -437,7 +435,6 @@ fn keyed(a: String) -> Option<usize> {
         None
     }
 }
-# pub fn main() { }
 ```
 
 ----
@@ -470,7 +467,7 @@ let _: &mut u32 = cache.cache_get_or_set_with(1, || 2);
 ```
 ----
 
-```rust,no_run,ignore
+```rust
 use cached::macros::concurrent_cached;
 use cached::AsyncRedisCache;
 use cached::time::Duration;
@@ -508,7 +505,7 @@ async fn async_cached_sleep_secs(secs: u64) -> Result<String, ExampleError> {
 
 ----
 
-```rust,no_run,ignore
+```rust
 use cached::macros::concurrent_cached;
 use cached::RedbCache;
 use thiserror::Error;
@@ -536,7 +533,7 @@ fn cached_sleep_secs(secs: u64) -> Result<String, ExampleError> {
 
 ----
 
-```rust,no_run,ignore
+```rust
 use cached::macros::concurrent_cached;
 
 /// Memoize with the default in-memory sharded store — no `map_error`, `ty`,

--- a/README.md
+++ b/README.md
@@ -294,6 +294,25 @@ Because LRU caches require updating access recency, `ShardedLruCache`, `ShardedL
   `cache_peek_with_expiry_status` as a side-effect-free counterpart (a read with no hit/miss
   counting, LRU promotion, or TTL renewal).
 
+**Performance**
+
+v3 reworks the hot paths of the in-memory and sharded stores. Steady-state `O(1)` reads and
+capacity-bounded inserts are unchanged; the wins concentrate in a few paths (measured with
+`cargo bench --bench cache_benches`, so the exact figures are hardware- and workload-dependent):
+
+- Overwriting an existing key with `cache_set` reuses the stored key instead of re-cloning it.
+  On the timed stores this is roughly 10-30% faster, and the gain grows with key clone cost, so
+  `String`-keyed caches benefit most.
+- Bulk eviction and retention (`evict`, `retain`, `retain_latest`) and the key/iteration order
+  helpers now sweep in a single pass instead of collecting keys first, up to about 2x faster at
+  10k entries. TTL stores also sample the clock once per operation rather than once per entry.
+- Single-threaded `cache_get` hits on the sharded LRU and expiring-LRU variants resolve in one
+  hash lookup instead of two, about 5-15% faster.
+
+One deliberate tradeoff comes with the `cache_set` recency change (see the migration guide): an
+overwrite now promotes the key to most-recently-used, which adds a small cost on stores with cheap
+`Copy` keys where there is no key clone to save.
+
 **Per-Value Expiry via the `Expires` Trait**
 
 While standard timed stores (`TtlCache`, `LruTtlCache`, `TtlSortedCache`) enforce a single, global Time-To-Live (TTL) duration applied to all entries in the cache, [`ExpiringLruCache`] and [`ExpiringCache`] let each individual value determine its own expiration. This is accomplished by storing values that implement the [`Expires`] trait.

--- a/benches/cache_benches.rs
+++ b/benches/cache_benches.rs
@@ -1857,17 +1857,24 @@ fn bench_expiry_storm(c: &mut Criterion) {
     group.measurement_time(Duration::from_millis(500));
     group.throughput(Throughput::Elements(N_THREADS_STORM as u64));
 
-    // ttl=1ns: by the time the N_KEYS-entry population loop below finishes, every
-    // entry is already expired.
+    // ttl=1ns, so an entry is expired the moment it is written. Each op OVERWRITES an
+    // already-expired entry, which is itself an eviction (fires on_evict, bumps the
+    // counter) and leaves behind a fresh entry that is immediately expired again. That
+    // makes the storm self-sustaining.
+    //
+    // Reading instead would not work: there are only N_KEYS entries, so after the first
+    // N_KEYS reads drained them the remaining millions of iterations would be plain
+    // misses on a read lock, measuring no eviction work at all.
     let storm_ttl = ShardedTtlCache::<usize, usize>::new(Duration::from_nanos(1));
     for i in 0..N_KEYS {
         storm_ttl.cache_set(i, i * 2).expect("infallible");
     }
-    group.bench_function("ShardedTtlCache (all entries expired)", |b| {
+    group.bench_function("ShardedTtlCache (every op evicts an expired entry)", |b| {
         b.iter_custom(|iters| {
             let cache = storm_ttl.clone();
             run_concurrent_n!(N_THREADS_STORM, cache, iters, t, i, {
-                black_box(cache.cache_get(&read_key(i, t)).expect("infallible"));
+                let k = read_key(i, t);
+                black_box(cache.cache_set(k, k).expect("infallible"));
             })
         })
     });
@@ -1884,13 +1891,94 @@ fn bench_expiry_storm(c: &mut Criterion) {
             )
             .expect("infallible");
     }
-    group.bench_function("ShardedExpiringLruCache (all entries expired)", |b| {
-        b.iter_custom(|iters| {
-            let cache = storm_elru.clone();
-            run_concurrent_n!(N_THREADS_STORM, cache, iters, t, i, {
-                black_box(cache.cache_get(&read_key(i, t)).expect("infallible"));
+    group.bench_function(
+        "ShardedExpiringLruCache (every op evicts an expired entry)",
+        |b| {
+            b.iter_custom(|iters| {
+                let cache = storm_elru.clone();
+                run_concurrent_n!(N_THREADS_STORM, cache, iters, t, i, {
+                    let k = read_key(i, t);
+                    black_box(
+                        cache
+                            .cache_set(
+                                k,
+                                SweepExpiring {
+                                    val: k,
+                                    expired: true,
+                                },
+                            )
+                            .expect("infallible"),
+                    );
+                })
             })
-        })
+        },
+    );
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Sharded expiry sweeps: `evict()` over a fully-expired cache. The single-owner
+// "Sweeps" group does not cover the sharded stores, whose sweep walks every shard
+// under its own write lock.
+// ---------------------------------------------------------------------------
+
+fn bench_sharded_sweeps(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Sharded sweeps: evict() at N=10,000");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(200));
+    group.measurement_time(Duration::from_millis(500));
+
+    let expired_ttl_usize = || {
+        let c = ShardedTtlCache::<usize, usize>::new(Duration::from_nanos(1));
+        for i in 0..N_SWEEP {
+            c.cache_set(i, i * 2).expect("infallible");
+        }
+        c
+    };
+    group.bench_function("ShardedTtlCache evict (usize keys)", |b| {
+        b.iter_batched(
+            expired_ttl_usize,
+            |c| black_box(cached::ConcurrentCacheEvict::evict(&c)),
+            BatchSize::SmallInput,
+        )
+    });
+
+    let expired_ttl_string = || {
+        let c = ShardedTtlCache::<String, usize>::new(Duration::from_nanos(1));
+        for i in 0..N_SWEEP {
+            c.cache_set(format!("key-{i:016}"), i).expect("infallible");
+        }
+        c
+    };
+    group.bench_function("ShardedTtlCache evict (String keys)", |b| {
+        b.iter_batched(
+            expired_ttl_string,
+            |c| black_box(cached::ConcurrentCacheEvict::evict(&c)),
+            BatchSize::SmallInput,
+        )
+    });
+
+    let expired_exp_string = || {
+        let c = ShardedExpiringCache::<String, SweepExpiring>::new();
+        for i in 0..N_SWEEP {
+            c.cache_set(
+                format!("key-{i:016}"),
+                SweepExpiring {
+                    val: i,
+                    expired: true,
+                },
+            )
+            .expect("infallible");
+        }
+        c
+    };
+    group.bench_function("ShardedExpiringCache evict (String keys)", |b| {
+        b.iter_batched(
+            expired_exp_string,
+            |c| black_box(cached::ConcurrentCacheEvict::evict(&c)),
+            BatchSize::SmallInput,
+        )
     });
 
     group.finish();
@@ -2094,6 +2182,7 @@ criterion_group!(
     bench_sharded_expiring_lru_concurrent,
     bench_sharded_ttl_concurrent,
     bench_expiry_storm,
+    bench_sharded_sweeps,
     bench_sharded_poll,
     bench_sharded_build_time,
     bench_large_value_lru,

--- a/benches/cache_benches.rs
+++ b/benches/cache_benches.rs
@@ -1339,6 +1339,13 @@ fn bench_overwrite_existing_key(c: &mut Criterion) {
     // TtlSortedCache::set_and_get_mut via cache_get_or_set_with_mut on a miss (the
     // `#[cached]` write path): every key here is new, so this always takes the
     // miss -> set_and_get_mut branch.
+    //
+    // Three variants, because the unbounded/usize shape exercises none of the work this
+    // path does for real callers: with no `max_size` the size-limit branch (and the
+    // re-lookup inside it) never runs, and a `usize` key makes every key clone free. The
+    // cache also grows without bound here, so the measurement drifts into BTreeSet-insert
+    // and rehash cost. The bounded and String-keyed variants below cover the paths that
+    // owned keys and a capacity bound actually take.
     {
         let mut cache = TtlSortedCache::<usize, usize>::builder()
             .ttl(long_ttl)
@@ -1350,6 +1357,49 @@ fn bench_overwrite_existing_key(c: &mut Criterion) {
             |b| {
                 b.iter(|| {
                     let v = cache.cache_get_or_set_with_mut(key_ctr, || key_ctr);
+                    black_box(v);
+                    key_ctr += 1;
+                })
+            },
+        );
+    }
+
+    // Size-limited: every miss past the cap also runs the protected-eviction branch,
+    // which is where the removed re-lookup lived.
+    {
+        let mut cache = TtlSortedCache::<usize, usize>::builder()
+            .ttl(long_ttl)
+            .max_size(1_000)
+            .build()
+            .unwrap();
+        let mut key_ctr = 0usize;
+        group.bench_function(
+            "TtlSortedCache cache_get_or_set_with_mut (miss, size-limited)",
+            |b| {
+                b.iter(|| {
+                    let v = cache.cache_get_or_set_with_mut(key_ctr, || key_ctr);
+                    black_box(v);
+                    key_ctr += 1;
+                })
+            },
+        );
+    }
+
+    // Owned String keys, size-limited: the shape where the eliminated key clones are
+    // real allocations rather than register moves.
+    {
+        let mut cache = TtlSortedCache::<String, usize>::builder()
+            .ttl(long_ttl)
+            .max_size(1_000)
+            .build()
+            .unwrap();
+        let mut key_ctr = 0usize;
+        group.bench_function(
+            "TtlSortedCache cache_get_or_set_with_mut (miss, size-limited, String keys)",
+            |b| {
+                b.iter(|| {
+                    let key = format!("key-{key_ctr:016}");
+                    let v = cache.cache_get_or_set_with_mut(key, || key_ctr);
                     black_box(v);
                     key_ctr += 1;
                 })

--- a/benches/cache_benches.rs
+++ b/benches/cache_benches.rs
@@ -1845,9 +1845,9 @@ fn bench_sharded_ttl_concurrent(c: &mut Criterion) {
 
 // ---------------------------------------------------------------------------
 // Expiry storm: 8 threads, every entry already expired, so every concurrent read
-// takes the lazy-eviction path and contends on the single global `evictions`
-// AtomicU64 (ShardedTtlCache / ShardedExpiringLruCache both use one counter shared
-// across all shards, rather than a per-shard counter).
+// takes the lazy-eviction path and bumps that shard's `evictions` AtomicU64
+// (ShardedTtlCache / ShardedExpiringLruCache each give every shard its own counter,
+// summed at read time, rather than sharing a single global counter).
 // ---------------------------------------------------------------------------
 
 fn bench_expiry_storm(c: &mut Criterion) {

--- a/benches/cache_benches.rs
+++ b/benches/cache_benches.rs
@@ -1,10 +1,11 @@
 use cached::time::Duration;
 use cached::{
-    Cached, CachedRead, ConcurrentCached, Expires, ExpiringCache, ExpiringLruCache, LruCache,
-    LruTtlCache, ShardedLruCache, ShardedLruTtlCache, ShardedUnboundCache, TtlCache,
-    TtlSortedCache, UnboundCache,
+    Cached, CachedIter, CachedRead, ConcurrentCached, Expires, ExpiringCache, ExpiringLruCache,
+    LruCache, LruTtlCache, ShardedExpiringCache, ShardedExpiringLruCache, ShardedLruCache,
+    ShardedLruTtlCache, ShardedTtlCache, ShardedUnboundCache, TtlCache, TtlSortedCache,
+    UnboundCache,
 };
-use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use parking_lot::{Mutex, RwLock};
 use std::collections::HashMap;
 use std::hint::black_box;
@@ -22,6 +23,29 @@ impl Expires for ExpiringValue {
     fn is_expired(&self) -> bool {
         false
     }
+}
+
+/// Value type for the sweep/storm benchmarks, which need to control expiry directly
+/// (as opposed to `ExpiringValue`, which is always live) without sleeping past a real
+/// deadline in every setup closure.
+#[derive(Clone)]
+struct SweepExpiring {
+    #[allow(dead_code)]
+    val: usize,
+    expired: bool,
+}
+
+impl Expires for SweepExpiring {
+    fn is_expired(&self) -> bool {
+        self.expired
+    }
+}
+
+/// `String` key generator for the destructive-sweep benchmarks: a real heap allocation
+/// plus a re-hash on every lookup/removal, which a `usize` key can't expose.
+#[inline]
+fn skey(i: usize) -> String {
+    format!("sweep-key-{i:08}")
 }
 
 fn bench_cache_hits(c: &mut Criterion) {
@@ -322,6 +346,47 @@ macro_rules! run_concurrent {
     }};
 }
 
+/// Thread count for the expiry-storm and whole-cache-poll groups: wider than the
+/// 4-thread groups above to stress the single global `evictions` counter harder.
+const N_THREADS_STORM: usize = 8;
+
+/// Entry count for the O(n) sweep benchmarks (evict/retain/retain_latest/key_order/
+/// iter_order/`CachedIter::iter`).
+const N_SWEEP: usize = 10_000;
+
+/// Same shape as `run_concurrent!`, but with an explicit thread count instead of the
+/// fixed `N_THREADS` constant, for the 8-thread expiry-storm and poll groups.
+macro_rules! run_concurrent_n {
+    ($n_threads:expr, $cache:ident, $iters:expr, $thread_id:ident, $idx:ident, $bench_fn:block) => {{
+        let n_threads = $n_threads;
+        let ready_barrier = Arc::new(Barrier::new(n_threads + 1));
+        let start_barrier = Arc::new(Barrier::new(n_threads + 1));
+        let handles: Vec<_> = (0..n_threads)
+            .map(|t| {
+                let ready_barrier = ready_barrier.clone();
+                let start_barrier = start_barrier.clone();
+                let $cache = $cache.clone();
+                thread::spawn(move || {
+                    ready_barrier.wait();
+                    start_barrier.wait();
+                    let $thread_id = t;
+                    let iters = $iters as usize;
+                    for $idx in 0..iters {
+                        $bench_fn
+                    }
+                })
+            })
+            .collect();
+        ready_barrier.wait();
+        let start = Instant::now();
+        start_barrier.wait();
+        for h in handles {
+            h.join().expect("bench thread panicked");
+        }
+        start.elapsed()
+    }};
+}
+
 // ---- Group 1: unbounded cache -------------------------------------------------
 
 fn bench_sharded_unbound_concurrent(c: &mut Criterion) {
@@ -587,6 +652,1381 @@ fn bench_sharded_lru_ttl_concurrent(c: &mut Criterion) {
     group.finish();
 }
 
+// ---------------------------------------------------------------------------
+// Sweeps at N=10,000: evict/retain/retain_latest/key_order/iter_order/
+// CachedIter::iter. These are O(n) paths that walk every entry, sample the clock
+// per entry (evict/retain on the TTL-aware stores), and -- on the destructive ops --
+// remove doomed entries, cloning their keys along the way.
+//
+// evict/retain/retain_latest are destructive (they drain the cache), so each is
+// rebuilt from scratch per-iteration via `iter_batched`: the setup closure's cost is
+// excluded from the measurement, but it does mean the *wall time* of these functions
+// is dominated by the N_SWEEP-entry rebuild, not just the swept op -- hence the very
+// short measurement/warm-up windows below.
+//
+// LruCache has no TTL/expiry concept, so it has no `evict()`. TtlCache has no LRU
+// ordering, so it has no `key_order`/`iter_order`.
+// ---------------------------------------------------------------------------
+
+fn bench_sweeps(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Sweeps (evict/retain/order) at N=10,000");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(100));
+    group.measurement_time(Duration::from_millis(300));
+    group.throughput(Throughput::Elements(N_SWEEP as u64));
+
+    // ==== TtlCache ===========================================================
+
+    // evict(): ttl=1ns means every entry is already expired by the time the
+    // N_SWEEP-entry setup loop finishes, so evict() removes all of them.
+    group.bench_function("TtlCache evict (usize keys)", |b| {
+        b.iter_batched(
+            || {
+                let mut cache = TtlCache::builder()
+                    .ttl(Duration::from_nanos(1))
+                    .build()
+                    .unwrap();
+                for i in 0..N_SWEEP {
+                    cache.cache_set(i, i);
+                }
+                cache
+            },
+            |mut cache| black_box(cache.evict()),
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("TtlCache evict (String keys)", |b| {
+        b.iter_batched(
+            || {
+                let mut cache = TtlCache::builder()
+                    .ttl(Duration::from_nanos(1))
+                    .build()
+                    .unwrap();
+                for i in 0..N_SWEEP {
+                    cache.cache_set(skey(i), i);
+                }
+                cache
+            },
+            |mut cache| black_box(cache.evict()),
+            BatchSize::SmallInput,
+        )
+    });
+
+    // retain(): a long ttl means nothing auto-expires, so the sweep cost measured
+    // here is purely the predicate-driven removal (and doomed-key handling) of half
+    // the entries.
+    group.bench_function("TtlCache retain (usize keys)", |b| {
+        b.iter_batched(
+            || {
+                let mut cache = TtlCache::builder()
+                    .ttl(Duration::from_secs(3600))
+                    .build()
+                    .unwrap();
+                for i in 0..N_SWEEP {
+                    cache.cache_set(i, i);
+                }
+                cache
+            },
+            |mut cache| cache.retain(|k, _v| *k % 2 == 0),
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("TtlCache retain (String keys)", |b| {
+        b.iter_batched(
+            || {
+                let mut cache = TtlCache::builder()
+                    .ttl(Duration::from_secs(3600))
+                    .build()
+                    .unwrap();
+                for i in 0..N_SWEEP {
+                    cache.cache_set(skey(i), i);
+                }
+                cache
+            },
+            |mut cache| cache.retain(|_k, v| *v % 2 == 0),
+            BatchSize::SmallInput,
+        )
+    });
+
+    // CachedIter::iter(): non-destructive, so one cache serves every sample.
+    let mut ttl_iter_cache = TtlCache::builder()
+        .ttl(Duration::from_secs(3600))
+        .build()
+        .unwrap();
+    for i in 0..N_SWEEP {
+        ttl_iter_cache.cache_set(i, i);
+    }
+    group.bench_function("TtlCache CachedIter::iter (usize keys)", |b| {
+        b.iter(|| black_box(ttl_iter_cache.iter().count()))
+    });
+
+    // ==== LruTtlCache ========================================================
+
+    group.bench_function("LruTtlCache evict (usize keys)", |b| {
+        b.iter_batched(
+            || {
+                let mut cache = LruTtlCache::builder()
+                    .max_size(N_SWEEP)
+                    .ttl(Duration::from_nanos(1))
+                    .build()
+                    .unwrap();
+                for i in 0..N_SWEEP {
+                    cache.cache_set(i, i);
+                }
+                cache
+            },
+            |mut cache| black_box(cache.evict()),
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("LruTtlCache evict (String keys)", |b| {
+        b.iter_batched(
+            || {
+                let mut cache = LruTtlCache::builder()
+                    .max_size(N_SWEEP)
+                    .ttl(Duration::from_nanos(1))
+                    .build()
+                    .unwrap();
+                for i in 0..N_SWEEP {
+                    cache.cache_set(skey(i), i);
+                }
+                cache
+            },
+            |mut cache| black_box(cache.evict()),
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("LruTtlCache retain (usize keys)", |b| {
+        b.iter_batched(
+            || {
+                let mut cache = LruTtlCache::builder()
+                    .max_size(N_SWEEP)
+                    .ttl(Duration::from_secs(3600))
+                    .build()
+                    .unwrap();
+                for i in 0..N_SWEEP {
+                    cache.cache_set(i, i);
+                }
+                cache
+            },
+            |mut cache| cache.retain(|k, _v| *k % 2 == 0),
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("LruTtlCache retain (String keys)", |b| {
+        b.iter_batched(
+            || {
+                let mut cache = LruTtlCache::builder()
+                    .max_size(N_SWEEP)
+                    .ttl(Duration::from_secs(3600))
+                    .build()
+                    .unwrap();
+                for i in 0..N_SWEEP {
+                    cache.cache_set(skey(i), i);
+                }
+                cache
+            },
+            |mut cache| cache.retain(|_k, v| *v % 2 == 0),
+            BatchSize::SmallInput,
+        )
+    });
+
+    let mut lru_ttl_order_cache = LruTtlCache::builder()
+        .max_size(N_SWEEP)
+        .ttl(Duration::from_secs(3600))
+        .build()
+        .unwrap();
+    for i in 0..N_SWEEP {
+        lru_ttl_order_cache.cache_set(i, i);
+    }
+    group.bench_function("LruTtlCache key_order (usize keys)", |b| {
+        b.iter(|| black_box(lru_ttl_order_cache.key_order()))
+    });
+    group.bench_function("LruTtlCache iter_order (usize keys)", |b| {
+        b.iter(|| black_box(lru_ttl_order_cache.iter_order()))
+    });
+    group.bench_function("LruTtlCache CachedIter::iter (usize keys)", |b| {
+        b.iter(|| black_box(lru_ttl_order_cache.iter().count()))
+    });
+
+    // ==== LruCache (no TTL, so no evict()) ==================================
+
+    group.bench_function("LruCache retain (usize keys)", |b| {
+        b.iter_batched(
+            || {
+                let mut cache = LruCache::builder().max_size(N_SWEEP).build().unwrap();
+                for i in 0..N_SWEEP {
+                    cache.cache_set(i, i);
+                }
+                cache
+            },
+            |mut cache| cache.retain(|k, _v| *k % 2 == 0),
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("LruCache retain (String keys)", |b| {
+        b.iter_batched(
+            || {
+                let mut cache = LruCache::builder().max_size(N_SWEEP).build().unwrap();
+                for i in 0..N_SWEEP {
+                    cache.cache_set(skey(i), i);
+                }
+                cache
+            },
+            |mut cache| cache.retain(|_k, v| *v % 2 == 0),
+            BatchSize::SmallInput,
+        )
+    });
+
+    let mut lru_order_cache = LruCache::builder().max_size(N_SWEEP).build().unwrap();
+    for i in 0..N_SWEEP {
+        lru_order_cache.cache_set(i, i);
+    }
+    group.bench_function("LruCache key_order (usize keys)", |b| {
+        b.iter(|| black_box(lru_order_cache.key_order()))
+    });
+    group.bench_function("LruCache iter_order (usize keys)", |b| {
+        b.iter(|| black_box(lru_order_cache.iter_order()))
+    });
+    group.bench_function("LruCache CachedIter::iter (usize keys)", |b| {
+        b.iter(|| black_box(lru_order_cache.iter().count()))
+    });
+
+    // ==== ExpiringLruCache ===================================================
+
+    group.bench_function("ExpiringLruCache evict (usize keys)", |b| {
+        b.iter_batched(
+            || {
+                let mut cache = ExpiringLruCache::builder()
+                    .max_size(N_SWEEP)
+                    .build()
+                    .unwrap();
+                for i in 0..N_SWEEP {
+                    cache.cache_set(
+                        i,
+                        SweepExpiring {
+                            val: i,
+                            expired: true,
+                        },
+                    );
+                }
+                cache
+            },
+            |mut cache| black_box(cache.evict()),
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("ExpiringLruCache evict (String keys)", |b| {
+        b.iter_batched(
+            || {
+                let mut cache = ExpiringLruCache::builder()
+                    .max_size(N_SWEEP)
+                    .build()
+                    .unwrap();
+                for i in 0..N_SWEEP {
+                    cache.cache_set(
+                        skey(i),
+                        SweepExpiring {
+                            val: i,
+                            expired: true,
+                        },
+                    );
+                }
+                cache
+            },
+            |mut cache| black_box(cache.evict()),
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("ExpiringLruCache retain (usize keys)", |b| {
+        b.iter_batched(
+            || {
+                let mut cache = ExpiringLruCache::builder()
+                    .max_size(N_SWEEP)
+                    .build()
+                    .unwrap();
+                for i in 0..N_SWEEP {
+                    cache.cache_set(
+                        i,
+                        SweepExpiring {
+                            val: i,
+                            expired: false,
+                        },
+                    );
+                }
+                cache
+            },
+            |mut cache| cache.retain(|k, _v| *k % 2 == 0),
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("ExpiringLruCache retain (String keys)", |b| {
+        b.iter_batched(
+            || {
+                let mut cache = ExpiringLruCache::builder()
+                    .max_size(N_SWEEP)
+                    .build()
+                    .unwrap();
+                for i in 0..N_SWEEP {
+                    cache.cache_set(
+                        skey(i),
+                        SweepExpiring {
+                            val: i,
+                            expired: false,
+                        },
+                    );
+                }
+                cache
+            },
+            |mut cache| cache.retain(|_k, v| v.val % 2 == 0),
+            BatchSize::SmallInput,
+        )
+    });
+
+    let mut elru_order_cache = ExpiringLruCache::builder()
+        .max_size(N_SWEEP)
+        .build()
+        .unwrap();
+    for i in 0..N_SWEEP {
+        elru_order_cache.cache_set(
+            i,
+            SweepExpiring {
+                val: i,
+                expired: false,
+            },
+        );
+    }
+    group.bench_function("ExpiringLruCache key_order (usize keys)", |b| {
+        b.iter(|| black_box(elru_order_cache.key_order()))
+    });
+    group.bench_function("ExpiringLruCache iter_order (usize keys)", |b| {
+        b.iter(|| black_box(elru_order_cache.iter_order()))
+    });
+    group.bench_function("ExpiringLruCache CachedIter::iter (usize keys)", |b| {
+        b.iter(|| black_box(elru_order_cache.iter().count()))
+    });
+
+    // ==== TtlSortedCache =====================================================
+
+    group.bench_function("TtlSortedCache evict (usize keys)", |b| {
+        b.iter_batched(
+            || {
+                let mut cache = TtlSortedCache::builder()
+                    .ttl(Duration::from_nanos(1))
+                    .build()
+                    .unwrap();
+                for i in 0..N_SWEEP {
+                    let _ = cache.cache_set(i, i);
+                }
+                cache
+            },
+            |mut cache| black_box(cache.evict()),
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("TtlSortedCache evict (String keys)", |b| {
+        b.iter_batched(
+            || {
+                let mut cache = TtlSortedCache::builder()
+                    .ttl(Duration::from_nanos(1))
+                    .build()
+                    .unwrap();
+                for i in 0..N_SWEEP {
+                    let _ = cache.cache_set(skey(i), i);
+                }
+                cache
+            },
+            |mut cache| black_box(cache.evict()),
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("TtlSortedCache retain (usize keys)", |b| {
+        b.iter_batched(
+            || {
+                let mut cache = TtlSortedCache::builder()
+                    .ttl(Duration::from_secs(3600))
+                    .build()
+                    .unwrap();
+                for i in 0..N_SWEEP {
+                    let _ = cache.cache_set(i, i);
+                }
+                cache
+            },
+            |mut cache| cache.retain(|k, _v| *k % 2 == 0),
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("TtlSortedCache retain (String keys)", |b| {
+        b.iter_batched(
+            || {
+                let mut cache = TtlSortedCache::builder()
+                    .ttl(Duration::from_secs(3600))
+                    .build()
+                    .unwrap();
+                for i in 0..N_SWEEP {
+                    let _ = cache.cache_set(skey(i), i);
+                }
+                cache
+            },
+            |mut cache| cache.retain(|_k, v| *v % 2 == 0),
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("TtlSortedCache retain_latest (usize keys)", |b| {
+        b.iter_batched(
+            || {
+                let mut cache = TtlSortedCache::builder()
+                    .ttl(Duration::from_secs(3600))
+                    .build()
+                    .unwrap();
+                for i in 0..N_SWEEP {
+                    let _ = cache.cache_set(i, i);
+                }
+                cache
+            },
+            |mut cache| black_box(cache.retain_latest(N_SWEEP / 2, false)),
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("TtlSortedCache retain_latest (String keys)", |b| {
+        b.iter_batched(
+            || {
+                let mut cache = TtlSortedCache::builder()
+                    .ttl(Duration::from_secs(3600))
+                    .build()
+                    .unwrap();
+                for i in 0..N_SWEEP {
+                    let _ = cache.cache_set(skey(i), i);
+                }
+                cache
+            },
+            |mut cache| black_box(cache.retain_latest(N_SWEEP / 2, false)),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// refresh_on_hit hit path: TtlCache and LruTtlCache, refresh on vs off, so the
+// per-hit cost of re-sampling the clock and rewriting expires_at is visible as a
+// delta between the two.
+// ---------------------------------------------------------------------------
+
+fn bench_refresh_on_hit(c: &mut Criterion) {
+    let mut group = c.benchmark_group("TTL refresh_on_hit: hit path delta");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(100));
+    group.measurement_time(Duration::from_millis(300));
+
+    let limit = 1000;
+    let query_key = 500;
+    let long_ttl = Duration::from_secs(3600);
+
+    for refresh in [false, true] {
+        let mut cache = TtlCache::builder()
+            .ttl(long_ttl)
+            .refresh_on_hit(refresh)
+            .build()
+            .unwrap();
+        for i in 0..limit {
+            cache.cache_set(i, i * 2);
+        }
+        group.bench_function(format!("TtlCache hit (refresh_on_hit={refresh})"), |b| {
+            b.iter(|| {
+                black_box(cache.cache_get(black_box(&query_key)));
+            })
+        });
+    }
+
+    for refresh in [false, true] {
+        let mut cache = LruTtlCache::builder()
+            .max_size(limit)
+            .ttl(long_ttl)
+            .refresh_on_hit(refresh)
+            .build()
+            .unwrap();
+        for i in 0..limit {
+            cache.cache_set(i, i * 2);
+        }
+        group.bench_function(format!("LruTtlCache hit (refresh_on_hit={refresh})"), |b| {
+            b.iter(|| {
+                black_box(cache.cache_get(black_box(&query_key)));
+            })
+        });
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Overwrite path: cache_set over an EXISTING key, with and without an on_evict
+// callback configured. The callback only fires when the displaced value had already
+// expired, but implementations may still pay for a key clone (or other setup) on every
+// call whenever a callback is *configured*, whether or not it ends up firing -- this
+// group makes that delta visible.
+// ---------------------------------------------------------------------------
+
+fn bench_overwrite_existing_key(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Overwrite: cache_set on an existing (live) key");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(100));
+    group.measurement_time(Duration::from_millis(300));
+
+    let limit = 1000;
+    let key = 500;
+    let long_ttl = Duration::from_secs(3600);
+
+    // TtlCache: on_evict() returns `Self`, so the callback can be attached conditionally.
+    for with_callback in [false, true] {
+        let mut builder = TtlCache::<usize, usize>::builder().ttl(long_ttl);
+        if with_callback {
+            builder = builder.on_evict(|_k: &usize, _v: &usize| {});
+        }
+        let mut cache = builder.build().unwrap();
+        for i in 0..limit {
+            cache.cache_set(i, i);
+        }
+        let mut val = 0usize;
+        group.bench_function(
+            format!("TtlCache cache_set overwrite (on_evict={with_callback})"),
+            |b| {
+                b.iter(|| {
+                    cache.cache_set(black_box(key), black_box(val));
+                    val = val.wrapping_add(1);
+                })
+            },
+        );
+    }
+
+    // LruTtlCache: on_evict() is a typestate transition (NoEvict -> HasEvict), so the
+    // two configurations need separate builder chains rather than a runtime branch.
+    {
+        let mut cache = LruTtlCache::<usize, usize>::builder()
+            .max_size(limit)
+            .ttl(long_ttl)
+            .build()
+            .unwrap();
+        for i in 0..limit {
+            cache.cache_set(i, i);
+        }
+        let mut val = 0usize;
+        group.bench_function("LruTtlCache cache_set overwrite (on_evict=false)", |b| {
+            b.iter(|| {
+                cache.cache_set(black_box(key), black_box(val));
+                val = val.wrapping_add(1);
+            })
+        });
+    }
+    {
+        let mut cache = LruTtlCache::<usize, usize>::builder()
+            .max_size(limit)
+            .ttl(long_ttl)
+            .on_evict(|_k: &usize, _v: &usize| {})
+            .build()
+            .unwrap();
+        for i in 0..limit {
+            cache.cache_set(i, i);
+        }
+        let mut val = 0usize;
+        group.bench_function("LruTtlCache cache_set overwrite (on_evict=true)", |b| {
+            b.iter(|| {
+                cache.cache_set(black_box(key), black_box(val));
+                val = val.wrapping_add(1);
+            })
+        });
+    }
+
+    // TtlSortedCache
+    for with_callback in [false, true] {
+        let mut builder = TtlSortedCache::<usize, usize>::builder().ttl(long_ttl);
+        if with_callback {
+            builder = builder.on_evict(|_k: &usize, _v: &usize| {});
+        }
+        let mut cache = builder.build().unwrap();
+        for i in 0..limit {
+            let _ = cache.cache_set(i, i);
+        }
+        let mut val = 0usize;
+        group.bench_function(
+            format!("TtlSortedCache cache_set overwrite (on_evict={with_callback})"),
+            |b| {
+                b.iter(|| {
+                    let _ = cache.cache_set(black_box(key), black_box(val));
+                    val = val.wrapping_add(1);
+                })
+            },
+        );
+    }
+
+    // ExpiringLruCache: cache_set clones the key up front whenever a callback is
+    // configured (to have it ready if the displaced value turns out to be expired),
+    // even though this overwrite is always of a live entry and the callback never
+    // fires -- this is exactly the wasted-clone cost this group is meant to expose.
+    for with_callback in [false, true] {
+        let mut builder = ExpiringLruCache::<usize, SweepExpiring>::builder().max_size(limit);
+        if with_callback {
+            builder = builder.on_evict(|_k: &usize, _v: &SweepExpiring| {});
+        }
+        let mut cache = builder.build().unwrap();
+        for i in 0..limit {
+            cache.cache_set(
+                i,
+                SweepExpiring {
+                    val: i,
+                    expired: false,
+                },
+            );
+        }
+        let mut val = 0usize;
+        group.bench_function(
+            format!("ExpiringLruCache cache_set overwrite (on_evict={with_callback})"),
+            |b| {
+                b.iter(|| {
+                    cache.cache_set(
+                        black_box(key),
+                        SweepExpiring {
+                            val: black_box(val),
+                            expired: false,
+                        },
+                    );
+                    val = val.wrapping_add(1);
+                })
+            },
+        );
+    }
+
+    // Same overwrite, but with a `String` key: `usize` is `Copy`, so the unconditional
+    // `k.clone()` above is invisible in the usize benchmark above -- a `String` clone is
+    // a real heap allocation and should make the on_evict=true delta visible.
+    for with_callback in [false, true] {
+        let skey_fixed = skey(key);
+        let mut builder = ExpiringLruCache::<String, SweepExpiring>::builder().max_size(limit);
+        if with_callback {
+            builder = builder.on_evict(|_k: &String, _v: &SweepExpiring| {});
+        }
+        let mut cache = builder.build().unwrap();
+        for i in 0..limit {
+            cache.cache_set(
+                skey(i),
+                SweepExpiring {
+                    val: i,
+                    expired: false,
+                },
+            );
+        }
+        let mut val = 0usize;
+        group.bench_function(
+            format!(
+                "ExpiringLruCache cache_set overwrite (on_evict={with_callback}) (String keys)"
+            ),
+            |b| {
+                b.iter(|| {
+                    cache.cache_set(
+                        black_box(skey_fixed.clone()),
+                        SweepExpiring {
+                            val: black_box(val),
+                            expired: false,
+                        },
+                    );
+                    val = val.wrapping_add(1);
+                })
+            },
+        );
+    }
+
+    // TtlSortedCache::set_and_get_mut via cache_get_or_set_with_mut on a miss (the
+    // `#[cached]` write path): every key here is new, so this always takes the
+    // miss -> set_and_get_mut branch.
+    {
+        let mut cache = TtlSortedCache::<usize, usize>::builder()
+            .ttl(long_ttl)
+            .build()
+            .unwrap();
+        let mut key_ctr = 0usize;
+        group.bench_function(
+            "TtlSortedCache cache_get_or_set_with_mut (miss -> set_and_get_mut)",
+            |b| {
+                b.iter(|| {
+                    let v = cache.cache_get_or_set_with_mut(key_ctr, || key_ctr);
+                    black_box(v);
+                    key_ctr += 1;
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Whole-cache ops: cache_clear_with_on_evict (with/without callback, LRU family),
+// len(), and metrics() on a 256-shard cache.
+// ---------------------------------------------------------------------------
+
+fn bench_whole_cache_ops(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Whole-cache ops: clear/len/metrics");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(100));
+    group.measurement_time(Duration::from_millis(300));
+
+    let limit = 1000;
+    let long_ttl = Duration::from_secs(3600);
+
+    // LruCache
+    for with_callback in [false, true] {
+        group.bench_function(
+            format!("LruCache cache_clear_with_on_evict (on_evict={with_callback})"),
+            |b| {
+                b.iter_batched(
+                    || {
+                        let mut builder = LruCache::<usize, usize>::builder().max_size(limit);
+                        if with_callback {
+                            builder = builder.on_evict(|_k: &usize, _v: &usize| {});
+                        }
+                        let mut cache = builder.build().unwrap();
+                        for i in 0..limit {
+                            cache.cache_set(i, i);
+                        }
+                        cache
+                    },
+                    |mut cache| cache.cache_clear_with_on_evict(),
+                    BatchSize::SmallInput,
+                )
+            },
+        );
+    }
+
+    // LruTtlCache: on_evict() typestate again means two explicit blocks.
+    group.bench_function(
+        "LruTtlCache cache_clear_with_on_evict (on_evict=false)",
+        |b| {
+            b.iter_batched(
+                || {
+                    let mut cache = LruTtlCache::<usize, usize>::builder()
+                        .max_size(limit)
+                        .ttl(long_ttl)
+                        .build()
+                        .unwrap();
+                    for i in 0..limit {
+                        cache.cache_set(i, i);
+                    }
+                    cache
+                },
+                |mut cache| cache.cache_clear_with_on_evict(),
+                BatchSize::SmallInput,
+            )
+        },
+    );
+    group.bench_function(
+        "LruTtlCache cache_clear_with_on_evict (on_evict=true)",
+        |b| {
+            b.iter_batched(
+                || {
+                    let mut cache = LruTtlCache::<usize, usize>::builder()
+                        .max_size(limit)
+                        .ttl(long_ttl)
+                        .on_evict(|_k: &usize, _v: &usize| {})
+                        .build()
+                        .unwrap();
+                    for i in 0..limit {
+                        cache.cache_set(i, i);
+                    }
+                    cache
+                },
+                |mut cache| cache.cache_clear_with_on_evict(),
+                BatchSize::SmallInput,
+            )
+        },
+    );
+
+    // ExpiringLruCache
+    for with_callback in [false, true] {
+        group.bench_function(
+            format!("ExpiringLruCache cache_clear_with_on_evict (on_evict={with_callback})"),
+            |b| {
+                b.iter_batched(
+                    || {
+                        let mut builder =
+                            ExpiringLruCache::<usize, SweepExpiring>::builder().max_size(limit);
+                        if with_callback {
+                            builder = builder.on_evict(|_k: &usize, _v: &SweepExpiring| {});
+                        }
+                        let mut cache = builder.build().unwrap();
+                        for i in 0..limit {
+                            cache.cache_set(
+                                i,
+                                SweepExpiring {
+                                    val: i,
+                                    expired: false,
+                                },
+                            );
+                        }
+                        cache
+                    },
+                    |mut cache| cache.cache_clear_with_on_evict(),
+                    BatchSize::SmallInput,
+                )
+            },
+        );
+    }
+
+    // len()/metrics() on a 256-shard cache: both are O(shards) fan-outs, so a large
+    // shard count makes their cost visible.
+    let big_shard_cache = ShardedUnboundCache::<usize, usize>::builder()
+        .shards(256)
+        .build()
+        .unwrap();
+    for i in 0..N_KEYS {
+        big_shard_cache.cache_set(i, i * 2).expect("infallible");
+    }
+    group.bench_function("ShardedUnboundCache len() (256 shards)", |b| {
+        b.iter(|| black_box(big_shard_cache.len()))
+    });
+    group.bench_function("ShardedUnboundCache metrics() (256 shards)", |b| {
+        b.iter(|| black_box(big_shard_cache.metrics()))
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Sharded single-threaded per-op cache_get hit for all six sharded stores. Only a
+// 4-thread aggregate exists elsewhere in this file, which hides per-op regressions
+// (e.g. a single-shard lock/hash/clone cost that gets amortized away in the aggregate).
+// ---------------------------------------------------------------------------
+
+fn bench_sharded_single_threaded_hit(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Sharded stores: single-threaded cache_get hit");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(100));
+    group.measurement_time(Duration::from_millis(300));
+
+    let limit = N_KEYS;
+    let query_key = N_KEYS / 2;
+    let long_ttl = Duration::from_secs(3600);
+
+    let unbound = ShardedUnboundCache::<usize, usize>::builder()
+        .build()
+        .unwrap();
+    for i in 0..limit {
+        unbound.cache_set(i, i * 2).expect("infallible");
+    }
+    group.bench_function("ShardedUnboundCache", |b| {
+        b.iter(|| {
+            black_box(
+                unbound
+                    .cache_get(black_box(&query_key))
+                    .expect("infallible"),
+            )
+        })
+    });
+
+    let lru = ShardedLruCache::<usize, usize>::builder()
+        .max_size(limit)
+        .build()
+        .unwrap();
+    for i in 0..limit {
+        lru.cache_set(i, i * 2).expect("infallible");
+    }
+    group.bench_function("ShardedLruCache", |b| {
+        b.iter(|| black_box(lru.cache_get(black_box(&query_key)).expect("infallible")))
+    });
+
+    let lru_ttl = ShardedLruTtlCache::<usize, usize>::builder()
+        .max_size(limit)
+        .ttl(long_ttl)
+        .build()
+        .unwrap();
+    for i in 0..limit {
+        lru_ttl.cache_set(i, i * 2).expect("infallible");
+    }
+    group.bench_function("ShardedLruTtlCache", |b| {
+        b.iter(|| {
+            black_box(
+                lru_ttl
+                    .cache_get(black_box(&query_key))
+                    .expect("infallible"),
+            )
+        })
+    });
+
+    let ttl = ShardedTtlCache::<usize, usize>::builder()
+        .ttl(long_ttl)
+        .build()
+        .unwrap();
+    for i in 0..limit {
+        ttl.cache_set(i, i * 2).expect("infallible");
+    }
+    group.bench_function("ShardedTtlCache", |b| {
+        b.iter(|| black_box(ttl.cache_get(black_box(&query_key)).expect("infallible")))
+    });
+
+    let expiring = ShardedExpiringCache::<usize, ExpiringValue>::builder()
+        .build()
+        .unwrap();
+    for i in 0..limit {
+        expiring
+            .cache_set(i, ExpiringValue { val: i })
+            .expect("infallible");
+    }
+    group.bench_function("ShardedExpiringCache", |b| {
+        b.iter(|| {
+            black_box(
+                expiring
+                    .cache_get(black_box(&query_key))
+                    .expect("infallible"),
+            )
+        })
+    });
+
+    let expiring_lru = ShardedExpiringLruCache::<usize, ExpiringValue>::builder()
+        .max_size(limit)
+        .build()
+        .unwrap();
+    for i in 0..limit {
+        expiring_lru
+            .cache_set(i, ExpiringValue { val: i })
+            .expect("infallible");
+    }
+    group.bench_function("ShardedExpiringLruCache", |b| {
+        b.iter(|| {
+            black_box(
+                expiring_lru
+                    .cache_get(black_box(&query_key))
+                    .expect("infallible"),
+            )
+        })
+    });
+
+    group.finish();
+}
+
+// ---- Group 4: ExpiringLruCache -------------------------------------------------
+
+fn bench_sharded_expiring_lru_concurrent(c: &mut Criterion) {
+    let cap = 4 * N_KEYS;
+
+    let mut group =
+        c.benchmark_group("Concurrent Reads: ShardedExpiringLruCache vs Mutex<ExpiringLruCache>");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(200));
+    group.measurement_time(Duration::from_millis(500));
+    group.throughput(Throughput::Elements(N_THREADS as u64));
+
+    let mutex_elru: Arc<Mutex<ExpiringLruCache<usize, ExpiringValue>>> = Arc::new(Mutex::new(
+        ExpiringLruCache::builder().max_size(cap).build().unwrap(),
+    ));
+    {
+        let mut g = mutex_elru.lock();
+        for i in 0..N_KEYS {
+            g.cache_set(i, ExpiringValue { val: i });
+        }
+    }
+    group.bench_function("Mutex<ExpiringLruCache>", |b| {
+        b.iter_custom(|iters| {
+            let cache = mutex_elru.clone();
+            run_concurrent!(cache, iters, t, i, {
+                black_box(cache.lock().cache_get(&read_key(i, t)));
+            })
+        })
+    });
+
+    let sharded_elru = ShardedExpiringLruCache::<usize, ExpiringValue>::builder()
+        .max_size(cap)
+        .build()
+        .unwrap();
+    for i in 0..N_KEYS {
+        sharded_elru
+            .cache_set(i, ExpiringValue { val: i })
+            .expect("infallible");
+    }
+    group.bench_function("ShardedExpiringLruCache", |b| {
+        b.iter_custom(|iters| {
+            let cache = sharded_elru.clone();
+            run_concurrent!(cache, iters, t, i, {
+                black_box(cache.cache_get(&read_key(i, t)).expect("infallible"));
+            })
+        })
+    });
+
+    group.finish();
+
+    let mut group =
+        c.benchmark_group("Concurrent Writes: ShardedExpiringLruCache vs Mutex<ExpiringLruCache>");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(200));
+    group.measurement_time(Duration::from_millis(500));
+    group.throughput(Throughput::Elements(N_THREADS as u64));
+
+    let mutex_elru_w: Arc<Mutex<ExpiringLruCache<usize, ExpiringValue>>> = Arc::new(Mutex::new(
+        ExpiringLruCache::builder().max_size(cap).build().unwrap(),
+    ));
+    group.bench_function("Mutex<ExpiringLruCache>", |b| {
+        b.iter_custom(|iters| {
+            let cache = mutex_elru_w.clone();
+            run_concurrent!(cache, iters, t, i, {
+                cache
+                    .lock()
+                    .cache_set(write_key(i, t), ExpiringValue { val: i });
+            })
+        })
+    });
+
+    let sharded_elru_w = ShardedExpiringLruCache::<usize, ExpiringValue>::builder()
+        .max_size(cap)
+        .build()
+        .unwrap();
+    group.bench_function("ShardedExpiringLruCache", |b| {
+        b.iter_custom(|iters| {
+            let cache = sharded_elru_w.clone();
+            run_concurrent!(cache, iters, t, i, {
+                cache
+                    .cache_set(write_key(i, t), ExpiringValue { val: i })
+                    .expect("infallible");
+            })
+        })
+    });
+
+    group.finish();
+}
+
+// ---- Group 5: TtlCache (unbounded, TTL only) -----------------------------------
+
+fn bench_sharded_ttl_concurrent(c: &mut Criterion) {
+    let long_ttl = Duration::from_secs(3600);
+
+    let mut group = c.benchmark_group("Concurrent Reads: ShardedTtlCache vs Mutex<TtlCache>");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(200));
+    group.measurement_time(Duration::from_millis(500));
+    group.throughput(Throughput::Elements(N_THREADS as u64));
+
+    let mutex_ttl: Arc<Mutex<TtlCache<usize, usize>>> = Arc::new(Mutex::new(
+        TtlCache::builder().ttl(long_ttl).build().unwrap(),
+    ));
+    {
+        let mut g = mutex_ttl.lock();
+        for i in 0..N_KEYS {
+            g.cache_set(i, i * 2);
+        }
+    }
+    group.bench_function("Mutex<TtlCache>", |b| {
+        b.iter_custom(|iters| {
+            let cache = mutex_ttl.clone();
+            run_concurrent!(cache, iters, t, i, {
+                black_box(cache.lock().cache_get(&read_key(i, t)));
+            })
+        })
+    });
+
+    let sharded_ttl_no_refresh = ShardedTtlCache::<usize, usize>::builder()
+        .ttl(long_ttl)
+        .refresh_on_hit(false)
+        .build()
+        .unwrap();
+    for i in 0..N_KEYS {
+        sharded_ttl_no_refresh
+            .cache_set(i, i * 2)
+            .expect("infallible");
+    }
+    group.bench_function("ShardedTtlCache (refresh_on_hit=false)", |b| {
+        b.iter_custom(|iters| {
+            let cache = sharded_ttl_no_refresh.clone();
+            run_concurrent!(cache, iters, t, i, {
+                black_box(cache.cache_get(&read_key(i, t)).expect("infallible"));
+            })
+        })
+    });
+
+    let sharded_ttl_refresh = ShardedTtlCache::<usize, usize>::builder()
+        .ttl(long_ttl)
+        .refresh_on_hit(true)
+        .build()
+        .unwrap();
+    for i in 0..N_KEYS {
+        sharded_ttl_refresh.cache_set(i, i * 2).expect("infallible");
+    }
+    group.bench_function("ShardedTtlCache (refresh_on_hit=true)", |b| {
+        b.iter_custom(|iters| {
+            let cache = sharded_ttl_refresh.clone();
+            run_concurrent!(cache, iters, t, i, {
+                black_box(cache.cache_get(&read_key(i, t)).expect("infallible"));
+            })
+        })
+    });
+
+    group.finish();
+
+    let mut group = c.benchmark_group("Concurrent Writes: ShardedTtlCache vs Mutex<TtlCache>");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(200));
+    group.measurement_time(Duration::from_millis(500));
+    group.throughput(Throughput::Elements(N_THREADS as u64));
+
+    let mutex_ttl_w: Arc<Mutex<TtlCache<usize, usize>>> = Arc::new(Mutex::new(
+        TtlCache::builder().ttl(long_ttl).build().unwrap(),
+    ));
+    group.bench_function("Mutex<TtlCache>", |b| {
+        b.iter_custom(|iters| {
+            let cache = mutex_ttl_w.clone();
+            run_concurrent!(cache, iters, t, i, {
+                cache.lock().cache_set(write_key(i, t), i * 2);
+            })
+        })
+    });
+
+    let sharded_ttl_w = ShardedTtlCache::<usize, usize>::builder()
+        .ttl(long_ttl)
+        .build()
+        .unwrap();
+    group.bench_function("ShardedTtlCache", |b| {
+        b.iter_custom(|iters| {
+            let cache = sharded_ttl_w.clone();
+            run_concurrent!(cache, iters, t, i, {
+                cache.cache_set(write_key(i, t), i * 2).expect("infallible");
+            })
+        })
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Expiry storm: 8 threads, every entry already expired, so every concurrent read
+// takes the lazy-eviction path and contends on the single global `evictions`
+// AtomicU64 (ShardedTtlCache / ShardedExpiringLruCache both use one counter shared
+// across all shards, rather than a per-shard counter).
+// ---------------------------------------------------------------------------
+
+fn bench_expiry_storm(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Expiry storm: 8 threads, every read is a lazy eviction");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(200));
+    group.measurement_time(Duration::from_millis(500));
+    group.throughput(Throughput::Elements(N_THREADS_STORM as u64));
+
+    // ttl=1ns: by the time the N_KEYS-entry population loop below finishes, every
+    // entry is already expired.
+    let storm_ttl = ShardedTtlCache::<usize, usize>::new(Duration::from_nanos(1));
+    for i in 0..N_KEYS {
+        storm_ttl.cache_set(i, i * 2).expect("infallible");
+    }
+    group.bench_function("ShardedTtlCache (all entries expired)", |b| {
+        b.iter_custom(|iters| {
+            let cache = storm_ttl.clone();
+            run_concurrent_n!(N_THREADS_STORM, cache, iters, t, i, {
+                black_box(cache.cache_get(&read_key(i, t)).expect("infallible"));
+            })
+        })
+    });
+
+    let storm_elru = ShardedExpiringLruCache::<usize, SweepExpiring>::new(N_KEYS);
+    for i in 0..N_KEYS {
+        storm_elru
+            .cache_set(
+                i,
+                SweepExpiring {
+                    val: i,
+                    expired: true,
+                },
+            )
+            .expect("infallible");
+    }
+    group.bench_function("ShardedExpiringLruCache (all entries expired)", |b| {
+        b.iter_custom(|iters| {
+            let cache = storm_elru.clone();
+            run_concurrent_n!(N_THREADS_STORM, cache, iters, t, i, {
+                black_box(cache.cache_get(&read_key(i, t)).expect("infallible"));
+            })
+        })
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// 8 threads polling len()/metrics() concurrently against a live, populated cache.
+// ---------------------------------------------------------------------------
+
+fn bench_sharded_poll(c: &mut Criterion) {
+    let mut group = c.benchmark_group("8 threads polling len()/metrics() concurrently");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(200));
+    group.measurement_time(Duration::from_millis(500));
+    group.throughput(Throughput::Elements(N_THREADS_STORM as u64));
+
+    let poll_cache = ShardedUnboundCache::<usize, usize>::builder()
+        .build()
+        .unwrap();
+    for i in 0..N_KEYS {
+        poll_cache.cache_set(i, i * 2).expect("infallible");
+    }
+
+    group.bench_function("ShardedUnboundCache len()", |b| {
+        b.iter_custom(|iters| {
+            let cache = poll_cache.clone();
+            run_concurrent_n!(N_THREADS_STORM, cache, iters, _t, _i, {
+                black_box(cache.len());
+            })
+        })
+    });
+
+    group.bench_function("ShardedUnboundCache metrics()", |b| {
+        b.iter_custom(|iters| {
+            let cache = poll_cache.clone();
+            run_concurrent_n!(N_THREADS_STORM, cache, iters, _t, _i, {
+                black_box(cache.metrics());
+            })
+        })
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Build time: builder().build() for each sharded store, at the default shard count.
+// The default shard count calls `available_parallelism()` on every build, which
+// parses /proc files on Linux.
+// ---------------------------------------------------------------------------
+
+fn bench_sharded_build_time(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Sharded store build() time (default shard count)");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(50));
+    group.measurement_time(Duration::from_millis(200));
+
+    group.bench_function("ShardedUnboundCache::builder().build()", |b| {
+        b.iter(|| {
+            let cache = ShardedUnboundCache::<usize, usize>::builder()
+                .build()
+                .unwrap();
+            black_box(cache);
+        })
+    });
+
+    group.bench_function("ShardedLruCache::builder().build()", |b| {
+        b.iter(|| {
+            let cache = ShardedLruCache::<usize, usize>::builder()
+                .max_size(1000)
+                .build()
+                .unwrap();
+            black_box(cache);
+        })
+    });
+
+    group.bench_function("ShardedLruTtlCache::builder().build()", |b| {
+        b.iter(|| {
+            let cache = ShardedLruTtlCache::<usize, usize>::builder()
+                .max_size(1000)
+                .ttl(Duration::from_secs(3600))
+                .build()
+                .unwrap();
+            black_box(cache);
+        })
+    });
+
+    group.bench_function("ShardedTtlCache::builder().build()", |b| {
+        b.iter(|| {
+            let cache = ShardedTtlCache::<usize, usize>::builder()
+                .ttl(Duration::from_secs(3600))
+                .build()
+                .unwrap();
+            black_box(cache);
+        })
+    });
+
+    group.bench_function("ShardedExpiringCache::builder().build()", |b| {
+        b.iter(|| {
+            let cache = ShardedExpiringCache::<usize, ExpiringValue>::builder()
+                .build()
+                .unwrap();
+            black_box(cache);
+        })
+    });
+
+    group.bench_function("ShardedExpiringLruCache::builder().build()", |b| {
+        b.iter(|| {
+            let cache = ShardedExpiringLruCache::<usize, ExpiringValue>::builder()
+                .max_size(1000)
+                .build()
+                .unwrap();
+            black_box(cache);
+        })
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Large-V LRU: LruCache<usize, [u8; 512]> hit/insert/eviction. Decision instrument
+// for a proposed LRU node-layout change -- this group exists so that change can be
+// judged; it does not itself change any store code.
+// ---------------------------------------------------------------------------
+
+fn bench_large_value_lru(c: &mut Criterion) {
+    let mut group = c.benchmark_group("LruCache<usize, [u8; 512]>: large-value node layout");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(100));
+    group.measurement_time(Duration::from_millis(300));
+
+    let capacity = 1000;
+
+    let mut lru: LruCache<usize, [u8; 512]> =
+        LruCache::builder().max_size(capacity).build().unwrap();
+    for i in 0..capacity {
+        lru.cache_set(i, [i as u8; 512]);
+    }
+    let query_key = capacity / 2;
+    group.bench_function("hit", |b| {
+        b.iter(|| {
+            black_box(lru.cache_get(black_box(&query_key)));
+        })
+    });
+
+    group.bench_function("insert (no eviction)", |b| {
+        let mut cache: LruCache<usize, [u8; 512]> =
+            LruCache::builder().max_size(100_000).build().unwrap();
+        let mut key = 0;
+        b.iter(|| {
+            cache.cache_set(key, [key as u8; 512]);
+            key += 1;
+        })
+    });
+
+    let mut lru_full: LruCache<usize, [u8; 512]> =
+        LruCache::builder().max_size(capacity).build().unwrap();
+    for i in 0..capacity {
+        lru_full.cache_set(i, [i as u8; 512]);
+    }
+    let mut key = capacity;
+    group.bench_function("eviction overhead", |b| {
+        b.iter(|| {
+            lru_full.cache_set(key, [key as u8; 512]);
+            key += 1;
+        })
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Clock cost: a standalone micro-benchmark of `Instant::now()` itself, so the clock
+// cost is recorded in the baseline rather than being a remembered constant.
+// ---------------------------------------------------------------------------
+
+fn bench_instant_now(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Clock cost");
+    group.sample_size(50);
+    group.warm_up_time(Duration::from_millis(300));
+    group.measurement_time(Duration::from_secs(1));
+
+    group.bench_function("Instant::now()", |b| b.iter(|| black_box(Instant::now())));
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_cache_hits,
@@ -596,5 +2036,17 @@ criterion_group!(
     bench_sharded_unbound_concurrent,
     bench_sharded_lru_concurrent,
     bench_sharded_lru_ttl_concurrent,
+    bench_sweeps,
+    bench_refresh_on_hit,
+    bench_overwrite_existing_key,
+    bench_whole_cache_ops,
+    bench_sharded_single_threaded_hit,
+    bench_sharded_expiring_lru_concurrent,
+    bench_sharded_ttl_concurrent,
+    bench_expiry_storm,
+    bench_sharded_poll,
+    bench_sharded_build_time,
+    bench_large_value_lru,
+    bench_instant_now,
 );
 criterion_main!(benches);

--- a/docs/migrations/2.0-to-3.0-human.md
+++ b/docs/migrations/2.0-to-3.0-human.md
@@ -436,6 +436,15 @@ LRU recency, and refreshed TTL on refresh-on-hit stores. The new implementation 
 things and reports expired entries as absent. No code change is required; this is a behavioral
 note for callers who relied on the side effects of the old `contains`.
 
+### `cache_set` over an existing key now promotes it to most-recently-used
+
+Overwriting an existing key with `cache_set` moves it to most-recently-used instead of leaving it
+in place. On the LRU-family stores (`LruCache`, `LruTtlCache`, `ExpiringLruCache`, and their
+sharded forms) this changes which entry a capacity eviction picks in overwrite-heavy workloads:
+the overwritten key survives longer, and `iter_order` / `value_order` after an overwrite change
+accordingly. There is no API that writes a value without touching recency; `cache_peek` and
+`cache_contains` remain non-promoting.
+
 ---
 
 ## Cargo.toml

--- a/docs/migrations/2.0-to-3.0.md
+++ b/docs/migrations/2.0-to-3.0.md
@@ -1658,6 +1658,26 @@ No code change is required. The trait-level default of `Cached::cache_contains` 
 get-based, so a custom `impl Cached` that does not override `cache_contains` keeps the previous
 side-effecting behavior.
 
+### 76. `cache_set` over an existing key promotes it to most-recently-used
+
+`cache_set` over an existing key now promotes that key to most-recently-used. Previously the
+value was replaced in place and the entry kept its position in the eviction order. This affects
+`LruCache`, `LruTtlCache`, `ExpiringLruCache`, `ShardedLruCache`, `ShardedLruTtlCache`, and
+`ShardedExpiringLruCache`, and it changes which entry a capacity eviction selects in
+overwrite-heavy workloads: the overwritten key survives longer and another key becomes the
+victim. It also changes `iter_order` / `value_order` after an overwrite, and the `on_evict`
+victim sequence. It resolves a divergence on `ShardedLruTtlCache` / `ShardedExpiringLruCache`,
+where configuring an `on_evict` callback changed eviction order because the callback branch
+promoted an overwritten entry and the no-callback branch did not; both branches now promote.
+
+Detection: code that overwrites existing keys with `cache_set` and relies on capacity eviction
+selecting the least-recently-inserted entry, or that asserts on `iter_order` / `value_order`
+after an overwrite.
+
+Action: none required for correctness. There is no public API that writes a value without
+touching recency; `cache_peek`, `cache_peek_with_expiry_status`, and `cache_contains` remain
+non-promoting reads.
+
 ## Required Cargo.toml change
 
 ```toml
@@ -1732,4 +1752,5 @@ has a breaking change this major, see #51).
   - `` `sync_writes_buckets` only applies to `sync_writes = "by_key"` `` → add `sync_writes = "by_key"` to opt into per-key locking, or remove `sync_writes_buckets` to keep no-synchronization behavior (#68).
   - `no method named disk_directory` on a `RedbCacheBuilder` → renamed to `disk_dir` (#69).
   - `no method named set_ttl`/`ttl`/`unset_ttl`/`refresh_on_hit`/`set_refresh_on_hit` on a `ShardedTtlCache`/`ShardedLruTtlCache` value → `use cached::ConcurrentCacheTtl;` or the prelude (#70).
+  - no compile error, but a capacity eviction now picks a different victim after overwriting an existing key with `cache_set`, or `iter_order`/`value_order` differ after an overwrite → `cache_set` now promotes the overwritten key to most-recently-used (#76).
 - `cargo test` — no behavior changes beyond the above; disk caches will be empty on first run after upgrade (format change). The default `#[cached]` write behavior is unchanged from 2.x (no synchronization); `sync_writes = "by_key"` is an opt-in (#39).

--- a/specs/design/0037-sharded-lru-default-shard-cap.md
+++ b/specs/design/0037-sharded-lru-default-shard-cap.md
@@ -58,7 +58,7 @@ For caches built through the default (no explicit `.shards(n)`) path with a `max
 
 - `capacity()`: the effective total capacity is smaller for small `max_size` values on
   high-core-count machines, though it can still exceed `max_size` when the 16-per-shard floor
-  applies (e.g. `max_size = 100` now yields 8 shards x 16 = 128, versus 256 shards x 16 = 4096
+  applies (e.g. `max_size = 100` would yield 8 shards x 16 = 128, versus 256 shards x 16 = 4096
   before).
 - `shards()`: reports the capped default shard count, not the raw
   `available_parallelism() * 4` figure.

--- a/specs/design/0037-sharded-lru-default-shard-cap.md
+++ b/specs/design/0037-sharded-lru-default-shard-cap.md
@@ -1,0 +1,87 @@
+# 0037 - sharded LRU default shard count bounded by max_size
+
+Status: Not implemented
+
+## Current state
+
+The sharded LRU-family builders (`ShardedLruCacheBuilder`, and the LRU-half of
+`ShardedLruTtlCacheBuilder` / `ShardedExpiringLruCacheBuilder`) derive the default shard count
+from `default_shard_count()`: `available_parallelism() * 4`, clamped to `[8, 1024]` and rounded up
+to a power of two. This computation has no reference to the requested `max_size` at all.
+
+Combined with two other pieces of existing behavior, this makes the default path allocate far
+more capacity than requested for a bounded cache on a high-core-count machine:
+
+- `per_shard_cap_from_total` applies a 16-entries-per-shard floor whenever `n_shards > 1`, so a
+  small `max_size` divided across many shards still gives each shard at least 16 slots.
+- Each shard's `LruCache::builder().build()` eagerly preallocates: `HashTable::try_reserve(cap)`
+  plus `LRUList::try_with_capacity(cap)`.
+
+`ShardedLruCache::new(100)` on a 64-core box resolves to `default_shard_count() == 256`, and
+`per_shard_cap_from_total(100, 256)` applies the 16-per-shard floor, yielding 256 shards x 16 =
+4096 effective capacity: 256 hash tables and 256 `Vec`s eagerly allocated for a cache asked to
+hold only 100 entries.
+
+## The rule
+
+When a builder has a total `max_size` (as opposed to an explicit `per_shard_max_size`), the
+DEFAULT shard count becomes:
+
+```text
+next_power_of_two(max_size / 16).clamp(1, default_shard_count())
+```
+
+implemented by `default_shard_count_for_capacity(Option<usize>)` in
+`src/stores/sharded/mod.rs`. Passing `None` (the unbounded stores' path) reproduces
+`default_shard_count()` exactly, unchanged. This keeps each shard at roughly its 16-entry floor
+by construction instead of relying on the floor to silently inflate a shard count picked without
+regard to capacity.
+
+**An explicit `.shards(n)` on a builder remains authoritative.** `default_shard_count_for_capacity`
+is consulted only on the default (unconfigured) shard-count path; a caller who sets `.shards(n)`
+gets exactly `n` shards regardless of `max_size`.
+
+## Why this is default tuning, not a bug fix
+
+The over-capacity outcome is currently *documented*, not merely an accident of the formula:
+`src/stores/sharded/lru.rs` around lines 738-745 (the `max_size` builder doc) and around lines
+86-91 (`ShardedLruCache::new` doc) both state that "the effective total capacity can exceed
+`max_size` for small values" and point at `capacity()` to read the actual figure. A caller could
+be relying on the current default shard count for its own reasons (e.g. deliberately
+over-provisioning to reduce shard contention). Changing the default is a considered tuning
+decision (trading some of that headroom for allocation cost proportional to the requested size),
+not a correctness fix for behavior that violated its own contract.
+
+## Observable surface that changes
+
+For caches built through the default (no explicit `.shards(n)`) path with a `max_size`:
+
+- `capacity()`: the effective total capacity is smaller for small `max_size` values on
+  high-core-count machines, though it can still exceed `max_size` when the 16-per-shard floor
+  applies (e.g. `max_size = 100` now yields 8 shards x 16 = 128, versus 256 shards x 16 = 4096
+  before).
+- `shards()`: reports the capped default shard count, not the raw
+  `available_parallelism() * 4` figure.
+- `shard_sizes()`: fewer, larger shards under the new default.
+- Eviction distribution: with fewer shards, each shard holds a larger fraction of the total
+  entries, so LRU eviction (which is per-shard) is coarser-grained under concurrent load.
+
+Existing tests that construct sharded LRU caches with an explicit `.shards(n)` are unaffected,
+since `.shards(n)` overrides the default path entirely. Only default-shard-count construction
+(`::new(max_size)` or `.max_size(n).build()` with no `.shards()` call) observes the new sizing.
+
+This must land before the 3.0.0 final release: it changes an observable default (not just an
+internal allocation detail), and 3.0 is the last point where a default like this can move without
+a deprecation cycle.
+
+## Notes
+
+- `default_shard_count_for_capacity` and its test suite already exist in
+  `src/stores/sharded/mod.rs`; the LRU-family builders (`ShardedLruCacheBuilder`,
+  `ShardedLruTtlCacheBuilder`, `ShardedExpiringLruCacheBuilder`) need to call it on their default
+  shard-count path in place of the bare `default_shard_count()`. See
+  `checked_shard_count` in `src/stores/sharded/mod.rs`, which is the current unconditional
+  `shards.unwrap_or_else(default_shard_count)` call site each builder's `build()` goes through.
+- The 16-per-shard floor itself (`per_shard_cap_from_total`) is unchanged; this record only
+  changes how many shards the default path asks for.
+- See [store-sharded.md](../store-sharded.md) for the shipped behavior statement.

--- a/specs/design/0037-sharded-lru-default-shard-cap.md
+++ b/specs/design/0037-sharded-lru-default-shard-cap.md
@@ -22,24 +22,24 @@ more capacity than requested for a bounded cache on a high-core-count machine:
 4096 effective capacity: 256 hash tables and 256 `Vec`s eagerly allocated for a cache asked to
 hold only 100 entries.
 
-## The rule
+## The rule (proposed)
 
 When a builder has a total `max_size` (as opposed to an explicit `per_shard_max_size`), the
-DEFAULT shard count becomes:
+DEFAULT shard count would become:
 
 ```text
 next_power_of_two(max_size / 16).clamp(1, default_shard_count())
 ```
 
-implemented by `default_shard_count_for_capacity(Option<usize>)` in
-`src/stores/sharded/mod.rs`. Passing `None` (the unbounded stores' path) reproduces
-`default_shard_count()` exactly, unchanged. This keeps each shard at roughly its 16-entry floor
-by construction instead of relying on the floor to silently inflate a shard count picked without
-regard to capacity.
+to be implemented by `default_shard_count_for_capacity(Option<usize>)` in
+`src/stores/sharded/mod.rs`. Passing `None` (the unbounded stores' path) would reproduce
+`default_shard_count()` exactly, unchanged. This would keep each shard at roughly its 16-entry
+floor by construction instead of relying on the floor to silently inflate a shard count picked
+without regard to capacity.
 
-**An explicit `.shards(n)` on a builder remains authoritative.** `default_shard_count_for_capacity`
-is consulted only on the default (unconfigured) shard-count path; a caller who sets `.shards(n)`
-gets exactly `n` shards regardless of `max_size`.
+**An explicit `.shards(n)` on a builder would remain authoritative.** `default_shard_count_for_capacity`
+would be consulted only on the default (unconfigured) shard-count path; a caller who sets
+`.shards(n)` would still get exactly `n` shards regardless of `max_size`.
 
 ## Why this is default tuning, not a bug fix
 
@@ -52,23 +52,25 @@ over-provisioning to reduce shard contention). Changing the default is a conside
 decision (trading some of that headroom for allocation cost proportional to the requested size),
 not a correctness fix for behavior that violated its own contract.
 
-## Observable surface that changes
+## Observable surface that would change
 
-For caches built through the default (no explicit `.shards(n)`) path with a `max_size`:
+For caches built through the default (no explicit `.shards(n)`) path with a `max_size`, once this
+lands:
 
-- `capacity()`: the effective total capacity is smaller for small `max_size` values on
-  high-core-count machines, though it can still exceed `max_size` when the 16-per-shard floor
+- `capacity()`: the effective total capacity would be smaller for small `max_size` values on
+  high-core-count machines, though it could still exceed `max_size` when the 16-per-shard floor
   applies (e.g. `max_size = 100` would yield 8 shards x 16 = 128, versus 256 shards x 16 = 4096
-  before).
-- `shards()`: reports the capped default shard count, not the raw
+  today).
+- `shards()`: would report the capped default shard count, not the raw
   `available_parallelism() * 4` figure.
 - `shard_sizes()`: fewer, larger shards under the new default.
-- Eviction distribution: with fewer shards, each shard holds a larger fraction of the total
-  entries, so LRU eviction (which is per-shard) is coarser-grained under concurrent load.
+- Eviction distribution: with fewer shards, each shard would hold a larger fraction of the total
+  entries, so LRU eviction (which is per-shard) would be coarser-grained under concurrent load.
 
-Existing tests that construct sharded LRU caches with an explicit `.shards(n)` are unaffected,
-since `.shards(n)` overrides the default path entirely. Only default-shard-count construction
-(`::new(max_size)` or `.max_size(n).build()` with no `.shards()` call) observes the new sizing.
+Existing tests that construct sharded LRU caches with an explicit `.shards(n)` would be
+unaffected, since `.shards(n)` overrides the default path entirely. Only default-shard-count
+construction (`::new(max_size)` or `.max_size(n).build()` with no `.shards()` call) would observe
+the new sizing.
 
 This must land before the 3.0.0 final release: it changes an observable default (not just an
 internal allocation detail), and 3.0 is the last point where a default like this can move without
@@ -84,4 +86,5 @@ a deprecation cycle.
   `shards.unwrap_or_else(default_shard_count)` call site each builder's `build()` goes through.
 - The 16-per-shard floor itself (`per_shard_cap_from_total`) is unchanged; this record only
   changes how many shards the default path asks for.
-- See [store-sharded.md](../store-sharded.md) for the shipped behavior statement.
+- See [store-sharded.md](../store-sharded.md) SHARD-7 for the current (not-yet-changed) behavior
+  and the same planned cap described here.

--- a/specs/design/0038-cache-set-promotes-on-overwrite.md
+++ b/specs/design/0038-cache-set-promotes-on-overwrite.md
@@ -1,0 +1,60 @@
+# 0038 - `cache_set` over an existing key promotes to most-recently-used
+
+Status: Implemented
+
+## Previous state
+
+`LruCache::cache_set` replaced an existing entry through `LRUList::set(index, (key, val))`, which
+writes the new `(K, V)` into the slot the entry already occupies. The slot's position in the
+recency chain was left alone, so an overwrite did not change which entry a later capacity
+eviction selected. `LruCache::cache_set_returning_entry` did the same, and both behaviors
+propagated to `LruTtlCache`, `ExpiringLruCache`, `ShardedLruCache`, and the no-callback write
+branch of `ShardedLruTtlCache` / `ShardedExpiringLruCache`.
+
+The non-promotion was an artifact of the original `SizedCache` implementation (an in-place
+`order.set` was the cheap path), documented and pinned by tests only after the fact. It was
+never chosen on the merits.
+
+It also produced a wart on the sharded LRU-TTL and expiring-LRU stores. Those two need the
+displaced *stored* key to hand to an `on_evict` callback, so their callback branch wrote through
+a promoting helper (`get_or_set_with_if` with a never-valid predicate) while their no-callback
+branch called the non-promoting `LruCache::cache_set`. Attaching a purely observational
+`on_evict` callback therefore changed eviction order.
+
+## The rule
+
+`cache_set` on an existing key promotes that key to most-recently-used: after
+`LRUList::set(index, ..)` the entry is moved with `LRUList::move_to_front(index)`. A write is an
+access, so an overwrite behaves like inserting a fresh value.
+
+The change is made in two primitives in `src/stores/lru.rs`, `LruCache::cache_set` and
+`LruCache::cache_set_returning_entry`, and propagates to every store in the LRU family. Since
+`cache_set_returning_entry` now both promotes and returns the displaced stored `(K, V)` pair, the
+sharded stores' promoting helper is redundant and was deleted; both write branches call a
+primitive with identical recency behavior, so the `on_evict` divergence is gone.
+
+Reads documented as side-effect-free are untouched: `cache_peek`,
+`cache_peek_with_expiry_status`, `cache_contains`, and the internal `pop_raw_with_hash` remain
+non-promoting, so a write and a peek stay distinguishable. Inserting a NEW key already went to
+the front via `push_front` and is unchanged. Key rebinding on overwrite (LRU-6) is a separate
+question and is unaffected.
+
+## Observable surface that changes
+
+- Which entry a capacity eviction selects in any workload that overwrites existing keys. The
+  overwritten key survives longer; some other key becomes the victim.
+- `iter_order()` / `key_order()` / `value_order()` after an overwrite.
+- The `on_evict` victim sequence and its order on `cache_clear_with_on_evict` (an MRU -> LRU
+  drain) and on a `set_max_size` shrink (LRU-first).
+- On `ShardedLruTtlCache` / `ShardedExpiringLruCache`, the no-callback path now matches the
+  callback path. Code that configured `on_evict` already saw promotion and is unaffected.
+
+There is no direct substitute for the old in-place behavior: no public API writes a value
+without touching recency. The closest reconstruction is to read the entry's position first
+(`key_order()`) and restore it afterwards, which is not a supported operation on the store API.
+
+## Notes
+
+- `LRUList::move_to_front` on a slot already at the head is a safe no-op: `unlink` repairs the
+  neighbours and `link_after(index, OCCUPIED)` re-reads the sentinel's `next` after the unlink.
+- See [store-lru.md](../store-lru.md) LRU-7 for the shipped behavior statement.

--- a/specs/design/README.md
+++ b/specs/design/README.md
@@ -56,3 +56,4 @@ the item stays here for history.
 | [0035](0035-seeded-per-key-lock-bucket-hasher.md) | Seeded per-key lock-bucket hasher | Implemented |
 | [0036](0036-in-impl-static-placement.md) | `in_impl` static placement | Implemented |
 | [0037](0037-sharded-lru-default-shard-cap.md) | Sharded LRU default shard count bounded by `max_size` | Not implemented |
+| [0038](0038-cache-set-promotes-on-overwrite.md) | `cache_set` over an existing key promotes to MRU | Implemented |

--- a/specs/design/README.md
+++ b/specs/design/README.md
@@ -55,3 +55,4 @@ the item stays here for history.
 | [0034](0034-prime-companion-body-before-lock.md) | Prime companion runs body before lock | Implemented |
 | [0035](0035-seeded-per-key-lock-bucket-hasher.md) | Seeded per-key lock-bucket hasher | Implemented |
 | [0036](0036-in-impl-static-placement.md) | `in_impl` static placement | Implemented |
+| [0037](0037-sharded-lru-default-shard-cap.md) | Sharded LRU default shard count bounded by `max_size` | Not implemented |

--- a/specs/store-expiring.md
+++ b/specs/store-expiring.md
@@ -39,3 +39,10 @@ check expiry themselves. See [design/0030-force-refresh-result-fallback-interact
 `ExpiringLruCache` has the LRU-family order accessors (`iter_order` / `key_order` /
 `value_order`) with `CacheValue<V>` values (no per-entry metadata; expiry lives on the value
 itself via `Expires`). See [store-lru.md](store-lru.md) LRU-5.
+
+## EXPIRE-7
+
+`ExpiringLruCache::cache_set` fires `on_evict` with the **stored** key of any displaced entry, not
+the caller's key, matching the rest of the LRU family (`LruCache`, `LruTtlCache`). The two keys
+compare equal (same `Hash`/`Eq`) but can differ in fields outside `Hash`/`Eq`; observable only for
+key types with such fields. See [store-lru.md](store-lru.md) LRU-6.

--- a/specs/store-expiring.md
+++ b/specs/store-expiring.md
@@ -42,7 +42,8 @@ itself via `Expires`). See [store-lru.md](store-lru.md) LRU-5.
 
 ## EXPIRE-7
 
-`ExpiringLruCache::cache_set` fires `on_evict` with the **stored** key of any displaced entry, not
-the caller's key, matching the rest of the LRU family (`LruCache`, `LruTtlCache`). The two keys
-compare equal (same `Hash`/`Eq`) but can differ in fields outside `Hash`/`Eq`; observable only for
-key types with such fields. See [store-lru.md](store-lru.md) LRU-6.
+`ExpiringLruCache::cache_set` fires `on_evict` only when the displaced entry has already
+**expired**; a live overwrite returns the old value via `Some` and fires no callback. When it does
+fire, it passes the **stored** key of the displaced entry, not the caller's key, matching
+`LruTtlCache`. The two keys compare equal (same `Hash`/`Eq`) but can differ in fields outside
+`Hash`/`Eq`; observable only for key types with such fields. See [store-lru.md](store-lru.md) LRU-6.

--- a/specs/store-lru.md
+++ b/specs/store-lru.md
@@ -56,3 +56,35 @@ is the one callers with such key types should see. `LruCache`, `LruTtlCache`, an
 `LruCache::cache_set_returning_entry` primitive (shared by the timed wrappers) returns the
 displaced `(stored_key, stored_value)` pair for exactly this reason, and `ExpiringLruCache`'s
 `cache_set` was brought onto the same contract (it previously passed the caller's key instead).
+
+Which key SURVIVES an overwrite is a separate question from which key `on_evict` sees, and the
+two store families deliberately differ. The LRU family overwrites through `LRUList::set`, which
+replaces the whole `(K, V)` slot, so the caller's key REBINDS the entry and the previous stored
+key is handed to `on_evict` and then dropped. The HashMap-backed stores (`ExpiringCache`,
+`TtlSortedCache`) overwrite through `Entry::Occupied::insert`, which keeps the original key and
+discards the caller's, matching `HashMap::insert` (see
+[store-ttl.md](store-ttl.md) TTL-7). For a key type whose `Eq` ignores part of its payload, the
+key left in an LRU-family cache after `cache_set` / a `get_or_set` overwrite is therefore the
+most recently inserted one, while in the HashMap-backed stores it is the first-inserted one.
+Key rebinding is independent of recency (LRU-7): a rebind happens on every overwrite regardless
+of where the entry sits in the eviction order.
+
+## LRU-7
+
+`cache_set` over an EXISTING key promotes that key to most-recently-used. A write is an access,
+so an overwrite moves the entry to the front of the eviction order exactly as a fresh insertion
+would, and it therefore changes which entry a later capacity eviction selects. This holds across
+`LruCache`, `LruTtlCache`, `ExpiringLruCache`, `ShardedLruCache`, `ShardedLruTtlCache`, and
+`ShardedExpiringLruCache`, and it holds regardless of whether an `on_evict` callback is
+configured: on the sharded LRU-TTL and expiring-LRU stores the callback branch (which needs the
+displaced stored key, so it writes through `LruCache::cache_set_returning_entry`) and the
+no-callback branch (a plain `LruCache::cache_set`) now agree, so attaching a purely
+observational callback cannot change eviction order.
+
+Reads that are documented as side-effect-free stay side-effect-free: `cache_peek`,
+`cache_peek_with_expiry_status`, and `cache_contains` do NOT promote, so a write and a peek
+remain distinguishable. Inserting a NEW key already went to the front and is unchanged.
+
+Before 3.0 an overwrite replaced the value in place and left recency untouched (an artifact of
+the original `SizedCache` implementation, where `LRUList::set` in place was the cheap path).
+See [design/0038-cache-set-promotes-on-overwrite.md](design/0038-cache-set-promotes-on-overwrite.md).

--- a/specs/store-lru.md
+++ b/specs/store-lru.md
@@ -45,3 +45,14 @@ Order accessors, shared across the LRU family (`LruCache`, `LruTtlCache`, `Expir
 and `ExpiringLruCache`, `M = Option<Instant>` for `LruTtlCache`, read via `expires_at()`. The
 wrapper `Deref`s to `V`, exposes `value()` / `into_value()`, and compares equal against bare
 values (`PartialEq<V>`).
+
+## LRU-6
+
+`on_evict` receives the **stored** key, not the caller's key, whenever an existing entry is
+displaced (an overwrite via `cache_set`, or eviction of an already-present key). The two keys
+compare equal (same `Hash`/`Eq`) but can differ in fields outside `Hash`/`Eq`, and the stored key
+is the one callers with such key types should see. `LruCache`, `LruTtlCache`, and
+`ExpiringLruCache` are all consistent on this contract; the internal
+`LruCache::cache_set_returning_entry` primitive (shared by the timed wrappers) returns the
+displaced `(stored_key, stored_value)` pair for exactly this reason, and `ExpiringLruCache`'s
+`cache_set` was brought onto the same contract (it previously passed the caller's key instead).

--- a/specs/store-lru.md
+++ b/specs/store-lru.md
@@ -48,10 +48,13 @@ values (`PartialEq<V>`).
 
 ## LRU-6
 
-`on_evict` receives the **stored** key, not the caller's key, whenever an existing entry is
-displaced (an overwrite via `cache_set`, or eviction of an already-present key). The two keys
-compare equal (same `Hash`/`Eq`) but can differ in fields outside `Hash`/`Eq`, and the stored key
-is the one callers with such key types should see. `LruCache`, `LruTtlCache`, and
+When `on_evict` fires for a displaced entry it receives the **stored** key, not the caller's key.
+It does not fire on every overwrite: a plain `cache_set` overwrite on `LruCache` returns the old
+value and fires no callback, and on `LruTtlCache` / `ExpiringLruCache` an overwrite fires
+`on_evict` only when the displaced entry has already expired; capacity eviction of an
+already-present key always fires it. The two keys compare equal (same `Hash`/`Eq`) but can differ
+in fields outside `Hash`/`Eq`, and the stored key is the one callers with such key types should
+see. `LruCache`, `LruTtlCache`, and
 `ExpiringLruCache` are all consistent on this contract; the internal
 `LruCache::cache_set_returning_entry` primitive (shared by the timed wrappers) returns the
 displaced `(stored_key, stored_value)` pair for exactly this reason, and `ExpiringLruCache`'s

--- a/specs/store-lru.md
+++ b/specs/store-lru.md
@@ -74,19 +74,22 @@ of where the entry sits in the eviction order.
 
 ## LRU-7
 
-`cache_set` over an EXISTING key promotes that key to most-recently-used. A write is an access,
-so an overwrite moves the entry to the front of the eviction order exactly as a fresh insertion
-would, and it therefore changes which entry a later capacity eviction selects. This holds across
-`LruCache`, `LruTtlCache`, `ExpiringLruCache`, `ShardedLruCache`, `ShardedLruTtlCache`, and
-`ShardedExpiringLruCache`, and it holds regardless of whether an `on_evict` callback is
-configured: on the sharded LRU-TTL and expiring-LRU stores the callback branch (which needs the
-displaced stored key, so it writes through `LruCache::cache_set_returning_entry`) and the
-no-callback branch (a plain `LruCache::cache_set`) now agree, so attaching a purely
-observational callback cannot change eviction order.
+`cache_set` and a `get_or_set` overwrite (`cache_get_or_set_with` and its try variants, backed by
+`LruCache::get_or_set_with_if`) over an EXISTING key both promote that key to most-recently-used.
+A write is an access, so an overwrite moves the entry to the front of the eviction order exactly
+as a fresh insertion would, and it therefore changes which entry a later capacity eviction
+selects. This holds across `LruCache`, `LruTtlCache`, `ExpiringLruCache`, `ShardedLruCache`,
+`ShardedLruTtlCache`, and `ShardedExpiringLruCache`, and it holds regardless of whether an
+`on_evict` callback is configured: on the sharded LRU-TTL and expiring-LRU stores the callback
+branch (which needs the displaced stored key, so it writes through
+`LruCache::cache_set_returning_entry`) and the no-callback branch (a plain `LruCache::cache_set`)
+now agree, so attaching a purely observational callback cannot change eviction order.
 
 Reads that are documented as side-effect-free stay side-effect-free: `cache_peek`,
 `cache_peek_with_expiry_status`, and `cache_contains` do NOT promote, so a write and a peek
-remain distinguishable. Inserting a NEW key already went to the front and is unchanged.
+remain distinguishable. Inserting a NEW key already went to the front and is unchanged. There is
+no public API that writes a value without touching recency: nothing substitutes for the pre-3.0
+in-place overwrite described below.
 
 Before 3.0 an overwrite replaced the value in place and left recency untouched (an artifact of
 the original `SizedCache` implementation, where `LRUList::set` in place was the cheap path).

--- a/specs/store-sharded.md
+++ b/specs/store-sharded.md
@@ -71,25 +71,36 @@ no `K: Clone` bound and is inherent-only, not a trait method; see
 
 ## SHARD-7
 
-For the LRU-bounded variants (`ShardedLruCache`, `ShardedLruTtlCache`, `ShardedExpiringLruCache`),
-the DEFAULT shard count (no explicit `.shards(n)` on the builder) is capped by the requested
-`max_size` rather than derived from `available_parallelism()` alone: it is
-`next_power_of_two(max_size / 16).clamp(1, default_shard_count())`, where `default_shard_count()`
-is `available_parallelism() * 4` clamped to `[8, 1024]` and rounded to a power of two. This keeps
-a small bounded cache (e.g. `ShardedLruCache::new(100)`) from preallocating hundreds of shards on
-a high-core-count machine when the 16-entries-per-shard floor (`per_shard_cap_from_total`) alone
-would already dominate the effective capacity. Building without a `max_size` (the unbounded
-sharded stores) is unaffected and keeps using `default_shard_count()` directly.
-`.shards(n)` on the builder always overrides this default and is authoritative regardless of
-`max_size`. See [design/0037-sharded-lru-default-shard-cap.md](design/0037-sharded-lru-default-shard-cap.md).
+**Planned, not yet in effect.** For the LRU-bounded variants (`ShardedLruCache`,
+`ShardedLruTtlCache`, `ShardedExpiringLruCache`), the DEFAULT shard count (no explicit
+`.shards(n)` on the builder) is intended to be capped by the requested `max_size` rather than
+derived from `available_parallelism()` alone: the helper `default_shard_count_for_capacity`
+would yield `next_power_of_two(max_size / 16).clamp(1, default_shard_count())`, where
+`default_shard_count()` is `available_parallelism() * 4` clamped to `[8, 1024]` and rounded to a
+power of two. This helper exists (`#[allow(dead_code)]`) but no builder's default path calls it
+yet, so today every LRU-bounded builder still ignores `max_size` when sizing the default shard
+count and can preallocate hundreds of shards on a high-core-count machine even for a small
+bounded cache (e.g. `ShardedLruCache::new(100)`), since the 16-entries-per-shard floor
+(`per_shard_cap_from_total`) alone would already dominate the effective capacity. Once wired in,
+building without a `max_size` (the unbounded sharded stores) would be unaffected and would keep
+using `default_shard_count()` directly, and `.shards(n)` on the builder would always override
+this default and remain authoritative regardless of `max_size`. See
+[design/0037-sharded-lru-default-shard-cap.md](design/0037-sharded-lru-default-shard-cap.md).
 
 ## SHARD-8
 
-On the expiry-aware sharded stores, the liveness of an entry is decided against a single clock
-sample taken by the calling thread BEFORE it acquires the shard lock, not re-read once the lock is
-held. Under lock contention an entry that crosses its expiry while the caller is queued is
-therefore judged live for that operation: `cache_set` returns `Some(old_value)` and fires no
-`on_evict`, and the entry is swept on a later access instead. This is inside the lazy-expiry
-contract in [SHARD-3](#shard-3), which promises only that an expired entry never reads as present,
-never that removal is prompt. Callers that need a hard bound on how long an expired entry can
-occupy space should call `evict()`.
+On the TTL-based sharded stores (`ShardedTtlCache`, `ShardedLruTtlCache`), the liveness of an
+entry is decided against a single clock sample taken by the calling thread BEFORE it acquires the
+shard lock, not re-read once the lock is held. Under lock contention an entry that crosses its
+expiry while the caller is queued is therefore judged live for that operation: `cache_set` returns
+`Some(old_value)` and fires no `on_evict`, and the entry is swept on a later access instead. This
+is inside the lazy-expiry contract in [SHARD-3](#shard-3), which promises only that an expired
+entry never reads as present, never that removal is prompt. Callers that need a hard bound on how
+long an expired entry can occupy space should call `evict()`.
+
+The per-value-`Expires` family (`ShardedExpiringCache`, `ShardedExpiringLruCache`) does not follow
+this contract: `is_expired()` is evaluated on the stored value while the shard write lock is
+already held in `cache_set`, so a value that crosses its own expiry boundary while the caller is
+queued for the lock is judged expired, not live, for that operation. In that case `cache_set`
+returns `None` and fires `on_evict` for the displaced entry, the opposite of the TTL-family
+outcome above.

--- a/specs/store-sharded.md
+++ b/specs/store-sharded.md
@@ -82,3 +82,14 @@ would already dominate the effective capacity. Building without a `max_size` (th
 sharded stores) is unaffected and keeps using `default_shard_count()` directly.
 `.shards(n)` on the builder always overrides this default and is authoritative regardless of
 `max_size`. See [design/0037-sharded-lru-default-shard-cap.md](design/0037-sharded-lru-default-shard-cap.md).
+
+## SHARD-8
+
+On the expiry-aware sharded stores, the liveness of an entry is decided against a single clock
+sample taken by the calling thread BEFORE it acquires the shard lock, not re-read once the lock is
+held. Under lock contention an entry that crosses its expiry while the caller is queued is
+therefore judged live for that operation: `cache_set` returns `Some(old_value)` and fires no
+`on_evict`, and the entry is swept on a later access instead. This is inside the lazy-expiry
+contract in [SHARD-3](#shard-3), which promises only that an expired entry never reads as present,
+never that removal is prompt. Callers that need a hard bound on how long an expired entry can
+occupy space should call `evict()`.

--- a/specs/store-sharded.md
+++ b/specs/store-sharded.md
@@ -68,3 +68,17 @@ the predicate and every removal counts an eviction; `ShardedUnboundCache` tracks
 counter, so an entry there simply survives exactly when `keep` returns `true`. `retain` requires
 no `K: Clone` bound and is inherent-only, not a trait method; see
 [traits-concurrent.md](traits-concurrent.md).
+
+## SHARD-7
+
+For the LRU-bounded variants (`ShardedLruCache`, `ShardedLruTtlCache`, `ShardedExpiringLruCache`),
+the DEFAULT shard count (no explicit `.shards(n)` on the builder) is capped by the requested
+`max_size` rather than derived from `available_parallelism()` alone: it is
+`next_power_of_two(max_size / 16).clamp(1, default_shard_count())`, where `default_shard_count()`
+is `available_parallelism() * 4` clamped to `[8, 1024]` and rounded to a power of two. This keeps
+a small bounded cache (e.g. `ShardedLruCache::new(100)`) from preallocating hundreds of shards on
+a high-core-count machine when the 16-entries-per-shard floor (`per_shard_cap_from_total`) alone
+would already dominate the effective capacity. Building without a `max_size` (the unbounded
+sharded stores) is unaffected and keeps using `default_shard_count()` directly.
+`.shards(n)` on the builder always overrides this default and is authoritative regardless of
+`max_size`. See [design/0037-sharded-lru-default-shard-cap.md](design/0037-sharded-lru-default-shard-cap.md).

--- a/specs/store-sharded.md
+++ b/specs/store-sharded.md
@@ -71,20 +71,23 @@ no `K: Clone` bound and is inherent-only, not a trait method; see
 
 ## SHARD-7
 
-**Planned, not yet in effect.** For the LRU-bounded variants (`ShardedLruCache`,
-`ShardedLruTtlCache`, `ShardedExpiringLruCache`), the DEFAULT shard count (no explicit
-`.shards(n)` on the builder) is intended to be capped by the requested `max_size` rather than
-derived from `available_parallelism()` alone: the helper `default_shard_count_for_capacity`
-would yield `next_power_of_two(max_size / 16).clamp(1, default_shard_count())`, where
-`default_shard_count()` is `available_parallelism() * 4` clamped to `[8, 1024]` and rounded to a
-power of two. This helper exists (`#[allow(dead_code)]`) but no builder's default path calls it
-yet, so today every LRU-bounded builder still ignores `max_size` when sizing the default shard
-count and can preallocate hundreds of shards on a high-core-count machine even for a small
-bounded cache (e.g. `ShardedLruCache::new(100)`), since the 16-entries-per-shard floor
-(`per_shard_cap_from_total`) alone would already dominate the effective capacity. Once wired in,
-building without a `max_size` (the unbounded sharded stores) would be unaffected and would keep
-using `default_shard_count()` directly, and `.shards(n)` on the builder would always override
-this default and remain authoritative regardless of `max_size`. See
+**Current behavior:** for the LRU-bounded variants (`ShardedLruCache`, `ShardedLruTtlCache`,
+`ShardedExpiringLruCache`), the DEFAULT shard count (no explicit `.shards(n)` on the builder)
+ignores `max_size` entirely; it is derived only from `available_parallelism()`. Combined with the
+16-entries-per-shard floor (`per_shard_cap_from_total`), this means the effective capacity can
+exceed the requested `max_size` by a wide margin on a high-core-count host: `ShardedLruCache::new(100)`
+on a 64-core box preallocates 256 shards and yields an effective capacity of 4096, not 100. Read
+`capacity()` after construction to see the actual figure a given host resolves to; an explicit
+`.shards(n)` on the builder is the only way to control this today.
+
+**Planned, not yet in effect.** The DEFAULT shard count is intended to be capped by the requested
+`max_size` instead: the helper `default_shard_count_for_capacity` would yield
+`next_power_of_two(max_size / 16).clamp(1, default_shard_count())`, where `default_shard_count()`
+is `available_parallelism() * 4` clamped to `[8, 1024]` and rounded to a power of two. This helper
+exists (`#[allow(dead_code)]`) but no builder's default path calls it yet. Once wired in, building
+without a `max_size` (the unbounded sharded stores) would be unaffected and would keep using
+`default_shard_count()` directly, and `.shards(n)` on the builder would always override this
+default and remain authoritative regardless of `max_size`. See
 [design/0037-sharded-lru-default-shard-cap.md](design/0037-sharded-lru-default-shard-cap.md).
 
 ## SHARD-8

--- a/specs/store-ttl.md
+++ b/specs/store-ttl.md
@@ -42,3 +42,21 @@ latest-expiring entries by size rather than filtering by predicate.
 `LruTtlCache` has the LRU-family order accessors (`iter_order` / `key_order` / `value_order`)
 with `CacheValue<V, Option<Instant>>` values carrying the entry expiry via `expires_at()`. See
 [store-lru.md](store-lru.md) LRU-5.
+
+## TTL-6
+
+`TtlSortedCache`'s `get_or_set` family (sync infallible, sync try, async infallible, async try)
+checks liveness in place instead of sweeping an expired entry before running the factory. A
+cancelled or panicking factory leaves the stale entry untouched and fires no `on_evict`; on
+success, the factory's value replaces the entry and `on_evict` fires after the factory completes,
+not before. All four variants agree with each other and with `TtlCache` / `LruTtlCache`.
+
+## TTL-7
+
+For a key type whose `Eq` ignores part of its payload, `set` / `set_with` report the
+**first-inserted** key to `on_evict` and the displaced value's key in `cache_remove_entry`, not
+the most recently inserted key: the occupied-entry insert path reuses the existing entry's stored
+key `Arc` rather than replacing it with the caller's new key. This matches `HashMap::insert`'s own
+rule for keys that compare equal. `retain_latest` counts an eviction (increments the `evictions`
+counter) before invoking `on_evict` for that entry, so a panicking `on_evict` callback still
+leaves the eviction counted.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,6 +293,25 @@ Because LRU caches require updating access recency, `ShardedLruCache`, `ShardedL
   `cache_peek_with_expiry_status` as a side-effect-free counterpart (a read with no hit/miss
   counting, LRU promotion, or TTL renewal).
 
+**Performance**
+
+v3 reworks the hot paths of the in-memory and sharded stores. Steady-state `O(1)` reads and
+capacity-bounded inserts are unchanged; the wins concentrate in a few paths (measured with
+`cargo bench --bench cache_benches`, so the exact figures are hardware- and workload-dependent):
+
+- Overwriting an existing key with `cache_set` reuses the stored key instead of re-cloning it.
+  On the timed stores this is roughly 10-30% faster, and the gain grows with key clone cost, so
+  `String`-keyed caches benefit most.
+- Bulk eviction and retention (`evict`, `retain`, `retain_latest`) and the key/iteration order
+  helpers now sweep in a single pass instead of collecting keys first, up to about 2x faster at
+  10k entries. TTL stores also sample the clock once per operation rather than once per entry.
+- Single-threaded `cache_get` hits on the sharded LRU and expiring-LRU variants resolve in one
+  hash lookup instead of two, about 5-15% faster.
+
+One deliberate tradeoff comes with the `cache_set` recency change (see the migration guide): an
+overwrite now promotes the key to most-recently-used, which adds a small cost on stores with cheap
+`Copy` keys where there is no key clone to save.
+
 **Per-Value Expiry via the `Expires` Trait**
 
 While standard timed stores (`TtlCache`, `LruTtlCache`, `TtlSortedCache`) enforce a single, global Time-To-Live (TTL) duration applied to all entries in the cache, [`ExpiringLruCache`] and [`ExpiringCache`] let each individual value determine its own expiration. This is accomplished by storing values that implement the [`Expires`] trait.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -939,7 +939,8 @@ pub trait Cached<K, V> {
         K: std::borrow::Borrow<Q>,
         Q: std::hash::Hash + Eq + ?Sized;
 
-    /// Insert a key-value pair and return the previous value.
+    /// Insert a key-value pair and return the previous value. On recency-ordered stores,
+    /// overwriting an existing key promotes it to most-recently-used.
     fn cache_set(&mut self, k: K, v: V) -> Option<V>;
 
     /// Fallible variant of [`Self::cache_set`] for custom stores whose insertion can fail.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,17 +296,20 @@ Because LRU caches require updating access recency, `ShardedLruCache`, `ShardedL
 **Performance**
 
 v3 reworks the hot paths of the in-memory and sharded stores. Steady-state `O(1)` reads and
-capacity-bounded inserts are unchanged; the wins concentrate in a few paths (measured with
-`cargo bench --bench cache_benches`, so the exact figures are hardware- and workload-dependent):
+capacity-bounded inserts are unchanged; the wins concentrate in a few paths (figures are
+hardware- and workload-dependent; see `benches/cache_benches.rs` for the paths measured):
 
-- Overwriting an existing key with `cache_set` reuses the stored key instead of re-cloning it.
-  On the timed stores this is roughly 10-30% faster, and the gain grows with key clone cost, so
-  `String`-keyed caches benefit most.
+- Overwriting an existing key with `cache_set` on the map-backed stores (`TtlCache`,
+  `TtlSortedCache`, `ExpiringCache`) reuses the stored key instead of cloning the caller's key.
+  The gain grows with key clone cost, so caches with expensive keys benefit most. The LRU-family
+  stores instead rebind the slot to the caller's key (see the recency note below).
 - Bulk eviction and retention (`evict`, `retain`, `retain_latest`) and the key/iteration order
-  helpers now sweep in a single pass instead of collecting keys first, up to about 2x faster at
-  10k entries. TTL stores also sample the clock once per operation rather than once per entry.
-- Single-threaded `cache_get` hits on the sharded LRU and expiring-LRU variants resolve in one
-  hash lookup instead of two, about 5-15% faster.
+  helpers on the single-owner in-memory and TTL stores now sweep in a single pass instead of
+  collecting keys first, up to about 2x faster at 10k entries. TTL stores also sample the clock
+  once per operation rather than once per entry.
+- Single-threaded `cache_get` hits on the expiring-LRU and sharded LRU-TTL variants resolve in
+  one hash lookup instead of two, about 5-15% faster. The plain sharded LRU releases the shard
+  lock before updating its counters.
 
 One deliberate tradeoff comes with the `cache_set` recency change (see the migration guide): an
 overwrite now promotes the key to most-recently-used, which adds a small cost on stores with cheap
@@ -2223,10 +2226,13 @@ pub trait ConcurrentCached<K, V>: ConcurrentCacheBase {
 
     /// Insert a key, value pair and return the previous live value at the key, if any.
     /// A displaced entry that has already expired is not returned: it is filtered to
-    /// `None` and delivered to `on_evict` instead (see `specs/store-sharded.md` SHARD-8),
-    /// so a returned `Some(v)` is always a previous value that was live for this
-    /// operation. On recency-ordered sharded stores, overwriting an existing key promotes
-    /// it to most-recently-used.
+    /// `None` and delivered to `on_evict` instead, so a returned `Some(v)` is always a
+    /// previous value that was live for this operation. When an entry crosses its expiry
+    /// while the caller is queued for the shard lock, the TTL stores judge it against the
+    /// pre-lock instant (returned as a live `Some`), while the per-value-expiry stores
+    /// judge it expired (filtered to `None` and delivered to `on_evict`). On
+    /// recency-ordered sharded stores, overwriting an existing key promotes it to
+    /// most-recently-used.
     ///
     /// # Errors
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2202,11 +2202,12 @@ pub trait ConcurrentCached<K, V>: ConcurrentCacheBase {
     #[must_use = "cache_get returns the looked-up value; ignoring it discards the result"]
     fn cache_get(&self, k: &K) -> Result<Option<V>, Self::Error>;
 
-    /// Insert a key, value pair and return the previous value at the key, if any,
-    /// without checking expiry. For TTL-based stores the returned value may have
-    /// elapsed its TTL; for per-value expiry stores (implementing [`Expires`]) the
-    /// returned value may report `is_expired() == true`. Check expiry on the returned
-    /// value if you need to distinguish a live previous entry from an expired one.
+    /// Insert a key, value pair and return the previous live value at the key, if any.
+    /// A displaced entry that has already expired is not returned: it is filtered to
+    /// `None` and delivered to `on_evict` instead (see `specs/store-sharded.md` SHARD-8),
+    /// so a returned `Some(v)` is always a previous value that was live for this
+    /// operation. On recency-ordered sharded stores, overwriting an existing key promotes
+    /// it to most-recently-used.
     ///
     /// # Errors
     ///

--- a/src/lru_list.rs
+++ b/src/lru_list.rs
@@ -283,6 +283,65 @@ mod tests {
         assert_eq!(l.back(), b); // 2 is now LRU
     }
 
+    /// Walk the occupied ring backwards via `prev`. `order` only follows `next`, so a
+    /// corrupted `prev` chain is invisible to it; comparing the two directions is what
+    /// actually proves the doubly-linked list is intact.
+    fn order_reversed(l: &LRUList<i32>) -> Vec<i32> {
+        let mut out = Vec::new();
+        let mut idx = l.values[LRUList::<i32>::OCCUPIED].prev;
+        while idx != LRUList::<i32>::OCCUPIED {
+            out.push(*l.get(idx));
+            idx = l.values[idx].prev;
+        }
+        out.reverse();
+        out
+    }
+
+    /// `move_to_front` on an index that is ALREADY the head is on the hot path now that
+    /// `cache_set` promotes an overwritten key. It aliases (`unlink` writes the same
+    /// sentinel links `link_after` then re-reads), so it gets its own integrity check
+    /// rather than only a shallow forward-order assertion.
+    #[test]
+    fn move_to_front_on_the_current_head_keeps_both_link_directions_intact() {
+        let mut l = LRUList::with_capacity(4);
+        let a = l.push_front(1);
+        let _b = l.push_front(2);
+        let c = l.push_front(3);
+        assert_eq!(order(&l), vec![3, 2, 1]);
+
+        // `c` is already the head; promoting it must be a no-op in both directions.
+        for _ in 0..3 {
+            l.move_to_front(c);
+            assert_eq!(order(&l), vec![3, 2, 1]);
+            assert_eq!(order_reversed(&l), order(&l), "prev chain must mirror next");
+            assert_eq!(l.back(), a);
+        }
+
+        // And the list still behaves normally afterwards.
+        l.move_to_front(a);
+        assert_eq!(order(&l), vec![1, 3, 2]);
+        assert_eq!(order_reversed(&l), order(&l));
+    }
+
+    /// The degenerate case: promoting the only entry empties and rebuilds the ring.
+    #[test]
+    fn move_to_front_on_the_sole_entry_keeps_the_ring_intact() {
+        let mut l = LRUList::with_capacity(2);
+        let a = l.push_front(42);
+        for _ in 0..3 {
+            l.move_to_front(a);
+            assert_eq!(order(&l), vec![42]);
+            assert_eq!(order_reversed(&l), vec![42]);
+            assert_eq!(l.back(), a);
+        }
+        // A later push must still link correctly onto the rebuilt ring.
+        let b = l.push_front(7);
+        assert_eq!(order(&l), vec![7, 42]);
+        assert_eq!(order_reversed(&l), order(&l));
+        assert_eq!(l.back(), a);
+        assert_eq!(*l.get(b), 7);
+    }
+
     #[test]
     fn set_replaces_and_clear_resets() {
         let mut l = LRUList::with_capacity(2);

--- a/src/lru_list.rs
+++ b/src/lru_list.rs
@@ -135,8 +135,43 @@ impl<T> LRUList<T> {
         });
     }
 
+    /// Move every occupied value into `out` in MRU -> LRU order (leaving the list
+    /// empty), then reset the two sentinel cells so the list is immediately reusable.
+    ///
+    /// This is the allocation-free counterpart of "collect the keys, then remove them
+    /// one at a time": it walks the occupied chain once taking owned values, so callers
+    /// clearing a whole cache never clone a key or re-hash anything. The backing `Vec`'s
+    /// capacity is retained.
+    pub(crate) fn drain_into(&mut self, out: &mut Vec<T>) {
+        let mut index = self.values[Self::OCCUPIED].next;
+        while index != Self::OCCUPIED {
+            let next = self.values[index].next;
+            if let Some(value) = self.values[index].value.take() {
+                out.push(value);
+            }
+            index = next;
+        }
+        // Reset the free/occupied sentinels; every cell is now vacant.
+        self.clear();
+    }
+
     pub fn iter(&self) -> LRUListIterator<'_, T> {
         LRUListIterator::<T> {
+            list: self,
+            index: Self::OCCUPIED,
+        }
+    }
+
+    /// Iterate the *slot indices* of the occupied cells in MRU -> LRU order (the same
+    /// order as [`iter`](Self::iter)).
+    ///
+    /// Lets a sweep collect a `Vec<usize>` of the slots it intends to touch instead of
+    /// cloning every candidate key. Slot indices are stable across removals of *other*
+    /// slots, so a collected list stays valid while the sweep removes entries -- but a
+    /// removal frees its slot for reuse, so a collected index must not be replayed after
+    /// any `push_front`.
+    pub(crate) fn iter_indices(&self) -> LRUListIndexIterator<'_, T> {
+        LRUListIndexIterator::<T> {
             list: self,
             index: Self::OCCUPIED,
         }
@@ -160,6 +195,28 @@ impl<'a, T> Iterator for LRUListIterator<'a, T> {
             let value = self.list.values[next].value.as_ref();
             self.index = next;
             value
+        }
+    }
+}
+
+/// Iterator over the occupied slot indices of an [`LRUList`], MRU -> LRU.
+/// See [`LRUList::iter_indices`].
+#[derive(Debug)]
+pub struct LRUListIndexIterator<'a, T> {
+    list: &'a LRUList<T>,
+    index: usize,
+}
+
+impl<T> Iterator for LRUListIndexIterator<'_, T> {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = self.list.values[self.index].next;
+        if next == LRUList::<T>::OCCUPIED {
+            None
+        } else {
+            self.index = next;
+            Some(next)
         }
     }
 }
@@ -236,5 +293,156 @@ mod tests {
         assert!(order(&l).is_empty());
         let b = l.push_front(9); // still usable after clear
         assert_eq!(*l.get(b), 9);
+    }
+
+    #[test]
+    fn iter_indices_matches_iter_order() {
+        let mut l = LRUList::with_capacity(4);
+        let a = l.push_front(1);
+        let b = l.push_front(2);
+        let c = l.push_front(3);
+        assert_eq!(l.iter_indices().collect::<Vec<_>>(), vec![c, b, a]);
+        // The index order must track the value order (MRU -> LRU) exactly.
+        let by_index: Vec<i32> = l.iter_indices().map(|i| *l.get(i)).collect();
+        assert_eq!(by_index, order(&l));
+
+        // Reordering and removal keep the two views in agreement.
+        l.move_to_front(a);
+        assert_eq!(l.iter_indices().collect::<Vec<_>>(), vec![a, c, b]);
+        assert_eq!(l.remove(c), 3);
+        assert_eq!(l.iter_indices().collect::<Vec<_>>(), vec![a, b]);
+        let by_index: Vec<i32> = l.iter_indices().map(|i| *l.get(i)).collect();
+        assert_eq!(by_index, order(&l));
+
+        // Empty list yields no indices.
+        let empty: LRUList<i32> = LRUList::with_capacity(2);
+        assert!(empty.iter_indices().next().is_none());
+    }
+
+    #[test]
+    fn drain_into_yields_mru_to_lru_and_resets() {
+        let mut l = LRUList::with_capacity(4);
+        l.push_front(1);
+        l.push_front(2);
+        let c = l.push_front(3);
+        l.move_to_front(c); // no-op, but pins that drain follows the live chain
+
+        let mut out = Vec::new();
+        l.drain_into(&mut out);
+        assert_eq!(out, vec![3, 2, 1], "drain must be MRU -> LRU");
+
+        // Sentinels are reset: the list is empty and reports no indices.
+        assert!(order(&l).is_empty());
+        assert!(l.iter_indices().next().is_none());
+
+        // Reusable after a drain, and slot allocation restarts from the free list.
+        let a = l.push_front(9);
+        let b = l.push_front(10);
+        assert_eq!(*l.get(a), 9);
+        assert_eq!(*l.get(b), 10);
+        assert_eq!(order(&l), vec![10, 9]);
+        assert_eq!(l.back(), a);
+
+        // Freed-slot reuse still works after a drain.
+        assert_eq!(l.remove(b), 10);
+        let d = l.push_front(11);
+        assert_eq!(d, b, "a freed slot must be reused after a drain, not grown");
+        assert_eq!(order(&l), vec![11, 9]);
+
+        // Draining an already-empty list appends nothing and leaves it usable.
+        let mut l2: LRUList<i32> = LRUList::with_capacity(2);
+        let mut out2 = vec![42];
+        l2.drain_into(&mut out2);
+        assert_eq!(out2, vec![42]);
+        let e = l2.push_front(5);
+        assert_eq!(*l2.get(e), 5);
+    }
+
+    #[test]
+    fn stale_index_after_push_front_refers_to_recycled_slot() {
+        // Pins the hazard documented on `iter_indices`: a collected index survives the
+        // removal of *other* slots, but a `push_front` recycles the freed slot, so
+        // replaying a stale index afterwards addresses the NEW occupant. Consumers that
+        // collect indices must not insert before they finish replaying them.
+        let mut l = LRUList::with_capacity(4);
+        let a = l.push_front(1);
+        let b = l.push_front(2);
+        let c = l.push_front(3);
+        let snapshot: Vec<usize> = l.iter_indices().collect();
+        assert_eq!(snapshot, vec![c, b, a]);
+
+        assert_eq!(l.remove(b), 2);
+        // Supported case: indices of untouched slots are still valid after a removal.
+        assert_eq!(*l.get(snapshot[0]), 3);
+        assert_eq!(*l.get(snapshot[2]), 1);
+
+        // A push recycles the just-freed slot ...
+        let d = l.push_front(99);
+        assert_eq!(d, b, "push_front must recycle the most recently freed slot");
+        // ... so the stale index now names the new entry, silently and without a panic.
+        assert_eq!(*l.get(snapshot[1]), 99);
+        assert_eq!(
+            l.remove(snapshot[1]),
+            99,
+            "replaying a stale index removes the recycled entry, not the original"
+        );
+        assert_eq!(order(&l), vec![3, 1]);
+    }
+
+    #[test]
+    fn iter_indices_empty_after_all_removals() {
+        let mut l = LRUList::with_capacity(4);
+        let a = l.push_front(1);
+        let b = l.push_front(2);
+        assert_eq!(l.remove(a), 1);
+        assert_eq!(l.remove(b), 2);
+        assert!(l.iter_indices().next().is_none());
+        assert!(order(&l).is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid index")]
+    fn remove_of_freed_slot_panics() {
+        // `LruCache::remove_index` documents a panic for a non-occupied slot; this is
+        // the primitive it panics through.
+        let mut l = LRUList::with_capacity(2);
+        let a = l.push_front(1);
+        assert_eq!(l.remove(a), 1);
+        let _ = l.remove(a);
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid index")]
+    fn get_of_freed_slot_panics() {
+        let mut l = LRUList::with_capacity(2);
+        let a = l.push_front(1);
+        assert_eq!(l.remove(a), 1);
+        let _ = l.get(a);
+    }
+
+    #[test]
+    #[should_panic(expected = "index out of bounds")]
+    fn get_out_of_range_index_panics() {
+        let mut l = LRUList::with_capacity(2);
+        l.push_front(1);
+        let _ = l.get(999);
+    }
+
+    #[test]
+    fn drain_into_skips_freed_slots() {
+        // A list with holes (removed entries) must drain only the live chain.
+        let mut l = LRUList::with_capacity(8);
+        let a = l.push_front(1);
+        let b = l.push_front(2);
+        let _c = l.push_front(3);
+        let d = l.push_front(4);
+        assert_eq!(l.remove(b), 2);
+        assert_eq!(l.remove(d), 4);
+        l.move_to_front(a);
+
+        let mut out = Vec::new();
+        l.drain_into(&mut out);
+        assert_eq!(out, vec![1, 3]);
+        assert!(order(&l).is_empty());
     }
 }

--- a/src/stores/expiring.rs
+++ b/src/stores/expiring.rs
@@ -1,5 +1,6 @@
-use super::{CacheEvict, Cached, DefaultHashBuilder, Expires, UnboundCache};
+use super::{CacheEvict, Cached, DefaultHashBuilder, Expires};
 use crate::{CachedIter, CachedPeek, CloneCached};
+use std::collections::HashMap;
 use std::hash::{BuildHasher, Hash};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -52,7 +53,8 @@ use {super::CachedGetOrSetAsync, std::collections::hash_map::Entry, std::future:
 ///
 /// Note: This cache is in-memory only.
 pub struct ExpiringCache<K, V, S = DefaultHashBuilder> {
-    pub(super) store: UnboundCache<K, V, S>,
+    pub(super) store: HashMap<K, V, S>,
+    pub(super) initial_capacity: Option<usize>,
     pub(super) hits: AtomicU64,
     pub(super) misses: AtomicU64,
     pub(super) evictions: AtomicU64,
@@ -101,6 +103,7 @@ where
     fn clone(&self) -> Self {
         Self {
             store: self.store.clone(),
+            initial_capacity: self.initial_capacity,
             hits: AtomicU64::new(self.hits.load(Ordering::Relaxed)),
             misses: AtomicU64::new(self.misses.load(Ordering::Relaxed)),
             evictions: AtomicU64::new(self.evictions.load(Ordering::Relaxed)),
@@ -211,18 +214,12 @@ impl<K, V, S> ExpiringCacheBuilder<K, V, S> {
         S: BuildHasher,
     {
         let store = match self.capacity {
-            Some(cap) => UnboundCache::builder()
-                .initial_capacity(cap)
-                .hasher(self.hasher)
-                .build()
-                .expect("infallible"),
-            None => UnboundCache::builder()
-                .hasher(self.hasher)
-                .build()
-                .expect("infallible"),
+            Some(cap) => HashMap::with_capacity_and_hasher(cap, self.hasher),
+            None => HashMap::with_hasher(self.hasher),
         };
         Ok(ExpiringCache {
             store,
+            initial_capacity: self.capacity,
             hits: AtomicU64::new(0),
             misses: AtomicU64::new(0),
             evictions: AtomicU64::new(0),
@@ -261,7 +258,7 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> ExpiringCache<K, V, S> {
         let on_evict = &self.on_evict;
         let evictions = &self.evictions;
         let mut removed = 0;
-        self.store.store.retain(|key, value| {
+        self.store.retain(|key, value| {
             if value.is_expired() {
                 if let Some(on_evict) = on_evict {
                     on_evict(key, value);
@@ -287,7 +284,7 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> ExpiringCache<K, V, S> {
         if self.on_evict.is_none() {
             return self.cache_clear();
         }
-        let entries: Vec<(K, V)> = self.store.store.drain().collect();
+        let entries: Vec<(K, V)> = self.store.drain().collect();
         let count = entries.len() as u64;
         if count > 0 {
             self.evictions.fetch_add(count, Ordering::Relaxed);
@@ -312,7 +309,7 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> ExpiringCache<K, V, S> {
     pub fn retain<F: FnMut(&K, &V) -> bool>(&mut self, mut keep: F) {
         let on_evict = &self.on_evict;
         let evictions = &self.evictions;
-        self.store.store.retain(|key, value| {
+        self.store.retain(|key, value| {
             if value.is_expired() || !keep(key, value) {
                 if let Some(on_evict) = on_evict {
                     on_evict(key, value);
@@ -342,17 +339,20 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> Cached<K, V> for ExpiringCache<K,
     {
         // Two lookups on the hit path: the first checks expiry (releasing the borrow via
         // `.map`), the second returns the reference. A single-lookup approach is not possible
-        // in stable Rust because returning `&'1 V` from inside an `if let` block ties the
-        // borrow to lifetime `'1`, which prevents `remove_entry` (a mutable borrow) even on
-        // the non-returning path. Polonius (nightly) would fix this.
-        match self.store.store.get(k).map(|v| v.is_expired()) {
+        // SAFELY in stable Rust because returning `&'1 V` from inside an `if let` block ties
+        // the borrow to lifetime `'1`, which prevents `remove_entry` (a mutable borrow) even on
+        // the non-returning path. Polonius (nightly) would fix this without unsafe.
+        // `TtlCache::cache_get` (src/stores/ttl.rs) already collapses this to a single lookup
+        // via a documented `&entry.value as *const V` reborrow; that unsafe tradeoff is
+        // intentionally not made here.
+        match self.store.get(k).map(|v| v.is_expired()) {
             None => {
                 self.misses.fetch_add(1, Ordering::Relaxed);
                 None
             }
             Some(true) => {
                 self.misses.fetch_add(1, Ordering::Relaxed);
-                if let Some((key, old)) = self.store.store.remove_entry(k) {
+                if let Some((key, old)) = self.store.remove_entry(k) {
                     if let Some(on_evict) = &self.on_evict {
                         on_evict(&key, &old);
                     }
@@ -362,7 +362,7 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> Cached<K, V> for ExpiringCache<K,
             }
             Some(false) => {
                 self.hits.fetch_add(1, Ordering::Relaxed);
-                self.store.store.get(k)
+                self.store.get(k)
             }
         }
     }
@@ -373,14 +373,14 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> Cached<K, V> for ExpiringCache<K,
         Q: std::hash::Hash + Eq + ?Sized,
     {
         // Two lookups on the hit path for the same reason as `cache_get` (NLL limitation).
-        match self.store.store.get(k).map(|v| v.is_expired()) {
+        match self.store.get(k).map(|v| v.is_expired()) {
             None => {
                 self.misses.fetch_add(1, Ordering::Relaxed);
                 None
             }
             Some(true) => {
                 self.misses.fetch_add(1, Ordering::Relaxed);
-                if let Some((key, old)) = self.store.store.remove_entry(k) {
+                if let Some((key, old)) = self.store.remove_entry(k) {
                     if let Some(on_evict) = &self.on_evict {
                         on_evict(&key, &old);
                     }
@@ -390,13 +390,13 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> Cached<K, V> for ExpiringCache<K,
             }
             Some(false) => {
                 self.hits.fetch_add(1, Ordering::Relaxed);
-                self.store.store.get_mut(k)
+                self.store.get_mut(k)
             }
         }
     }
 
     fn cache_get_or_set_with_mut<F: FnOnce() -> V>(&mut self, k: K, f: F) -> &mut V {
-        match self.store.store.entry(k) {
+        match self.store.entry(k) {
             std::collections::hash_map::Entry::Occupied(mut occupied) => {
                 if !occupied.get().is_expired() {
                     self.hits.fetch_add(1, Ordering::Relaxed);
@@ -432,7 +432,7 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> Cached<K, V> for ExpiringCache<K,
         k: K,
         f: F,
     ) -> Result<&mut V, E> {
-        match self.store.store.entry(k) {
+        match self.store.entry(k) {
             std::collections::hash_map::Entry::Occupied(mut occupied) => {
                 if !occupied.get().is_expired() {
                     self.hits.fetch_add(1, Ordering::Relaxed);
@@ -459,7 +459,7 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> Cached<K, V> for ExpiringCache<K,
 
     fn cache_set(&mut self, k: K, v: V) -> Option<V> {
         use std::collections::hash_map::Entry;
-        match self.store.store.entry(k) {
+        match self.store.entry(k) {
             Entry::Occupied(mut occupied) => {
                 let old = occupied.insert(v);
                 if old.is_expired() {
@@ -502,7 +502,7 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> Cached<K, V> for ExpiringCache<K,
         K: std::borrow::Borrow<Q>,
         Q: std::hash::Hash + Eq + ?Sized,
     {
-        if let Some((stored_k, v)) = self.store.store.remove_entry(k) {
+        if let Some((stored_k, v)) = self.store.remove_entry(k) {
             if let Some(on_evict) = &self.on_evict {
                 on_evict(&stored_k, &v);
             }
@@ -514,16 +514,19 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> Cached<K, V> for ExpiringCache<K,
     }
 
     fn cache_clear(&mut self) {
-        self.store.cache_clear();
+        self.store.clear();
     }
 
     fn cache_reset(&mut self) {
-        self.store.cache_reset();
+        // Clear all entries and shrink capacity back toward the initial hint, matching
+        // `UnboundCache::cache_reset` (which this store used to delegate to).
+        self.store.clear();
+        self.store.shrink_to(self.initial_capacity.unwrap_or(0));
         self.cache_reset_metrics();
     }
 
     fn cache_size(&self) -> usize {
-        self.store.cache_size()
+        self.store.len()
     }
 
     fn cache_hits(&self) -> Option<u64> {
@@ -542,7 +545,6 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> Cached<K, V> for ExpiringCache<K,
         self.hits.store(0, Ordering::Relaxed);
         self.misses.store(0, Ordering::Relaxed);
         self.evictions.store(0, Ordering::Relaxed);
-        self.store.cache_reset_metrics();
     }
 
     /// Check whether the cache contains a live (non-expired) entry for `k`.
@@ -565,7 +567,6 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> CachedIter<K, V> for ExpiringCach
         V: 'a,
     {
         self.store
-            .store
             .iter()
             .filter_map(|(k, v)| if v.is_expired() { None } else { Some((k, v)) })
     }
@@ -577,7 +578,7 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> CachedPeek<K, V> for ExpiringCach
         K: std::borrow::Borrow<Q>,
         Q: std::hash::Hash + Eq + ?Sized,
     {
-        self.store.store.get(key).and_then(|value| {
+        self.store.get(key).and_then(|value| {
             if value.is_expired() {
                 None
             } else {
@@ -607,7 +608,7 @@ where
         Fut: Future<Output = V> + Send + 'a,
     {
         async move {
-            match self.store.store.entry(k) {
+            match self.store.entry(k) {
                 Entry::Occupied(mut occupied) => {
                     if !occupied.get().is_expired() {
                         self.hits.fetch_add(1, Ordering::Relaxed);
@@ -646,7 +647,7 @@ where
         Fut: Future<Output = Result<V, E>> + Send + 'a,
     {
         async move {
-            let v = match self.store.store.entry(k) {
+            let v = match self.store.entry(k) {
                 Entry::Occupied(mut occupied) => {
                     if !occupied.get().is_expired() {
                         self.hits.fetch_add(1, Ordering::Relaxed);
@@ -686,7 +687,7 @@ impl<K: Hash + Eq, V: Expires + Clone, S: BuildHasher> CloneCached<K, V>
         K: std::borrow::Borrow<Q>,
         Q: std::hash::Hash + Eq + ?Sized,
     {
-        if let Some(value) = self.store.store.get(k) {
+        if let Some(value) = self.store.get(k) {
             let expired = value.is_expired();
             if expired {
                 self.misses.fetch_add(1, Ordering::Relaxed);
@@ -712,7 +713,7 @@ impl<K: Hash + Eq, V: Expires + Clone, S: BuildHasher> CloneCached<K, V>
         Q: std::hash::Hash + Eq + ?Sized,
         V: Clone,
     {
-        if let Some(value) = self.store.store.get(k) {
+        if let Some(value) = self.store.get(k) {
             let expired = value.is_expired();
             (Some(value.clone()), expired)
         } else {
@@ -1282,6 +1283,268 @@ mod tests {
             .build()
             .unwrap();
         // The backing store must have at least the requested capacity.
-        assert!(c.store.store.capacity() >= 32);
+        assert!(c.store.capacity() >= 32);
+    }
+
+    #[test]
+    fn struct_holds_hashmap_directly_not_an_unbound_cache() {
+        // `ExpiringCache` used to wrap a full `UnboundCache` (HashMap + two
+        // `StripedCounter`s, each a `Box<[Slot]>` fat-pointer field, plus a dead
+        // `on_evict` field) purely for `cache_clear` / `cache_reset` / `cache_size`
+        // / `cache_reset_metrics`, while every read/write bypassed it entirely.
+        // Now the struct holds a `HashMap` directly (plus an `initial_capacity`
+        // hint for `cache_reset`'s shrink behavior).
+        //
+        // The prior version of this test hard-coded the expected byte size of
+        // `Option<usize>` / `AtomicU64` / `Option<Arc<dyn Fn>>` and a padding
+        // slack constant. `#[repr(Rust)]` layout (padding, niche optimization,
+        // field reordering) is not guaranteed by the language, so that arithmetic
+        // could drift on a different toolchain or target and flake without any
+        // real regression. Comparing directly against the sibling `UnboundCache`
+        // struct (same K/V, built in the same compilation) sidesteps all of that:
+        // whatever the concrete field layout is on a given target, `ExpiringCache`
+        // holding its own bare `HashMap` + `initial_capacity` + 3x `AtomicU64` +
+        // `on_evict` is strictly smaller than `UnboundCache` holding a `HashMap` +
+        // 2x `StripedCounter` + `initial_capacity` + `on_evict` (one extra
+        // `AtomicU64` costs less than a second `StripedCounter`). If `ExpiringCache`
+        // ever again embeds an `UnboundCache` (directly or via a wrapper), its size
+        // becomes `UnboundCache`'s size *plus* its own extra fields, which flips
+        // this comparison and fails the assertion on any target.
+        let expiring = std::mem::size_of::<ExpiringCache<u8, ExpiredU8>>();
+        let unbound = std::mem::size_of::<crate::UnboundCache<u8, ExpiredU8>>();
+        assert!(
+            expiring < unbound,
+            "ExpiringCache ({expiring} bytes) must be smaller than UnboundCache \
+             ({unbound} bytes) for the same K/V types; equal-or-larger implies \
+             ExpiringCache is once again wrapping a full UnboundCache instead of \
+             holding a bare HashMap directly"
+        );
+    }
+
+    #[test]
+    fn cache_reset_shrinks_toward_initial_capacity_hint_matching_unbound_cache() {
+        // Exercise the `shrink_to(initial_capacity.unwrap_or(0))` branch with a
+        // real, non-default hint (the other reset test uses the default builder,
+        // so `initial_capacity` is `None` and this branch collapses to
+        // `shrink_to(0)`, leaving it unexercised).
+        let init_capacity = 4usize;
+        let n: u32 = 200;
+        let mut c: ExpiringCache<u32, ExpiredU8> = ExpiringCache::builder()
+            .initial_capacity(init_capacity)
+            .build()
+            .unwrap();
+        for i in 0..n {
+            c.cache_set(i, ExpiredU8(1));
+        }
+        let grown_capacity = c.store.capacity();
+        assert!(
+            grown_capacity >= n as usize,
+            "sanity: inserting well beyond the hint must have grown the map"
+        );
+
+        c.cache_reset();
+        assert_eq!(c.cache_size(), 0);
+        let reset_capacity = c.store.capacity();
+        assert!(
+            reset_capacity < grown_capacity,
+            "cache_reset must shrink the map back down from the grown capacity \
+             ({grown_capacity}), not leave it in place (got {reset_capacity})"
+        );
+        assert!(
+            reset_capacity >= init_capacity,
+            "cache_reset must settle near the initial_capacity hint ({init_capacity}), \
+             not shrink all the way to 0 (got {reset_capacity})"
+        );
+
+        // Equivalence contract: `ExpiringCache::cache_reset` is documented to
+        // reproduce `UnboundCache::cache_reset`'s shrink behavior. For the same
+        // key type, initial_capacity hint, and insert sequence -- both back onto
+        // `HashMap<u32, _, DefaultHashBuilder>` -- they must settle on the exact
+        // same capacity.
+        let mut u: crate::UnboundCache<u32, ExpiredU8> = crate::UnboundCache::builder()
+            .initial_capacity(init_capacity)
+            .build()
+            .unwrap();
+        for i in 0..n {
+            u.cache_set(i, ExpiredU8(1));
+        }
+        u.cache_reset();
+        assert_eq!(
+            reset_capacity,
+            u.store.capacity(),
+            "ExpiringCache::cache_reset must settle on the same capacity as \
+             UnboundCache::cache_reset for the same initial_capacity hint"
+        );
+    }
+
+    #[test]
+    fn clone_preserves_initial_capacity_hint_for_reset() {
+        // `Clone` now also copies `initial_capacity`; verify that copy is not
+        // just structural but actually drives the clone's own `cache_reset`
+        // shrink behavior, and that the clone remains independent of the
+        // original (mutating/resetting the clone does not affect the source).
+        let init_capacity = 8usize;
+        let n: u32 = 100;
+        let mut c: ExpiringCache<u32, ExpiredU8> = ExpiringCache::builder()
+            .initial_capacity(init_capacity)
+            .build()
+            .unwrap();
+        for i in 0..n {
+            c.cache_set(i, ExpiredU8(1));
+        }
+        let mut clone = c.clone();
+        assert_eq!(clone.cache_size(), n as usize);
+
+        let grown_capacity = clone.store.capacity();
+        clone.cache_reset();
+        assert_eq!(clone.cache_size(), 0);
+        assert!(
+            clone.store.capacity() < grown_capacity,
+            "clone must shrink on reset just like the original would"
+        );
+        assert!(
+            clone.store.capacity() >= init_capacity,
+            "clone must carry its own initial_capacity hint after Clone, not \
+             default to shrinking all the way to 0"
+        );
+        // The original is untouched by resetting the clone.
+        assert_eq!(c.cache_size(), n as usize);
+    }
+
+    #[test]
+    fn cache_size_includes_expired_but_iter_excludes_and_evict_removes_them() {
+        // Pins the documented `cache_size` / `iter` / `evict` contract: `cache_size`
+        // is the raw stored-entry count (including expired-but-unswept entries),
+        // `iter()` filters expired entries from the view without removing them,
+        // and `evict()` is the only one of the three that physically removes them.
+        use crate::{CacheEvict, CachedIter};
+        let mut c: ExpiringCache<u8, ExpiredU8> = ExpiringCache::builder().build().unwrap();
+        c.cache_set(1, ExpiredU8(5)); // live
+        c.cache_set(2, ExpiredU8(15)); // expired, never re-accessed so stays physically present
+        c.cache_set(3, ExpiredU8(20)); // expired
+
+        assert_eq!(
+            c.cache_size(),
+            3,
+            "cache_size includes unswept expired entries"
+        );
+        assert_eq!(
+            CachedIter::iter(&c).count(),
+            1,
+            "iter excludes expired entries"
+        );
+        assert_eq!(
+            c.cache_size(),
+            3,
+            "iter must not physically remove anything"
+        );
+
+        let removed = CacheEvict::evict(&mut c);
+        assert_eq!(removed, 2, "evict must sweep both expired entries");
+        assert_eq!(c.cache_size(), 1);
+        assert_eq!(CachedIter::iter(&c).count(), 1);
+    }
+
+    #[test]
+    fn cache_get_or_set_with_miss_inserts_value_and_counts() {
+        // The Vacant arm of `cache_get_or_set_with_mut` (a plain cache miss on an
+        // absent key) has no direct coverage elsewhere in this module -- existing
+        // tests only exercise the Occupied (hit / expired) arms.
+        let mut c: ExpiringCache<u8, ExpiredU8> = ExpiringCache::builder().build().unwrap();
+        let mut called = false;
+        let v = c.cache_get_or_set_with(1, || {
+            called = true;
+            ExpiredU8(9)
+        });
+        assert!(called, "closure must run on cache miss");
+        assert_eq!(*v, ExpiredU8(9));
+        assert_eq!(c.cache_misses(), Some(1));
+        assert_eq!(c.cache_hits(), Some(0));
+        assert_eq!(c.cache_size(), 1);
+        assert_eq!(
+            c.cache_peek(&1),
+            Some(&ExpiredU8(9)),
+            "the value must actually be stored, not just returned transiently"
+        );
+    }
+
+    #[test]
+    fn cache_try_get_or_set_with_miss_ok_inserts_value() {
+        let mut c: ExpiringCache<u8, ExpiredU8> = ExpiringCache::builder().build().unwrap();
+        let result: Result<&ExpiredU8, &str> = c.cache_try_get_or_set_with(1, || Ok(ExpiredU8(7)));
+        assert_eq!(*result.unwrap(), ExpiredU8(7));
+        assert_eq!(c.cache_misses(), Some(1));
+        assert_eq!(c.cache_size(), 1);
+    }
+
+    #[test]
+    fn cache_try_get_or_set_with_miss_err_inserts_nothing() {
+        // The Vacant + Err arm: `f()?` short-circuits before `vacant.insert` runs,
+        // so a failing factory on an absent key must leave the cache empty.
+        let mut c: ExpiringCache<u8, ExpiredU8> = ExpiringCache::builder().build().unwrap();
+        let result: Result<&ExpiredU8, &str> = c.cache_try_get_or_set_with(1, || Err("boom"));
+        assert!(result.is_err());
+        assert_eq!(c.cache_misses(), Some(1));
+        assert_eq!(
+            c.cache_size(),
+            0,
+            "a failing factory on a vacant key must not insert anything"
+        );
+    }
+
+    #[cfg(feature = "async_core")]
+    #[tokio::test]
+    async fn async_cache_get_or_set_with_hit_does_not_call_factory() {
+        // The Occupied + live arm of `async_cache_get_or_set_with_mut` has no
+        // coverage anywhere in the crate; only the Occupied + expired arm is
+        // covered (tests/v3_expiring_evict_order.rs).
+        use crate::CachedGetOrSetAsync;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering as AOrdering};
+        let mut c: ExpiringCache<u8, ExpiredU8> = ExpiringCache::builder().build().unwrap();
+        c.cache_set(1, ExpiredU8(5)); // live
+        let called = Arc::new(AtomicBool::new(false));
+        let called2 = called.clone();
+        let v = c
+            .async_cache_get_or_set_with_mut(1, move || async move {
+                called2.store(true, AOrdering::Relaxed);
+                ExpiredU8(99)
+            })
+            .await;
+        assert!(
+            !called.load(AOrdering::Relaxed),
+            "factory must not run on cache hit"
+        );
+        assert_eq!(*v, ExpiredU8(5));
+        assert_eq!(c.cache_hits(), Some(1));
+        assert_eq!(c.cache_misses(), Some(0));
+    }
+
+    #[cfg(feature = "async_core")]
+    #[tokio::test]
+    async fn async_cache_get_or_set_with_miss_inserts_value_and_counts() {
+        // The Vacant arm has no coverage anywhere in the crate.
+        use crate::CachedGetOrSetAsync;
+        let mut c: ExpiringCache<u8, ExpiredU8> = ExpiringCache::builder().build().unwrap();
+        let v = c
+            .async_cache_get_or_set_with_mut(1, || async { ExpiredU8(9) })
+            .await;
+        assert_eq!(*v, ExpiredU8(9));
+        assert_eq!(c.cache_misses(), Some(1));
+        assert_eq!(c.cache_size(), 1);
+    }
+
+    #[cfg(feature = "async_core")]
+    #[tokio::test]
+    async fn async_cache_try_get_or_set_with_miss_err_inserts_nothing() {
+        // The Vacant + Err arm has no coverage anywhere in the crate.
+        use crate::CachedGetOrSetAsync;
+        let mut c: ExpiringCache<u8, ExpiredU8> = ExpiringCache::builder().build().unwrap();
+        let result: Result<&mut ExpiredU8, &str> = c
+            .async_cache_try_get_or_set_with_mut(1, || async { Err("boom") })
+            .await;
+        assert!(result.is_err());
+        assert_eq!(c.cache_misses(), Some(1));
+        assert_eq!(c.cache_size(), 0);
     }
 }

--- a/src/stores/expiring_lru.rs
+++ b/src/stores/expiring_lru.rs
@@ -972,36 +972,70 @@ mod tests {
     }
 
     #[test]
-    fn cache_set_overwrite_does_not_promote_to_mru() {
-        // Perf shard item 5: `cache_set` switched from `LruCache::cache_set` + a caller-key
-        // clone to `LruCache::cache_set_returning_entry`. That primitive replaces an
-        // existing entry in place (`order.set`) and does NOT promote it to MRU (the
-        // documented recency trap) -- matching the old `LruCache::cache_set` behavior. This
-        // guards against a regression that adds an accidental `move_to_front` on this path,
-        // or against the switch silently starting to promote.
+    fn cache_set_overwrite_promotes_to_mru() {
+        // `cache_set` goes through `LruCache::cache_set_returning_entry`, which promotes an
+        // overwritten key to MRU: a write is an access. The user-visible consequence is
+        // which entry a later capacity eviction picks.
         let mut c: ExpiringLruCache<u8, ExpiredU8> =
             ExpiringLruCache::builder().max_size(3).build().unwrap();
         c.cache_set(1, 1); // live
         c.cache_set(2, 2); // live
         c.cache_set(3, 3); // live
         // LRU order after inserts (MRU -> LRU): 3, 2, 1.
+        assert_eq!(c.key_order(), vec![3, 2, 1]);
 
         // Overwrite key 1 -- the least-recently-used entry -- with a new live value.
-        // Because cache_set must not promote, 1 remains the LRU entry.
+        // The write promotes it, so 2 becomes the LRU entry.
         assert_eq!(c.cache_set(1, 10), Some(1));
+        assert_eq!(c.key_order(), vec![1, 3, 2]);
 
-        // Insert a 4th key to force a capacity eviction. If cache_set had wrongly promoted
-        // key 1, key 2 (now the true LRU) would be evicted instead of key 1.
+        // Insert a 4th key to force a capacity eviction: key 2 is now the victim.
         c.cache_set(4, 4);
         assert_eq!(c.cache_size(), 3);
         assert_eq!(
-            c.cache_get(&1),
+            c.cache_get(&2),
             None,
-            "key 1 must still be LRU and get evicted -- cache_set must not promote on overwrite"
+            "key 2 is the LRU victim -- cache_set promoted key 1 on overwrite"
         );
-        assert_eq!(c.cache_get(&2), Some(&2));
+        assert_eq!(c.cache_get(&1), Some(&10));
         assert_eq!(c.cache_get(&3), Some(&3));
         assert_eq!(c.cache_get(&4), Some(&4));
+    }
+
+    #[test]
+    fn cache_set_over_current_mru_and_sole_entry_keep_the_list_intact() {
+        let mut c: ExpiringLruCache<u8, ExpiredU8> =
+            ExpiringLruCache::builder().max_size(3).build().unwrap();
+        c.cache_set(1, 1);
+        c.cache_set(2, 2);
+        c.cache_set(3, 3);
+        // Overwriting the head exercises `move_to_front` on an already-front slot.
+        assert_eq!(c.cache_set(3, 4), Some(3));
+        assert_eq!(c.key_order(), vec![3, 2, 1]);
+        assert_eq!(c.cache_size(), 3);
+        let values: Vec<u8> = c.value_order().iter().map(|v| **v).collect();
+        assert_eq!(values, vec![4u8, 2, 1]);
+
+        // Sole entry of a 1-capacity cache.
+        let mut d: ExpiringLruCache<u8, ExpiredU8> =
+            ExpiringLruCache::builder().max_size(1).build().unwrap();
+        d.cache_set(1, 1);
+        assert_eq!(d.cache_set(1, 2), Some(1));
+        assert_eq!(d.key_order(), vec![1]);
+        assert_eq!(d.cache_size(), 1);
+    }
+
+    #[test]
+    fn cache_peek_still_does_not_promote_after_set_does() {
+        let mut c: ExpiringLruCache<u8, ExpiredU8> =
+            ExpiringLruCache::builder().max_size(3).build().unwrap();
+        c.cache_set(1, 1);
+        c.cache_set(2, 2);
+        c.cache_set(3, 3);
+        assert!(CachedPeek::cache_peek(&c, &1).is_some());
+        assert_eq!(c.key_order(), vec![3, 2, 1], "peek must not promote");
+        assert_eq!(c.cache_set(1, 4), Some(1));
+        assert_eq!(c.key_order(), vec![1, 3, 2]);
     }
 
     #[test]

--- a/src/stores/expiring_lru.rs
+++ b/src/stores/expiring_lru.rs
@@ -404,13 +404,9 @@ impl<K: Clone + Hash + Eq, V: Expires, S: BuildHasher> ExpiringLruCache<K, V, S>
         if self.on_evict.is_none() {
             return self.cache_clear();
         }
-        let keys = self.store.key_order();
-        let mut removed = Vec::with_capacity(keys.len());
-        for k in &keys {
-            if let Some(pair) = self.store.pop_raw(k) {
-                removed.push(pair);
-            }
-        }
+        // `drain_all` walks the LRU chain once taking owned pairs (MRU -> LRU, the same
+        // order the old key-by-key drain fired in) -- no key clones, no re-hashing.
+        let removed = self.store.drain_all();
         let count = removed.len() as u64;
         if count > 0 {
             self.evictions.fetch_add(count, Ordering::Relaxed);
@@ -448,17 +444,17 @@ impl<K: Clone + Hash + Eq, V: Expires, S: BuildHasher> ExpiringLruCache<K, V, S>
     where
         K: Clone,
     {
-        self.store
-            .order
-            .iter()
-            .filter_map(|(k, v)| {
-                if v.is_expired() {
-                    None
-                } else {
-                    Some(k.clone())
-                }
-            })
-            .collect()
+        // Upper-bound pre-size on the raw stored count (may include expired entries not
+        // yet swept); the filter below can only shrink the final length.
+        let mut out = Vec::with_capacity(self.store.cache_size());
+        out.extend(self.store.order.iter().filter_map(|(k, v)| {
+            if v.is_expired() {
+                None
+            } else {
+                Some(k.clone())
+            }
+        }));
+        out
     }
 
     /// Return a `Vec` of [`CacheValue`](super::CacheValue)-wrapped values in the
@@ -468,17 +464,17 @@ impl<K: Clone + Hash + Eq, V: Expires, S: BuildHasher> ExpiringLruCache<K, V, S>
     where
         V: Clone,
     {
-        self.store
-            .order
-            .iter()
-            .filter_map(|(_, v)| {
-                if v.is_expired() {
-                    None
-                } else {
-                    Some(super::CacheValue::new(v.clone(), ()))
-                }
-            })
-            .collect()
+        // Upper-bound pre-size on the raw stored count (may include expired entries not
+        // yet swept); the filter below can only shrink the final length.
+        let mut out = Vec::with_capacity(self.store.cache_size());
+        out.extend(self.store.order.iter().filter_map(|(_, v)| {
+            if v.is_expired() {
+                None
+            } else {
+                Some(super::CacheValue::new(v.clone(), ()))
+            }
+        }));
+        out
     }
 }
 
@@ -500,7 +496,9 @@ impl<K: Hash + Eq + Clone, V: Expires, S: BuildHasher> Cached<K, V> for Expiring
                 Some(&self.store.order.get(index).1)
             } else {
                 self.misses.fetch_add(1, Ordering::Relaxed);
-                if let Some((key, old)) = self.store.pop_raw(k) {
+                // `hash` was already computed above for `get_index`; reuse it instead of
+                // letting `pop_raw` re-hash the same key.
+                if let Some((key, old)) = self.store.pop_raw_with_hash(hash, k) {
                     if let Some(on_evict) = &self.on_evict {
                         on_evict(&key, &old);
                     }
@@ -528,7 +526,9 @@ impl<K: Hash + Eq + Clone, V: Expires, S: BuildHasher> Cached<K, V> for Expiring
                 Some(&mut self.store.order.get_mut(index).1)
             } else {
                 self.misses.fetch_add(1, Ordering::Relaxed);
-                if let Some((k, old)) = self.store.pop_raw(key) {
+                // `hash` was already computed above for `get_index`; reuse it instead of
+                // letting `pop_raw` re-hash the same key.
+                if let Some((k, old)) = self.store.pop_raw_with_hash(hash, key) {
                     if let Some(on_evict) = &self.on_evict {
                         on_evict(&k, &old);
                     }
@@ -602,19 +602,24 @@ impl<K: Hash + Eq + Clone, V: Expires, S: BuildHasher> Cached<K, V> for Expiring
         Ok(v)
     }
     fn cache_set(&mut self, k: K, v: V) -> Option<V> {
-        // Clone the key only when a callback might need it. The inner `LruCache::cache_set` does
-        // not fire `on_evict` on an overwrite, so an expired displaced value would otherwise be
-        // dropped silently; filter it from the return and fire `on_evict` + count once here.
-        let key_for_evict = self.on_evict.as_ref().map(|_| k.clone());
-        match self.store.cache_set(k, v) {
-            Some(old) if old.is_expired() => {
-                if let (Some(on_evict), Some(key)) = (&self.on_evict, &key_for_evict) {
-                    on_evict(key, &old);
+        // `cache_set_returning_entry` hands back the STORED key/value of the displaced
+        // entry, so no caller-side key clone is needed to feed `on_evict` (unlike the old
+        // `LruCache::cache_set` + `k.clone()` combination, which cloned the key on every
+        // insert whenever `on_evict` was configured). Like the plain `LruCache::cache_set`
+        // it does NOT fire `on_evict` on an overwrite itself, so an expired displaced value
+        // would otherwise be dropped silently; filter it from the return and fire
+        // `on_evict` + count once here -- now with the STORED key, matching
+        // `LruTtlCache::set_entry`.
+        match self.store.cache_set_returning_entry(k, v) {
+            Some((stored_key, old)) if old.is_expired() => {
+                if let Some(on_evict) = &self.on_evict {
+                    on_evict(&stored_key, &old);
                 }
                 self.evictions.fetch_add(1, Ordering::Relaxed);
                 None
             }
-            other => other,
+            Some((_, old)) => Some(old),
+            None => None,
         }
     }
     /// Removes the entry and returns the value only if it is still live;
@@ -967,6 +972,39 @@ mod tests {
     }
 
     #[test]
+    fn cache_set_overwrite_does_not_promote_to_mru() {
+        // Perf shard item 5: `cache_set` switched from `LruCache::cache_set` + a caller-key
+        // clone to `LruCache::cache_set_returning_entry`. That primitive replaces an
+        // existing entry in place (`order.set`) and does NOT promote it to MRU (the
+        // documented recency trap) -- matching the old `LruCache::cache_set` behavior. This
+        // guards against a regression that adds an accidental `move_to_front` on this path,
+        // or against the switch silently starting to promote.
+        let mut c: ExpiringLruCache<u8, ExpiredU8> =
+            ExpiringLruCache::builder().max_size(3).build().unwrap();
+        c.cache_set(1, 1); // live
+        c.cache_set(2, 2); // live
+        c.cache_set(3, 3); // live
+        // LRU order after inserts (MRU -> LRU): 3, 2, 1.
+
+        // Overwrite key 1 -- the least-recently-used entry -- with a new live value.
+        // Because cache_set must not promote, 1 remains the LRU entry.
+        assert_eq!(c.cache_set(1, 10), Some(1));
+
+        // Insert a 4th key to force a capacity eviction. If cache_set had wrongly promoted
+        // key 1, key 2 (now the true LRU) would be evicted instead of key 1.
+        c.cache_set(4, 4);
+        assert_eq!(c.cache_size(), 3);
+        assert_eq!(
+            c.cache_get(&1),
+            None,
+            "key 1 must still be LRU and get evicted -- cache_set must not promote on overwrite"
+        );
+        assert_eq!(c.cache_get(&2), Some(&2));
+        assert_eq!(c.cache_get(&3), Some(&3));
+        assert_eq!(c.cache_get(&4), Some(&4));
+    }
+
+    #[test]
     fn expiring_lru_try_get_or_set_with_err_keeps_expired_and_counts_miss() {
         // EXP-2: on a factory Err over an expired entry, ExpiringLruCache counts a miss the
         // instant the factory runs (matching ExpiringCache) instead of losing it on the `?`
@@ -1044,6 +1082,65 @@ mod tests {
         assert_eq!(c.get(&1), Some(&2));
         assert_eq!(c.cache_hits(), Some(1));
         assert_eq!(c.cache_misses(), Some(0));
+    }
+
+    #[test]
+    fn cache_get_lazy_sweep_of_expired_fires_on_evict_with_correct_key_and_removes_entry() {
+        // Perf shard item 3: cache_get's expired branch now reuses the hash already
+        // computed for get_index via pop_raw_with_hash instead of letting pop_raw
+        // re-hash. Pin that the sweep still fires on_evict with the right key/value,
+        // increments evictions exactly once, and physically removes the entry.
+        use std::sync::{Arc, Mutex};
+        let fired: Arc<Mutex<Vec<(u8, u8)>>> = Arc::new(Mutex::new(Vec::new()));
+        let fired2 = fired.clone();
+        let mut c: ExpiringLruCache<u8, ExpiredU8> = ExpiringLruCache::builder()
+            .max_size(4)
+            .on_evict(move |k: &u8, v: &ExpiredU8| fired2.lock().unwrap().push((*k, *v)))
+            .build()
+            .unwrap();
+        c.cache_set(1, 20); // expired: 20 > 10
+        assert_eq!(c.cache_get(&1), None, "expired entry must not be returned");
+        assert_eq!(
+            fired.lock().unwrap().clone(),
+            vec![(1u8, 20u8)],
+            "on_evict must fire once with the expired entry's key and value"
+        );
+        assert_eq!(c.cache_evictions(), Some(1));
+        assert_eq!(
+            c.cache_size(),
+            0,
+            "the expired entry must be physically removed by the lazy sweep"
+        );
+    }
+
+    #[test]
+    fn cache_get_mut_lazy_sweep_of_expired_fires_on_evict_with_correct_key_and_removes_entry() {
+        // Same as the cache_get variant above, for cache_get_mut's expired branch.
+        use std::sync::{Arc, Mutex};
+        let fired: Arc<Mutex<Vec<(u8, u8)>>> = Arc::new(Mutex::new(Vec::new()));
+        let fired2 = fired.clone();
+        let mut c: ExpiringLruCache<u8, ExpiredU8> = ExpiringLruCache::builder()
+            .max_size(4)
+            .on_evict(move |k: &u8, v: &ExpiredU8| fired2.lock().unwrap().push((*k, *v)))
+            .build()
+            .unwrap();
+        c.cache_set(1, 20); // expired: 20 > 10
+        assert_eq!(
+            c.cache_get_mut(&1),
+            None,
+            "expired entry must not be returned"
+        );
+        assert_eq!(
+            fired.lock().unwrap().clone(),
+            vec![(1u8, 20u8)],
+            "on_evict must fire once with the expired entry's key and value"
+        );
+        assert_eq!(c.cache_evictions(), Some(1));
+        assert_eq!(
+            c.cache_size(),
+            0,
+            "the expired entry must be physically removed by the lazy sweep"
+        );
     }
 
     #[test]
@@ -1243,6 +1340,38 @@ mod tests {
             "on_evict fires for all entries including expired"
         );
         assert_eq!(c.evictions.load(AOrdering::Relaxed), 3);
+    }
+
+    #[test]
+    fn cache_clear_with_on_evict_fires_in_mru_to_lru_order() {
+        // Perf shard item 1: `cache_clear_with_on_evict` was rewritten to use
+        // `LruCache::drain_all`, which must preserve the same MRU -> LRU firing order
+        // the old key-by-key `key_order()` + `pop_raw` loop produced.
+        use std::sync::{Arc, Mutex};
+        let fired: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let fired2 = fired.clone();
+        let mut c: ExpiringLruCache<u8, ExpiredU8> = ExpiringLruCache::builder()
+            .max_size(5)
+            .on_evict(move |k: &u8, _v: &ExpiredU8| {
+                fired2.lock().unwrap().push(*k);
+            })
+            .build()
+            .unwrap();
+        // Insert order: 1, 2, 3 -> LRU order after inserts: 1 < 2 < 3.
+        c.cache_set(1, 5);
+        c.cache_set(2, 6);
+        c.cache_set(3, 7);
+        // Access 1 then 2 so the final MRU -> LRU order is: 2, 1, 3.
+        let _ = c.cache_get(&1);
+        let _ = c.cache_get(&2);
+
+        c.cache_clear_with_on_evict();
+
+        assert_eq!(
+            fired.lock().unwrap().clone(),
+            vec![2u8, 1, 3],
+            "on_evict must fire in most-recently-used to least-recently-used order"
+        );
     }
 
     #[test]

--- a/src/stores/lru.rs
+++ b/src/stores/lru.rs
@@ -694,13 +694,14 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruCache<K, V, S> {
     /// Slot indices (MRU -> LRU) of the entries for which `keep` returns `false`.
     /// Shared by [`retain`](Self::retain) and [`retain_silent`](Self::retain_silent).
     fn doomed_indices<F: FnMut(&K, &V) -> bool>(&self, keep: &mut F) -> Vec<usize> {
-        self.order
-            .iter_indices()
-            .filter(|&i| {
-                let (k, v) = self.order.get(i);
-                !keep(k, v)
-            })
-            .collect()
+        // The live entry count is an upper bound on the number of doomed indices;
+        // pre-size instead of growing the Vec from zero.
+        let mut doomed = Vec::with_capacity(self.store.len());
+        doomed.extend(self.order.iter_indices().filter(|&i| {
+            let (k, v) = self.order.get(i);
+            !keep(k, v)
+        }));
+        doomed
     }
 
     /// Removes entries for which `keep` returns `false` without firing `on_evict` or

--- a/src/stores/lru.rs
+++ b/src/stores/lru.rs
@@ -723,23 +723,20 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruCache<K, V, S> {
     /// differ in those extra fields. Used by `LruTtlCache::set_entry` to pass the correct stored
     /// key to `on_evict`.
     ///
-    /// # Recency trap
+    /// # Recency
     ///
-    /// On an existing key this replaces the entry **in place** (`order.set`) and does
-    /// **NOT** promote it to most-recently-used, matching [`Cached::cache_set`]. A
-    /// remove-then-insert (`pop_raw` + `cache_set`) *does* promote, because the insert
-    /// goes through `push_front`. Any caller switching from remove-then-insert to this
-    /// method changes observable LRU order unless it follows up with
-    /// `order.move_to_front(index)` (or a `cache_get`) to restore the promotion.
+    /// Like [`Cached::cache_set`], writing over an existing key promotes that entry to
+    /// most-recently-used: a write counts as an access, so an overwrite is equivalent to
+    /// inserting a fresh value. This matches a remove-then-insert (`pop_raw` +
+    /// `cache_set`), whose insert goes through `push_front`.
     // Deliberately NOT `#[cfg(feature = "time_stores")]`: nothing in the body is
-    // time-related, and non-time_stores callers need it too. The only in-tree callers
-    // today are `time_stores`-gated, hence the dead-code allowance for builds without
-    // that feature.
-    #[cfg_attr(not(feature = "time_stores"), allow(dead_code))]
+    // time-related, and non-time_stores callers need it too.
     pub(super) fn cache_set_returning_entry(&mut self, key: K, val: V) -> Option<(K, V)> {
         let hash = self.hash(&key);
         let entry = if let Some(index) = self.get_index(hash, &key) {
-            self.order.set(index, (key, val))
+            let displaced = self.order.set(index, (key, val));
+            self.order.move_to_front(index);
+            displaced
         } else {
             let index = self.order.push_front((key, val));
             self.insert_index(hash, index);
@@ -901,14 +898,17 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruCache<K, V, S>
     /// Returns the previous value if the key already existed, or `None` for a
     /// new insertion.
     ///
-    /// **Note:** overwriting an existing key replaces the value in-place
-    /// **without** refreshing the key's LRU recency. The entry stays at its
-    /// current position in the eviction order. Use `cache_get` before
-    /// `cache_set` if you need to promote the entry to most-recently-used.
+    /// **Note:** overwriting an existing key promotes that key to
+    /// most-recently-used. A write counts as an access, so an overwrite moves
+    /// the entry to the front of the eviction order exactly as a fresh
+    /// insertion would. Use [`CachedPeek::cache_peek`](crate::CachedPeek::cache_peek)
+    /// if you need to inspect an entry without touching recency.
     fn cache_set(&mut self, key: K, val: V) -> Option<V> {
         let hash = self.hash(&key);
         let v = if let Some(index) = self.get_index(hash, &key) {
-            self.order.set(index, (key, val)).map(|(_, v)| v)
+            let displaced = self.order.set(index, (key, val)).map(|(_, v)| v);
+            self.order.move_to_front(index);
+            displaced
         } else {
             let index = self.order.push_front((key, val));
             self.insert_index(hash, index);
@@ -1601,30 +1601,29 @@ mod tests {
     }
 
     #[test]
-    fn cache_set_returning_entry_replaces_in_place_without_promoting() {
-        // TRAP: `cache_set_returning_entry` replaces via `order.set` and does NOT
-        // promote to MRU, while remove-then-insert does (`push_front`). Any caller
-        // switching to it must add `order.move_to_front(index)` for promotion.
+    fn cache_set_returning_entry_promotes_replaced_entry_to_mru() {
+        // `cache_set_returning_entry` matches `Cached::cache_set`: a write over an
+        // existing key promotes it to MRU, exactly as remove-then-insert would.
         let mut c = LruCache::builder().max_size(3).build().unwrap();
         c.cache_set(1u32, 10u32);
         c.cache_set(2u32, 20u32);
         c.cache_set(3u32, 30u32);
         assert_eq!(c.key_order(), vec![3, 2, 1]);
 
-        // Replacing the least-recently-used entry returns the stored pair and leaves
-        // the entry exactly where it was.
+        // Replacing the least-recently-used entry returns the stored pair and moves
+        // the entry to the front.
         assert_eq!(c.cache_set_returning_entry(1, 11), Some((1, 10)));
         assert_eq!(
             c.key_order(),
-            vec![3, 2, 1],
-            "cache_set_returning_entry must NOT promote the replaced entry"
+            vec![1, 3, 2],
+            "cache_set_returning_entry must promote the replaced entry to MRU"
         );
-        assert_eq!(c.value_order(), vec![30, 20, 11]);
+        assert_eq!(c.value_order(), vec![11, 30, 20]);
 
-        // Contrast: remove-then-insert DOES promote.
-        assert_eq!(c.pop_raw(&1u32), Some((1, 11)));
-        assert_eq!(Cached::cache_set(&mut c, 1u32, 12u32), None);
-        assert_eq!(c.key_order(), vec![1, 3, 2]);
+        // Remove-then-insert agrees.
+        assert_eq!(c.pop_raw(&2u32), Some((2, 20)));
+        assert_eq!(Cached::cache_set(&mut c, 2u32, 22u32), None);
+        assert_eq!(c.key_order(), vec![2, 1, 3]);
 
         // A fresh key inserts at the front and returns None.
         let mut d = LruCache::builder().max_size(3).build().unwrap();
@@ -1648,17 +1647,88 @@ mod tests {
     }
 
     #[test]
-    fn cache_set_over_existing_key_does_not_promote_recency() {
+    fn cache_set_over_existing_key_promotes_to_mru() {
         let mut c = LruCache::builder().max_size(3).build().unwrap();
         c.set(1, 10);
         c.set(2, 20);
         c.set(3, 30);
         assert_eq!(c.key_order(), vec![3, 2, 1]);
-        // Overwriting the least-recently-used key updates the value in-place and
-        // returns the old value, but must NOT move it to the front.
+        // Overwriting the least-recently-used key returns the old value and promotes
+        // the entry to most-recently-used: a write is an access.
         assert_eq!(Cached::cache_set(&mut c, 1, 11), Some(10));
+        assert_eq!(c.key_order(), vec![1, 3, 2]);
+        assert_eq!(c.value_order(), vec![11, 30, 20]);
+    }
+
+    #[test]
+    fn cache_set_over_current_mru_keeps_it_at_the_front() {
+        // Exercises `move_to_front` on a slot that is already the head: `unlink` +
+        // `link_after` must be a no-op there, not corrupt the chain.
+        let mut c = LruCache::builder().max_size(3).build().unwrap();
+        c.set(1, 10);
+        c.set(2, 20);
+        c.set(3, 30);
         assert_eq!(c.key_order(), vec![3, 2, 1]);
-        assert_eq!(c.value_order(), vec![30, 20, 11]);
+
+        assert_eq!(Cached::cache_set(&mut c, 3, 33), Some(30));
+        assert_eq!(c.key_order(), vec![3, 2, 1]);
+        assert_eq!(c.value_order(), vec![33, 20, 10]);
+
+        // The chain is still intact in both directions: the LRU victim is still 1,
+        // and every entry is reachable.
+        assert_eq!(c.cache_size(), 3);
+        let entries: Vec<(u32, u32)> = c.iter_order().into_iter().map(|(k, v)| (k, *v)).collect();
+        assert_eq!(entries, vec![(3, 33), (2, 20), (1, 10)]);
+        c.set(4, 40);
+        assert_eq!(c.key_order(), vec![4, 3, 2]);
+        assert_eq!(c.cache_get(&1), None);
+    }
+
+    #[test]
+    fn cache_set_over_sole_entry_of_capacity_one_cache() {
+        let mut c: LruCache<u32, u32> = LruCache::builder().max_size(1).build().unwrap();
+        c.set(1, 10);
+        assert_eq!(Cached::cache_set(&mut c, 1, 11), Some(10));
+        assert_eq!(c.key_order(), vec![1]);
+        assert_eq!(c.value_order(), vec![11]);
+        assert_eq!(c.cache_size(), 1);
+        // Still evicts correctly afterwards.
+        c.set(2, 20);
+        assert_eq!(c.key_order(), vec![2]);
+        assert_eq!(c.cache_size(), 1);
+    }
+
+    #[test]
+    fn cache_set_promotion_changes_the_capacity_eviction_victim() {
+        // The user-visible consequence of promote-on-set: after overwriting the LRU
+        // entry, the next insertion evicts the *other* old entry instead.
+        let mut c = LruCache::builder().max_size(3).build().unwrap();
+        c.set(1, 10);
+        c.set(2, 20);
+        c.set(3, 30);
+        // 1 is the LRU victim, but overwriting it makes 2 the victim.
+        assert_eq!(Cached::cache_set(&mut c, 1, 11), Some(10));
+        c.set(4, 40);
+        assert_eq!(c.key_order(), vec![4, 1, 3]);
+        assert_eq!(c.cache_get(&2), None, "2 became the LRU victim");
+        assert_eq!(c.cache_peek(&1), Some(&11));
+    }
+
+    #[test]
+    fn cache_peek_still_does_not_promote_after_set_does() {
+        // `cache_set` and `cache_peek` must remain distinguishable: only the write
+        // touches recency.
+        let mut c = LruCache::builder().max_size(3).build().unwrap();
+        c.set(1, 10);
+        c.set(2, 20);
+        c.set(3, 30);
+        assert_eq!(c.cache_peek(&1), Some(&10));
+        assert_eq!(c.key_order(), vec![3, 2, 1], "peek must not promote");
+        assert!(c.cache_contains(&1), "contains must not promote");
+        assert_eq!(c.key_order(), vec![3, 2, 1]);
+        // The write on the same key does promote.
+        assert_eq!(Cached::cache_set(&mut c, 1, 11), Some(10));
+        assert_eq!(c.key_order(), vec![1, 3, 2]);
     }
 
     #[test]
@@ -2834,10 +2904,10 @@ mod tests {
         // No eviction: a replace is not an eviction.
         assert!(seen.lock().unwrap().is_empty());
         assert_eq!(c.cache_evictions(), Some(0));
-        // And no promotion (the recency trap), so 1 is still the LRU victim.
+        // The write promoted 1 to MRU, so 2 is now the LRU victim.
         assert_eq!(
             c.key_order().iter().map(|k| k.id).collect::<Vec<_>>(),
-            vec![2, 1]
+            vec![1, 2]
         );
 
         // A fresh key over capacity evicts the LRU entry through `check_capacity`.
@@ -2851,11 +2921,11 @@ mod tests {
             ),
             None
         );
-        assert_eq!(*seen.lock().unwrap(), vec![(1, 11)]);
+        assert_eq!(*seen.lock().unwrap(), vec![(2, 20)]);
         assert_eq!(c.cache_evictions(), Some(1));
         assert_eq!(
             c.key_order().iter().map(|k| k.id).collect::<Vec<_>>(),
-            vec![3, 2]
+            vec![3, 1]
         );
         assert_store_and_order_agree(&c);
     }

--- a/src/stores/lru.rs
+++ b/src/stores/lru.rs
@@ -344,10 +344,15 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruCache<K, V, S> {
         K: Clone,
         V: Clone,
     {
-        self.order
-            .iter()
-            .map(|(k, v)| (k.clone(), super::CacheValue::new(v.clone(), ())))
-            .collect()
+        // `LRUListIterator` has no `size_hint`, so `collect` would grow the Vec from
+        // zero. The live entry count is known here, so pre-size instead.
+        let mut out = Vec::with_capacity(self.store.len());
+        out.extend(
+            self.order
+                .iter()
+                .map(|(k, v)| (k.clone(), super::CacheValue::new(v.clone(), ()))),
+        );
+        out
     }
 
     /// Internal tuple-form of [`iter_order`](Self::iter_order) for the wrapping
@@ -357,7 +362,9 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruCache<K, V, S> {
         K: Clone,
         V: Clone,
     {
-        self.order.iter().cloned().collect()
+        let mut out = Vec::with_capacity(self.store.len());
+        out.extend(self.order.iter().cloned());
+        out
     }
 
     /// Return a `Vec` of keys in the current order from most
@@ -367,7 +374,9 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruCache<K, V, S> {
     where
         K: Clone,
     {
-        self.order.iter().map(|(k, _v)| k.clone()).collect()
+        let mut out = Vec::with_capacity(self.store.len());
+        out.extend(self.order.iter().map(|(k, _v)| k.clone()));
+        out
     }
 
     /// Return a `Vec` of [`CacheValue`](super::CacheValue)-wrapped values in the
@@ -377,10 +386,13 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruCache<K, V, S> {
     where
         V: Clone,
     {
-        self.order
-            .iter()
-            .map(|(_k, v)| super::CacheValue::new(v.clone(), ()))
-            .collect()
+        let mut out = Vec::with_capacity(self.store.len());
+        out.extend(
+            self.order
+                .iter()
+                .map(|(_k, v)| super::CacheValue::new(v.clone(), ())),
+        );
+        out
     }
 
     pub(super) fn pop_raw<Q>(&mut self, k: &Q) -> Option<(K, V)>
@@ -389,11 +401,24 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruCache<K, V, S> {
         Q: Hash + Eq + ?Sized,
     {
         let hash = self.hash(k);
-        let key_borrow = k.borrow();
+        self.pop_raw_with_hash(hash, k)
+    }
+
+    /// [`pop_raw`](Self::pop_raw) for callers that already hold the key's hash.
+    ///
+    /// `hash` MUST be `self.hash(k)` (i.e. produced by this cache's own hash builder for
+    /// this key); passing any other value makes the lookup miss and the entry is left in
+    /// place. Use this when a caller has computed the hash for an earlier probe on the
+    /// same key -- it skips only the re-hash, the `K: Eq` bucket probe still runs.
+    pub(super) fn pop_raw_with_hash<Q>(&mut self, hash: u64, k: &Q) -> Option<(K, V)>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
         let order = &self.order;
         match self
             .store
-            .find_entry(hash, |&i| key_borrow == order.get(i).0.borrow())
+            .find_entry(hash, |&i| k == order.get(i).0.borrow())
         {
             Ok(entry) => {
                 let index = entry.remove().0;
@@ -401,6 +426,54 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruCache<K, V, S> {
             }
             Err(_) => None,
         }
+    }
+
+    /// Remove the entry occupying LRU slot `index`, returning the **stored** `(K, V)`.
+    ///
+    /// Fires no `on_evict` callback and touches no counters -- callers own those side
+    /// effects. Slot indices come from [`LRUList::iter_indices`] (or `order.back()`), and
+    /// stay valid across removals of *other* slots, so a sweep can collect a
+    /// `Vec<usize>` up front and remove from it.
+    ///
+    /// Compared to [`pop_raw`](Self::pop_raw), this removes the key **clone** and the
+    /// `K: Eq` comparisons (the table entry is located by comparing the stored slot
+    /// index, which is unique). It does **not** remove the hash: the table is keyed by
+    /// key-hash, so the stored key must still be hashed once to find its bucket. That is
+    /// unavoidable without a second index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is not an occupied slot, or if the hash table and the LRU order
+    /// have drifted out of sync (an internal invariant violation).
+    pub(super) fn remove_index(&mut self, index: usize) -> (K, V) {
+        // Hash the STORED key -- the caller may never have had a key at all.
+        let hash = {
+            let (key, _value) = self.order.get(index);
+            self.hash(key)
+        };
+        match self.store.find_entry(hash, |&i| i == index) {
+            Ok(entry) => {
+                entry.remove();
+            }
+            Err(_) => unreachable!(
+                "LruCache internal invariant violated: LRU order and hash table out of sync"
+            ),
+        }
+        self.order.remove(index)
+    }
+
+    /// Remove every entry, returning the stored `(K, V)` pairs in MRU -> LRU order.
+    ///
+    /// Fires no `on_evict` callback and touches no counters -- callers own those side
+    /// effects (see [`cache_clear_with_on_evict`](Self::cache_clear_with_on_evict)).
+    /// Unlike a key-by-key drain this performs **zero hashing and zero clones**: the LRU
+    /// chain is walked once taking owned values and the hash table is cleared wholesale.
+    /// The cache is empty and immediately reusable afterwards.
+    pub(super) fn drain_all(&mut self) -> Vec<(K, V)> {
+        let mut drained = Vec::with_capacity(self.store.len());
+        self.order.drain_into(&mut drained);
+        self.store.clear();
+        drained
     }
 
     pub(super) fn hash<Q>(&self, key: &Q) -> u64
@@ -605,29 +678,38 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruCache<K, V, S> {
     /// [`LruTtlCache::retain`](crate::LruTtlCache::retain) and
     /// [`ExpiringLruCache::retain`](crate::ExpiringLruCache::retain).
     pub fn retain<F: FnMut(&K, &V) -> bool>(&mut self, mut keep: F) {
-        let remove_keys = {
-            self.order
-                .iter()
-                .filter_map(|(k, v)| if keep(k, v) { None } else { Some(k.clone()) })
-                .collect::<Vec<_>>()
-        };
-        for k in remove_keys {
-            let _ = self.cache_remove(&k);
+        // Collect doomed *slot indices*, not cloned keys: `remove_index` then removes
+        // each entry without a key clone or an `Eq` probe. Indices stay valid because
+        // nothing is inserted between the scan and the removals.
+        let doomed = self.doomed_indices(&mut keep);
+        for index in doomed {
+            let (key, value) = self.remove_index(index);
+            if let Some(on_evict) = &self.on_evict {
+                on_evict(&key, &value);
+            }
+            self.evictions.fetch_add(1, Ordering::Relaxed);
         }
+    }
+
+    /// Slot indices (MRU -> LRU) of the entries for which `keep` returns `false`.
+    /// Shared by [`retain`](Self::retain) and [`retain_silent`](Self::retain_silent).
+    fn doomed_indices<F: FnMut(&K, &V) -> bool>(&self, keep: &mut F) -> Vec<usize> {
+        self.order
+            .iter_indices()
+            .filter(|&i| {
+                let (k, v) = self.order.get(i);
+                !keep(k, v)
+            })
+            .collect()
     }
 
     /// Removes entries for which `keep` returns `false` without firing `on_evict` or
     /// incrementing `evictions`. Used internally by TTL/expiring wrapper stores to avoid
     /// double-counting when those wrappers handle eviction side effects themselves.
     pub(super) fn retain_silent<F: FnMut(&K, &V) -> bool>(&mut self, mut keep: F) {
-        let remove_keys = {
-            self.order
-                .iter()
-                .filter_map(|(k, v)| if keep(k, v) { None } else { Some(k.clone()) })
-                .collect::<Vec<_>>()
-        };
-        for k in remove_keys {
-            self.pop_raw(&k);
+        let doomed = self.doomed_indices(&mut keep);
+        for index in doomed {
+            let _ = self.remove_index(index);
         }
     }
 
@@ -640,7 +722,20 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruCache<K, V, S> {
     /// `tag` that is ignored): the caller's key and the stored key compare as equal but may
     /// differ in those extra fields. Used by `LruTtlCache::set_entry` to pass the correct stored
     /// key to `on_evict`.
-    #[cfg(feature = "time_stores")]
+    ///
+    /// # Recency trap
+    ///
+    /// On an existing key this replaces the entry **in place** (`order.set`) and does
+    /// **NOT** promote it to most-recently-used, matching [`Cached::cache_set`]. A
+    /// remove-then-insert (`pop_raw` + `cache_set`) *does* promote, because the insert
+    /// goes through `push_front`. Any caller switching from remove-then-insert to this
+    /// method changes observable LRU order unless it follows up with
+    /// `order.move_to_front(index)` (or a `cache_get`) to restore the promotion.
+    // Deliberately NOT `#[cfg(feature = "time_stores")]`: nothing in the body is
+    // time-related, and non-time_stores callers need it too. The only in-tree callers
+    // today are `time_stores`-gated, hence the dead-code allowance for builds without
+    // that feature.
+    #[cfg_attr(not(feature = "time_stores"), allow(dead_code))]
     pub(super) fn cache_set_returning_entry(&mut self, key: K, val: V) -> Option<(K, V)> {
         let hash = self.hash(&key);
         let entry = if let Some(index) = self.get_index(hash, &key) {
@@ -664,13 +759,9 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruCache<K, V, S> {
         if self.on_evict.is_none() {
             return self.cache_clear();
         }
-        let keys = self.key_order();
-        let mut removed = Vec::with_capacity(keys.len());
-        for k in &keys {
-            if let Some(pair) = self.pop_raw(k) {
-                removed.push(pair);
-            }
-        }
+        // `drain_all` walks the LRU chain once taking owned pairs (MRU -> LRU, the same
+        // order the old key-by-key drain fired in) -- no key clones, no re-hashing.
+        let removed = self.drain_all();
         if !removed.is_empty() {
             self.evictions
                 .fetch_add(removed.len() as u64, Ordering::Relaxed);
@@ -1297,6 +1388,252 @@ mod tests {
     }
 
     #[test]
+    fn retain_fires_on_evict_in_mru_to_lru_order_and_counts_evictions() {
+        // Pins the side effects of the index-based `retain` rewrite: every doomed
+        // entry fires `on_evict` exactly once, MRU -> LRU, and is counted.
+        use std::sync::{Arc, Mutex};
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen2 = seen.clone();
+        let mut c = LruCache::builder()
+            .max_size(5)
+            .on_evict(move |k: &i32, v: &i32| seen2.lock().unwrap().push((*k, *v)))
+            .build()
+            .unwrap();
+        for i in 0i32..5 {
+            c.cache_set(i, i * 10);
+        }
+        // MRU -> LRU is 4, 3, 2, 1, 0; drop the odd keys.
+        c.retain(|k, _v| k % 2 == 0);
+        assert_eq!(
+            *seen.lock().unwrap(),
+            vec![(3, 30), (1, 10)],
+            "on_evict must fire once per removed entry, MRU -> LRU"
+        );
+        assert_eq!(c.cache_evictions(), Some(2));
+        // Survivors keep their relative recency order.
+        assert_eq!(c.key_order(), vec![4, 2, 0]);
+        assert_eq!(c.cache_size(), 3);
+        // The hash table entries are really gone, and the freed slots are reusable.
+        assert!(c.cache_peek(&1).is_none());
+        c.cache_set(7, 70);
+        assert_eq!(c.cache_peek(&7), Some(&70));
+        assert_eq!(c.key_order(), vec![7, 4, 2, 0]);
+    }
+
+    #[test]
+    fn retain_silent_removes_without_on_evict_or_counters() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering as AOrdering};
+        let count = Arc::new(AtomicUsize::new(0));
+        let count2 = count.clone();
+        let mut c = LruCache::builder()
+            .max_size(5)
+            .on_evict(move |_k: &i32, _v: &i32| {
+                count2.fetch_add(1, AOrdering::Relaxed);
+            })
+            .build()
+            .unwrap();
+        for i in 0i32..5 {
+            c.cache_set(i, i * 10);
+        }
+        c.retain_silent(|k, _v| k % 2 == 0);
+        assert_eq!(c.key_order(), vec![4, 2, 0]);
+        assert_eq!(count.load(AOrdering::Relaxed), 0);
+        assert_eq!(c.cache_evictions(), Some(0));
+    }
+
+    #[test]
+    fn remove_index_returns_stored_key_and_unlinks() {
+        #[derive(Debug, Clone)]
+        struct MyKey {
+            id: u32,
+            tag: &'static str,
+        }
+        impl PartialEq for MyKey {
+            fn eq(&self, other: &Self) -> bool {
+                self.id == other.id
+            }
+        }
+        impl Eq for MyKey {}
+        impl Hash for MyKey {
+            fn hash<H: Hasher>(&self, state: &mut H) {
+                self.id.hash(state);
+            }
+        }
+
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering as AOrdering};
+        let count = Arc::new(AtomicUsize::new(0));
+        let count2 = count.clone();
+        let mut c = LruCache::builder()
+            .max_size(4)
+            .on_evict(move |_k: &MyKey, _v: &u32| {
+                count2.fetch_add(1, AOrdering::Relaxed);
+            })
+            .build()
+            .unwrap();
+        for id in 1..=3u32 {
+            c.cache_set(MyKey { id, tag: "stored" }, id * 10);
+        }
+        // MRU -> LRU: 3, 2, 1
+        let indices: Vec<usize> = c.order.iter_indices().collect();
+        assert_eq!(indices.len(), 3);
+
+        // Removing the middle slot yields the STORED key (tag "stored"), not a
+        // caller-supplied lookup key.
+        let (key, value) = c.remove_index(indices[1]);
+        assert_eq!(key.id, 2);
+        assert_eq!(key.tag, "stored");
+        assert_eq!(value, 20);
+
+        // Unlinked from both the order and the hash table.
+        assert_eq!(c.cache_size(), 2);
+        assert!(
+            c.cache_peek(&MyKey {
+                id: 2,
+                tag: "lookup"
+            })
+            .is_none()
+        );
+        assert_eq!(
+            c.key_order().iter().map(|k| k.id).collect::<Vec<_>>(),
+            vec![3, 1]
+        );
+        // Untouched slots keep their indices valid.
+        assert_eq!(c.order.get(indices[0]).1, 30);
+        assert_eq!(c.order.get(indices[2]).1, 10);
+
+        // Silent: no callback, no counter.
+        assert_eq!(count.load(AOrdering::Relaxed), 0);
+        assert_eq!(c.cache_evictions(), Some(0));
+
+        // Re-inserting the removed key works (its table entry was really freed).
+        assert_eq!(
+            c.cache_set(
+                MyKey {
+                    id: 2,
+                    tag: "again"
+                },
+                22
+            ),
+            None
+        );
+        assert_eq!(
+            c.cache_peek(&MyKey {
+                id: 2,
+                tag: "lookup"
+            }),
+            Some(&22)
+        );
+        assert_eq!(
+            c.key_order().iter().map(|k| k.id).collect::<Vec<_>>(),
+            vec![2, 3, 1]
+        );
+    }
+
+    #[test]
+    fn drain_all_returns_mru_to_lru_and_leaves_cache_reusable() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering as AOrdering};
+        let count = Arc::new(AtomicUsize::new(0));
+        let count2 = count.clone();
+        let mut c = LruCache::builder()
+            .max_size(4)
+            .on_evict(move |_k: &u32, _v: &u32| {
+                count2.fetch_add(1, AOrdering::Relaxed);
+            })
+            .build()
+            .unwrap();
+        c.cache_set(1u32, 10u32);
+        c.cache_set(2u32, 20u32);
+        c.cache_set(3u32, 30u32);
+        c.cache_get(&1); // promote: MRU -> LRU is now 1, 3, 2
+
+        let drained = c.drain_all();
+        assert_eq!(drained, vec![(1, 10), (3, 30), (2, 20)]);
+        assert_eq!(c.cache_size(), 0);
+        assert!(c.key_order().is_empty());
+        assert!(c.cache_peek(&1).is_none());
+        // `drain_all` is silent: callers own the side effects.
+        assert_eq!(count.load(AOrdering::Relaxed), 0);
+        assert_eq!(c.cache_evictions(), Some(0));
+
+        // Reusable afterwards, with correct ordering and eviction behavior.
+        c.cache_set(5u32, 50u32);
+        c.cache_set(6u32, 60u32);
+        assert_eq!(c.cache_get(&5), Some(&50));
+        assert_eq!(c.key_order(), vec![5, 6]);
+        assert_eq!(c.cache_size(), 2);
+
+        // Draining an empty cache is a no-op.
+        let mut empty: LruCache<u32, u32> = LruCache::new(2);
+        assert!(empty.drain_all().is_empty());
+        empty.cache_set(1, 1);
+        assert_eq!(empty.cache_get(&1), Some(&1));
+    }
+
+    #[test]
+    fn pop_raw_with_hash_agrees_with_pop_raw() {
+        let mut a = LruCache::builder().max_size(4).build().unwrap();
+        let mut b = LruCache::builder().max_size(4).build().unwrap();
+        for i in 1..=3u32 {
+            a.cache_set(i, i * 10);
+            b.cache_set(i, i * 10);
+        }
+        let hash = a.hash(&2u32);
+        assert_eq!(a.pop_raw_with_hash(hash, &2u32), b.pop_raw(&2u32));
+        assert_eq!(a.key_order(), b.key_order());
+        assert_eq!(a.cache_size(), b.cache_size());
+
+        // Absent key: both report a miss and leave the cache untouched.
+        let missing = a.hash(&99u32);
+        assert_eq!(a.pop_raw_with_hash(missing, &99u32), None);
+        assert_eq!(b.pop_raw(&99u32), None);
+        assert_eq!(a.key_order(), b.key_order());
+
+        // Borrowed lookup form (String key probed by &str).
+        let mut s: LruCache<String, u32> = LruCache::new(4);
+        s.cache_set("a".to_string(), 1);
+        s.cache_set("b".to_string(), 2);
+        let hash = s.hash("a");
+        assert_eq!(s.pop_raw_with_hash(hash, "a"), Some(("a".to_string(), 1)));
+        assert_eq!(s.key_order(), vec!["b".to_string()]);
+    }
+
+    #[test]
+    fn cache_set_returning_entry_replaces_in_place_without_promoting() {
+        // TRAP: `cache_set_returning_entry` replaces via `order.set` and does NOT
+        // promote to MRU, while remove-then-insert does (`push_front`). Any caller
+        // switching to it must add `order.move_to_front(index)` for promotion.
+        let mut c = LruCache::builder().max_size(3).build().unwrap();
+        c.cache_set(1u32, 10u32);
+        c.cache_set(2u32, 20u32);
+        c.cache_set(3u32, 30u32);
+        assert_eq!(c.key_order(), vec![3, 2, 1]);
+
+        // Replacing the least-recently-used entry returns the stored pair and leaves
+        // the entry exactly where it was.
+        assert_eq!(c.cache_set_returning_entry(1, 11), Some((1, 10)));
+        assert_eq!(
+            c.key_order(),
+            vec![3, 2, 1],
+            "cache_set_returning_entry must NOT promote the replaced entry"
+        );
+        assert_eq!(c.value_order(), vec![30, 20, 11]);
+
+        // Contrast: remove-then-insert DOES promote.
+        assert_eq!(c.pop_raw(&1u32), Some((1, 11)));
+        assert_eq!(Cached::cache_set(&mut c, 1u32, 12u32), None);
+        assert_eq!(c.key_order(), vec![1, 3, 2]);
+
+        // A fresh key inserts at the front and returns None.
+        let mut d = LruCache::builder().max_size(3).build().unwrap();
+        assert_eq!(d.cache_set_returning_entry(1u32, 10u32), None);
+        assert_eq!(d.cache_set_returning_entry(2u32, 20u32), None);
+        assert_eq!(d.key_order(), vec![2, 1]);
+    }
+
+    #[test]
     fn key_order_and_value_order() {
         let mut c = LruCache::builder().max_size(3).build().unwrap();
         c.set(1, 10);
@@ -1776,6 +2113,833 @@ mod tests {
                 "cache exceeded capacity after insert {i}: len {}",
                 c.cache_size()
             );
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Certification coverage for the index/drain rewrite of `retain`,
+    // `retain_silent`, `cache_clear_with_on_evict`, and the `*_order`
+    // collectors. The bar is that observable behavior is UNCHANGED, so these
+    // pin side-effect ordering, counters, panic paths, and the store/order
+    // invariant the pre-sizing depends on.
+    // ---------------------------------------------------------------------
+
+    /// The hash table and the LRU chain must describe exactly the same entries, and
+    /// every order collector must agree with the chain. `store.len() == chain length`
+    /// is precisely the assumption the `Vec::with_capacity(self.store.len())` pre-size
+    /// in `iter_order`/`iter_order_raw`/`key_order`/`value_order` relies on.
+    fn assert_store_and_order_agree<K, V, S>(c: &LruCache<K, V, S>)
+    where
+        K: Hash + Eq + Clone + std::fmt::Debug,
+        V: Clone + PartialEq + std::fmt::Debug,
+        S: BuildHasher,
+    {
+        let n = c.cache_size();
+        assert_eq!(c.store.len(), n, "cache_size must equal hash table length");
+        let chain: Vec<usize> = c.order.iter_indices().collect();
+        assert_eq!(
+            chain.len(),
+            n,
+            "live LRU chain length must equal store.len() (the *_order pre-size assumption)"
+        );
+        let keys = c.key_order();
+        let vals = c.value_order();
+        let entries = c.iter_order();
+        let raw = c.iter_order_raw();
+        assert_eq!(keys.len(), n, "key_order length");
+        assert_eq!(vals.len(), n, "value_order length");
+        assert_eq!(entries.len(), n, "iter_order length");
+        assert_eq!(raw.len(), n, "iter_order_raw length");
+        for (pos, &i) in chain.iter().enumerate() {
+            let (k, v) = c.order.get(i);
+            assert_eq!(k, &keys[pos], "key_order disagrees with the chain");
+            assert_eq!(
+                c.get_index(c.hash(k), k),
+                Some(i),
+                "hash table must resolve {k:?} back to its chain slot (no orphan/stale entries)"
+            );
+            assert_eq!(v, &*vals[pos], "value_order disagrees with the chain");
+            assert_eq!(k, &raw[pos].0);
+            assert_eq!(v, &raw[pos].1);
+            assert_eq!(k, &entries[pos].0);
+            assert_eq!(v, &*entries[pos].1);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "live LRU chain length must equal store.len()")]
+    fn invariant_helper_detects_a_desynced_store() {
+        // Self-test: the certification helper must actually fail on a divergence,
+        // otherwise every assertion built on it is vacuous.
+        let mut c: LruCache<u32, u32> = LruCache::new(4);
+        c.cache_set(1, 10);
+        c.store.clear(); // chain still holds the entry
+        assert_store_and_order_agree(&c);
+    }
+
+    #[test]
+    #[should_panic(expected = "hash table must resolve")]
+    fn invariant_helper_detects_a_stale_table_pointer() {
+        // The other direction: a chain entry whose table entry points at the wrong
+        // slot. Lengths still agree, so only the per-entry resolution check catches it.
+        let mut c: LruCache<u32, u32> = LruCache::new(4);
+        c.cache_set(1, 10);
+        let slot_of_1 = c.order.iter_indices().next().unwrap();
+        let _unlinked = c.order.push_front((2, 20)); // chain entry with no table entry
+        let hash = c.hash(&2u32);
+        c.insert_index(hash, slot_of_1); // table entry pointing at the wrong slot
+        assert_store_and_order_agree(&c);
+    }
+
+    fn xorshift(state: &mut u64) -> u64 {
+        let mut x = *state;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        *state = x;
+        x
+    }
+
+    #[test]
+    fn remove_index_on_back_walks_the_cache_down_to_empty() {
+        let mut c: LruCache<u32, u32> = LruCache::new(4);
+        c.cache_set(1, 10);
+        c.cache_set(2, 20);
+        c.cache_set(3, 30);
+
+        // `order.back()` is the LRU slot -- the documented alternative index source.
+        assert_eq!(c.remove_index(c.order.back()), (1, 10));
+        assert_eq!(c.key_order(), vec![3, 2]);
+        assert_store_and_order_agree(&c);
+
+        assert_eq!(c.remove_index(c.order.back()), (2, 20));
+        // Sole remaining entry: back() and the MRU slot are the same slot.
+        assert_eq!(c.order.back(), c.order.iter_indices().next().unwrap());
+        assert_eq!(c.remove_index(c.order.back()), (3, 30));
+        assert_eq!(c.cache_size(), 0);
+        assert!(c.key_order().is_empty());
+        assert_store_and_order_agree(&c);
+
+        // Empty and immediately reusable, with eviction still correct afterwards.
+        for i in 1..=5u32 {
+            c.cache_set(i, i * 10);
+        }
+        assert_eq!(c.key_order(), vec![5, 4, 3, 2]);
+        assert_store_and_order_agree(&c);
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid index")]
+    fn remove_index_on_empty_cache_back_panics() {
+        // `back()` of an empty cache is the sentinel slot, which holds no value.
+        let mut c: LruCache<u32, u32> = LruCache::new(4);
+        let _ = c.remove_index(c.order.back());
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid index")]
+    fn remove_index_on_vacant_slot_panics() {
+        let mut c: LruCache<u32, u32> = LruCache::new(4);
+        c.cache_set(1, 10);
+        c.cache_set(2, 20);
+        let slots: Vec<usize> = c.order.iter_indices().collect();
+        // Free the slot through the normal path, then replay its index.
+        assert_eq!(c.cache_remove(&2u32), Some(20));
+        let _ = c.remove_index(slots[0]);
+    }
+
+    #[test]
+    #[should_panic(expected = "index out of bounds")]
+    fn remove_index_out_of_range_panics() {
+        let mut c: LruCache<u32, u32> = LruCache::new(4);
+        c.cache_set(1, 10);
+        let _ = c.remove_index(9_999);
+    }
+
+    #[test]
+    #[should_panic(expected = "out of sync")]
+    fn remove_index_on_desynced_store_hits_the_unreachable_arm() {
+        // The `unreachable!` arm fires when the LRU chain still holds an entry the hash
+        // table has lost. Simulate that drift directly -- there is no public way to
+        // reach it, which is exactly why it is `unreachable!` and not an `Option`.
+        let mut c: LruCache<u32, u32> = LruCache::new(4);
+        c.cache_set(1, 10);
+        c.cache_set(2, 20);
+        let slot = c.order.iter_indices().next().unwrap();
+        c.store.clear();
+        let _ = c.remove_index(slot);
+    }
+
+    #[test]
+    fn stale_slot_index_after_insert_targets_the_recycled_entry() {
+        // Pins the contract documented on `remove_index` / `iter_indices`: collected
+        // indices stay valid across removals of OTHER slots, but an insert recycles a
+        // freed slot, so replaying a stale index silently hits the new occupant. Any
+        // consuming shard that interleaves inserts into an index sweep is buggy.
+        let mut c: LruCache<u32, u32> = LruCache::new(8);
+        c.cache_set(1, 10);
+        c.cache_set(2, 20);
+        c.cache_set(3, 30);
+        let snapshot: Vec<usize> = c.order.iter_indices().collect(); // MRU -> LRU: 3, 2, 1
+
+        // Removing the middle entry leaves the other two indices valid.
+        assert_eq!(c.remove_index(snapshot[1]), (2, 20));
+        assert_eq!(c.order.get(snapshot[0]).1, 30);
+        assert_eq!(c.order.get(snapshot[2]).1, 10);
+
+        // The insert recycles slot `snapshot[1]` ...
+        c.cache_set(4, 40);
+        assert_eq!(
+            c.order.iter_indices().next(),
+            Some(snapshot[1]),
+            "the new MRU entry must occupy the recycled slot"
+        );
+        // ... so replaying the stale index removes key 4, not key 2.
+        assert_eq!(
+            c.remove_index(snapshot[1]),
+            (4, 40),
+            "a stale index replayed after an insert removes the recycled entry"
+        );
+        assert_eq!(c.key_order(), vec![3, 1]);
+        assert_store_and_order_agree(&c);
+    }
+
+    #[test]
+    fn retain_predicate_visits_entries_mru_to_lru() {
+        // The predicate visit order is observable through `FnMut` and must match the
+        // pre-rewrite `order.iter()` walk: MRU -> LRU, recency order (not insertion).
+        let mut c: LruCache<u32, u32> = LruCache::new(5);
+        for i in 1..=4u32 {
+            c.cache_set(i, i * 10);
+        }
+        assert_eq!(c.cache_get(&2), Some(&20)); // promote: MRU -> LRU is 2, 4, 3, 1
+        let mut seen = Vec::new();
+        c.retain(|k, v| {
+            seen.push((*k, *v));
+            true
+        });
+        assert_eq!(seen, vec![(2, 20), (4, 40), (3, 30), (1, 10)]);
+    }
+
+    #[test]
+    fn retain_on_evict_order_follows_recency_not_insertion() {
+        use std::sync::{Arc, Mutex};
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen2 = seen.clone();
+        let mut c = LruCache::builder()
+            .max_size(6)
+            .on_evict(move |k: &u32, v: &u32| seen2.lock().unwrap().push((*k, *v)))
+            .build()
+            .unwrap();
+        for i in 1..=5u32 {
+            c.cache_set(i, i * 10);
+        }
+        // Promote the two entries that will be removed to the extremes of the chain.
+        assert_eq!(c.cache_get(&1), Some(&10)); // MRU -> LRU: 1, 5, 4, 3, 2
+        c.retain(|k, _v| *k != 1 && *k != 2);
+        assert_eq!(
+            *seen.lock().unwrap(),
+            vec![(1, 10), (2, 20)],
+            "on_evict must fire in MRU -> LRU chain order, not insertion order"
+        );
+        assert_eq!(c.key_order(), vec![5, 4, 3]);
+        assert_eq!(c.cache_evictions(), Some(2));
+        assert_store_and_order_agree(&c);
+    }
+
+    #[test]
+    fn retain_removes_all_entries() {
+        use std::sync::{Arc, Mutex};
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen2 = seen.clone();
+        let mut c = LruCache::builder()
+            .max_size(4)
+            .on_evict(move |k: &u32, _v: &u32| seen2.lock().unwrap().push(*k))
+            .build()
+            .unwrap();
+        for i in 0..4u32 {
+            c.cache_set(i, i * 10);
+        }
+        c.retain(|_k, _v| false);
+        assert_eq!(c.cache_size(), 0);
+        assert!(c.key_order().is_empty());
+        assert_eq!(*seen.lock().unwrap(), vec![3, 2, 1, 0]);
+        assert_eq!(c.cache_evictions(), Some(4));
+        assert_store_and_order_agree(&c);
+
+        // Reusable: every slot was freed, and refilling past capacity still evicts LRU.
+        for i in 10..15u32 {
+            c.cache_set(i, i);
+        }
+        assert_eq!(c.key_order(), vec![14, 13, 12, 11]);
+        assert_eq!(c.cache_evictions(), Some(5));
+        assert_eq!(*seen.lock().unwrap(), vec![3, 2, 1, 0, 10]);
+        assert_store_and_order_agree(&c);
+    }
+
+    #[test]
+    fn retain_removing_nothing_is_a_no_op() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering as AOrdering};
+        let count = Arc::new(AtomicUsize::new(0));
+        let count2 = count.clone();
+        let mut c = LruCache::builder()
+            .max_size(4)
+            .on_evict(move |_k: &u32, _v: &u32| {
+                count2.fetch_add(1, AOrdering::Relaxed);
+            })
+            .build()
+            .unwrap();
+        for i in 0..3u32 {
+            c.cache_set(i, i * 10);
+        }
+        let before = c.key_order();
+        c.retain(|_k, _v| true);
+        assert_eq!(
+            c.key_order(),
+            before,
+            "retain must not perturb recency order"
+        );
+        assert_eq!(c.cache_size(), 3);
+        assert_eq!(count.load(AOrdering::Relaxed), 0);
+        assert_eq!(c.cache_evictions(), Some(0));
+        assert_store_and_order_agree(&c);
+    }
+
+    #[test]
+    fn retain_on_empty_cache_never_calls_the_predicate() {
+        let mut c: LruCache<u32, u32> = LruCache::new(4);
+        let mut calls = 0usize;
+        c.retain(|_k, _v| {
+            calls += 1;
+            false
+        });
+        assert_eq!(calls, 0);
+        assert_eq!(c.cache_size(), 0);
+        assert_eq!(c.cache_evictions(), Some(0));
+
+        // Same for `retain_silent`.
+        let mut calls = 0usize;
+        c.retain_silent(|_k, _v| {
+            calls += 1;
+            false
+        });
+        assert_eq!(calls, 0);
+        assert_store_and_order_agree(&c);
+    }
+
+    #[test]
+    fn retain_without_on_evict_still_counts_evictions() {
+        let mut c: LruCache<u32, u32> = LruCache::new(4);
+        for i in 0..4u32 {
+            c.cache_set(i, i * 10);
+        }
+        let (hits, misses) = (c.cache_hits(), c.cache_misses());
+        c.retain(|k, _v| *k >= 2);
+        assert_eq!(c.cache_evictions(), Some(2));
+        assert_eq!(c.key_order(), vec![3, 2]);
+        // The removal path must not look like a lookup: hit/miss counters are untouched.
+        assert_eq!(c.cache_hits(), hits);
+        assert_eq!(c.cache_misses(), misses);
+        c.retain_silent(|k, _v| *k >= 3);
+        assert_eq!(c.cache_hits(), hits);
+        assert_eq!(c.cache_misses(), misses);
+        assert_store_and_order_agree(&c);
+    }
+
+    #[test]
+    fn retain_silent_removes_all_and_none() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering as AOrdering};
+        let count = Arc::new(AtomicUsize::new(0));
+        let count2 = count.clone();
+        let mut c = LruCache::builder()
+            .max_size(4)
+            .on_evict(move |_k: &u32, _v: &u32| {
+                count2.fetch_add(1, AOrdering::Relaxed);
+            })
+            .build()
+            .unwrap();
+        for i in 0..4u32 {
+            c.cache_set(i, i * 10);
+        }
+        c.retain_silent(|_k, _v| true);
+        assert_eq!(c.key_order(), vec![3, 2, 1, 0]);
+        assert_store_and_order_agree(&c);
+
+        c.retain_silent(|_k, _v| false);
+        assert_eq!(c.cache_size(), 0);
+        assert!(c.key_order().is_empty());
+        assert_eq!(count.load(AOrdering::Relaxed), 0);
+        assert_eq!(c.cache_evictions(), Some(0));
+        assert_store_and_order_agree(&c);
+
+        // Freed slots are reusable and capacity eviction still fires normally
+        // (that path is NOT silent).
+        for i in 10..15u32 {
+            c.cache_set(i, i);
+        }
+        assert_eq!(c.key_order(), vec![14, 13, 12, 11]);
+        assert_eq!(count.load(AOrdering::Relaxed), 1);
+        assert_eq!(c.cache_evictions(), Some(1));
+        assert_store_and_order_agree(&c);
+    }
+
+    #[test]
+    fn retain_then_capacity_eviction_picks_the_right_victim() {
+        use std::sync::{Arc, Mutex};
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen2 = seen.clone();
+        let mut c = LruCache::builder()
+            .max_size(3)
+            .on_evict(move |k: &u32, _v: &u32| seen2.lock().unwrap().push(*k))
+            .build()
+            .unwrap();
+        c.cache_set(1, 10);
+        c.cache_set(2, 20);
+        c.cache_set(3, 30);
+        c.retain(|k, _v| *k != 2);
+        assert_eq!(c.key_order(), vec![3, 1]);
+
+        c.cache_set(4, 40); // fits exactly
+        assert_eq!(c.key_order(), vec![4, 3, 1]);
+        assert_eq!(c.cache_evictions(), Some(1));
+
+        c.cache_set(5, 50); // overflows: LRU (1) is evicted
+        assert_eq!(c.key_order(), vec![5, 4, 3]);
+        assert_eq!(*seen.lock().unwrap(), vec![2, 1]);
+        assert_eq!(c.cache_evictions(), Some(2));
+        assert_store_and_order_agree(&c);
+    }
+
+    #[test]
+    fn retain_with_panicking_on_evict_leaves_cache_consistent() {
+        // The rewrite removes the entry BEFORE notifying, so a panicking callback can
+        // never leave an entry half-removed. The remaining doomed entries stay (the
+        // loop unwinds) and `evictions` is not credited for the panicking entry --
+        // both match the pre-rewrite `cache_remove` loop.
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        use std::sync::{Arc, Mutex};
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen2 = seen.clone();
+        let mut c = LruCache::builder()
+            .max_size(5)
+            .on_evict(move |k: &i32, v: &i32| {
+                seen2.lock().unwrap().push((*k, *v));
+                assert_ne!(*k, 3, "boom");
+            })
+            .build()
+            .unwrap();
+        for i in 0i32..5 {
+            c.cache_set(i, i * 10);
+        }
+        // MRU -> LRU: 4, 3, 2, 1, 0; doomed are 3 then 1, and 3 panics first.
+        let r = catch_unwind(AssertUnwindSafe(|| c.retain(|k, _v| k % 2 == 0)));
+        assert!(r.is_err(), "on_evict should have panicked");
+
+        assert_eq!(*seen.lock().unwrap(), vec![(3, 30)]);
+        // Key 3 is fully gone (removed before the callback ran); key 1 was never reached.
+        assert!(c.cache_peek(&3).is_none());
+        assert_eq!(c.cache_peek(&1), Some(&10));
+        assert_eq!(c.cache_size(), 4);
+        assert_eq!(c.key_order(), vec![4, 2, 1, 0]);
+        assert_eq!(
+            c.cache_evictions(),
+            Some(0),
+            "evictions is credited after the callback, so a panicking callback skips it"
+        );
+        // No entry is both removed and still present.
+        assert_store_and_order_agree(&c);
+
+        // The cache still works: a second retain finishes the job for the survivor.
+        c.retain(|k, _v| k % 2 == 0);
+        assert_eq!(*seen.lock().unwrap(), vec![(3, 30), (1, 10)]);
+        assert_eq!(c.key_order(), vec![4, 2, 0]);
+        assert_eq!(c.cache_evictions(), Some(1));
+        assert_store_and_order_agree(&c);
+    }
+
+    #[test]
+    fn retain_with_panicking_predicate_leaves_cache_untouched() {
+        // The predicate runs during the index scan, before any removal, so an unwind
+        // out of it must not have removed anything.
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        let mut c: LruCache<u32, u32> = LruCache::new(5);
+        for i in 0..5u32 {
+            c.cache_set(i, i * 10);
+        }
+        let before = c.key_order();
+        let r = catch_unwind(AssertUnwindSafe(|| {
+            c.retain(|k, _v| {
+                assert_ne!(*k, 2, "boom");
+                false
+            })
+        }));
+        assert!(r.is_err(), "the predicate should have panicked");
+        assert_eq!(c.key_order(), before);
+        assert_eq!(c.cache_size(), 5);
+        assert_eq!(c.cache_evictions(), Some(0));
+        assert_store_and_order_agree(&c);
+    }
+
+    #[test]
+    fn cache_clear_with_on_evict_fires_mru_to_lru() {
+        use std::sync::{Arc, Mutex};
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen2 = seen.clone();
+        let mut c = LruCache::builder()
+            .max_size(5)
+            .on_evict(move |k: &u32, v: &u32| seen2.lock().unwrap().push((*k, *v)))
+            .build()
+            .unwrap();
+        c.cache_set(1, 10);
+        c.cache_set(2, 20);
+        c.cache_set(3, 30);
+        assert_eq!(c.cache_get(&1), Some(&10)); // MRU -> LRU: 1, 3, 2
+        let (hits, misses) = (c.cache_hits(), c.cache_misses());
+        c.cache_clear_with_on_evict();
+        assert_eq!(
+            *seen.lock().unwrap(),
+            vec![(1, 10), (3, 30), (2, 20)],
+            "callbacks must fire MRU -> LRU, the same order the key-by-key drain used"
+        );
+        assert_eq!(c.cache_evictions(), Some(3));
+        // The wholesale drain must not look like a lookup either.
+        assert_eq!(c.cache_hits(), hits);
+        assert_eq!(c.cache_misses(), misses);
+        assert_store_and_order_agree(&c);
+
+        // A second clear on the now-empty cache fires nothing further.
+        c.cache_clear_with_on_evict();
+        assert_eq!(seen.lock().unwrap().len(), 3);
+        assert_eq!(c.cache_evictions(), Some(3));
+    }
+
+    #[test]
+    fn cache_clear_with_on_evict_on_empty_cache_is_a_no_op() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering as AOrdering};
+        let count = Arc::new(AtomicUsize::new(0));
+        let count2 = count.clone();
+        let mut c = LruCache::builder()
+            .max_size(4)
+            .on_evict(move |_k: &u32, _v: &u32| {
+                count2.fetch_add(1, AOrdering::Relaxed);
+            })
+            .build()
+            .unwrap();
+        c.cache_clear_with_on_evict();
+        assert_eq!(count.load(AOrdering::Relaxed), 0);
+        assert_eq!(c.cache_evictions(), Some(0));
+        assert_eq!(c.cache_size(), 0);
+
+        // Still usable, and the cleared-then-populated cache behaves normally.
+        c.cache_set(1, 10);
+        assert_eq!(c.cache_get(&1), Some(&10));
+        assert_store_and_order_agree(&c);
+    }
+
+    #[test]
+    fn cache_clear_with_on_evict_without_callback_is_a_silent_clear() {
+        // The early-return branch: no callback configured, so it must degrade to
+        // `cache_clear` semantics -- entries gone, `evictions` untouched.
+        let mut c: LruCache<u32, u32> = LruCache::new(4);
+        c.cache_set(1, 10);
+        c.cache_set(2, 20);
+        c.cache_clear_with_on_evict();
+        assert_eq!(c.cache_size(), 0);
+        assert_eq!(c.cache_evictions(), Some(0));
+        assert!(c.key_order().is_empty());
+        c.cache_set(3, 30);
+        assert_eq!(c.cache_get(&3), Some(&30));
+        assert_store_and_order_agree(&c);
+    }
+
+    #[test]
+    fn cache_clear_with_panicking_on_evict_leaves_cache_empty_and_counted() {
+        // `drain_all` empties the cache before any callback runs, and `evictions` is
+        // credited for the whole batch up front, so a panic mid-callback still leaves
+        // an empty, consistent, reusable cache.
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        use std::sync::{Arc, Mutex};
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen2 = seen.clone();
+        let mut c = LruCache::builder()
+            .max_size(5)
+            .on_evict(move |k: &u32, v: &u32| {
+                seen2.lock().unwrap().push((*k, *v));
+                assert_ne!(*k, 2, "boom");
+            })
+            .build()
+            .unwrap();
+        c.cache_set(1, 10);
+        c.cache_set(2, 20);
+        c.cache_set(3, 30);
+
+        let r = catch_unwind(AssertUnwindSafe(|| c.cache_clear_with_on_evict()));
+        assert!(r.is_err(), "on_evict should have panicked");
+        // MRU -> LRU is 3, 2, 1; the callback for 1 never ran.
+        assert_eq!(*seen.lock().unwrap(), vec![(3, 30), (2, 20)]);
+        assert_eq!(c.cache_size(), 0);
+        assert!(c.key_order().is_empty());
+        assert_eq!(
+            c.cache_evictions(),
+            Some(3),
+            "evictions is credited for the whole batch before callbacks run"
+        );
+        assert_store_and_order_agree(&c);
+
+        // Reusable after the unwind.
+        c.cache_set(7, 70);
+        assert_eq!(c.cache_get(&7), Some(&70));
+        assert_store_and_order_agree(&c);
+    }
+
+    #[test]
+    fn drain_all_with_holes_and_repeated_cycles() {
+        // `drain_all` walks the live chain only, so slabs full of freed slots (from
+        // retain/remove churn) must not resurrect removed entries.
+        let mut c: LruCache<u32, u32> = LruCache::new(8);
+        for i in 0..6u32 {
+            c.cache_set(i, i * 10);
+        }
+        c.retain(|k, _v| k % 2 == 0); // frees three slots
+        assert_eq!(c.cache_remove(&0u32), Some(0));
+        let drained = c.drain_all();
+        assert_eq!(drained, vec![(4, 40), (2, 20)]);
+        assert_eq!(c.cache_size(), 0);
+        assert_store_and_order_agree(&c);
+
+        // Repeated fill/drain cycles keep both structures in step.
+        for round in 0..3u32 {
+            for i in 0..5u32 {
+                c.cache_set(round * 100 + i, i);
+            }
+            assert_store_and_order_agree(&c);
+            let drained = c.drain_all();
+            assert_eq!(drained.len(), 5);
+            assert_eq!(c.cache_size(), 0);
+            assert_store_and_order_agree(&c);
+        }
+    }
+
+    #[test]
+    fn pop_raw_with_hash_wrong_hash_misses_and_leaves_the_entry() {
+        // Documented misuse contract: `hash` MUST be `self.hash(k)`. Flipping the top
+        // bit changes hashbrown's control tag deterministically, so the probe cannot
+        // match -- the lookup misses and the entry stays put.
+        let mut c: LruCache<u32, u32> = LruCache::new(4);
+        c.cache_set(1, 10);
+        c.cache_set(2, 20);
+        c.cache_set(3, 30);
+        let before = c.key_order();
+
+        let wrong = c.hash(&2u32) ^ (1u64 << 63);
+        assert_eq!(
+            c.pop_raw_with_hash(wrong, &2u32),
+            None,
+            "a hash that is not self.hash(k) must silently miss"
+        );
+        assert_eq!(c.cache_size(), 3);
+        assert_eq!(c.key_order(), before);
+        assert_eq!(c.cache_peek(&2), Some(&20));
+        assert_store_and_order_agree(&c);
+
+        // The correct hash still finds it, and the miss left no damage behind.
+        let right = c.hash(&2u32);
+        assert_eq!(c.pop_raw_with_hash(right, &2u32), Some((2, 20)));
+        assert_eq!(c.key_order(), vec![3, 1]);
+        assert_store_and_order_agree(&c);
+
+        // A correct hash paired with an absent key misses without side effects, and
+        // does not fire callbacks or counters (pop_raw* is silent).
+        assert_eq!(c.pop_raw_with_hash(c.hash(&99u32), &99u32), None);
+        assert_eq!(c.cache_evictions(), Some(0));
+        assert_store_and_order_agree(&c);
+    }
+
+    #[test]
+    fn pop_raw_with_hash_does_not_promote_or_touch_hit_miss_counters() {
+        let mut c: LruCache<u32, u32> = LruCache::new(4);
+        c.cache_set(1, 10);
+        c.cache_set(2, 20);
+        c.cache_set(3, 30);
+        let hits = c.cache_hits();
+        let misses = c.cache_misses();
+        assert_eq!(c.pop_raw_with_hash(c.hash(&3u32), &3u32), Some((3, 30)));
+        assert_eq!(c.cache_hits(), hits);
+        assert_eq!(c.cache_misses(), misses);
+        assert_eq!(c.cache_evictions(), Some(0));
+        assert_eq!(c.key_order(), vec![2, 1]);
+    }
+
+    #[test]
+    fn cache_set_returning_entry_returns_the_stored_key_and_evicts_at_capacity() {
+        #[derive(Debug, Clone)]
+        struct TaggedKey {
+            id: u32,
+            tag: &'static str,
+        }
+        impl PartialEq for TaggedKey {
+            fn eq(&self, other: &Self) -> bool {
+                self.id == other.id
+            }
+        }
+        impl Eq for TaggedKey {}
+        impl Hash for TaggedKey {
+            fn hash<H: Hasher>(&self, state: &mut H) {
+                self.id.hash(state);
+            }
+        }
+
+        use std::sync::{Arc, Mutex};
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen2 = seen.clone();
+        let mut c = LruCache::builder()
+            .max_size(2)
+            .on_evict(move |k: &TaggedKey, v: &u32| seen2.lock().unwrap().push((k.id, *v)))
+            .build()
+            .unwrap();
+        c.cache_set(
+            TaggedKey {
+                id: 1,
+                tag: "stored",
+            },
+            10,
+        );
+        c.cache_set(
+            TaggedKey {
+                id: 2,
+                tag: "stored",
+            },
+            20,
+        );
+
+        // Replacing returns the STORED key (with its ignored field), not the caller's.
+        let displaced = c
+            .cache_set_returning_entry(
+                TaggedKey {
+                    id: 1,
+                    tag: "caller",
+                },
+                11,
+            )
+            .expect("existing key must return the displaced entry");
+        assert_eq!(displaced.0.id, 1);
+        assert_eq!(
+            displaced.0.tag, "stored",
+            "the displaced pair must carry the stored key, not the caller's"
+        );
+        assert_eq!(displaced.1, 10);
+        // No eviction: a replace is not an eviction.
+        assert!(seen.lock().unwrap().is_empty());
+        assert_eq!(c.cache_evictions(), Some(0));
+        // And no promotion (the recency trap), so 1 is still the LRU victim.
+        assert_eq!(
+            c.key_order().iter().map(|k| k.id).collect::<Vec<_>>(),
+            vec![2, 1]
+        );
+
+        // A fresh key over capacity evicts the LRU entry through `check_capacity`.
+        assert_eq!(
+            c.cache_set_returning_entry(
+                TaggedKey {
+                    id: 3,
+                    tag: "stored"
+                },
+                30
+            ),
+            None
+        );
+        assert_eq!(*seen.lock().unwrap(), vec![(1, 11)]);
+        assert_eq!(c.cache_evictions(), Some(1));
+        assert_eq!(
+            c.key_order().iter().map(|k| k.id).collect::<Vec<_>>(),
+            vec![3, 2]
+        );
+        assert_store_and_order_agree(&c);
+    }
+
+    #[test]
+    fn order_collectors_presize_from_live_count_not_capacity() {
+        // The pre-size must come from `store.len()`, never from the configured
+        // capacity: a large `max_size` with two live entries must not allocate large
+        // vectors.
+        let mut c: LruCache<u32, u32> = LruCache::new(65_536);
+        c.cache_set(1, 10);
+        c.cache_set(2, 20);
+        assert!(
+            c.key_order().capacity() < 1_000,
+            "key_order pre-sized from capacity instead of the live count"
+        );
+        assert!(c.value_order().capacity() < 1_000);
+        assert!(c.iter_order().capacity() < 1_000);
+        assert!(c.iter_order_raw().capacity() < 1_000);
+
+        // An empty cache pre-sizes to zero and allocates nothing.
+        let empty: LruCache<u32, u32> = LruCache::new(65_536);
+        assert_eq!(empty.key_order().capacity(), 0);
+        assert!(empty.key_order().is_empty());
+        assert!(empty.iter_order().is_empty());
+        assert!(empty.value_order().is_empty());
+        assert!(empty.iter_order_raw().is_empty());
+    }
+
+    #[test]
+    fn store_len_and_live_chain_never_diverge_under_mixed_operations() {
+        // The `*_order` pre-sizing assumes `store.len()` equals the live chain length.
+        // Hammer every mutating path that touches the slab -- capacity eviction,
+        // retain, retain_silent, remove_index, drain_all, clear-with-callback, replace
+        // -- and assert the two views agree after every single step.
+        use std::sync::{Arc, Mutex};
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen2 = seen.clone();
+        let mut c = LruCache::builder()
+            .max_size(8)
+            .on_evict(move |k: &u32, _v: &u32| seen2.lock().unwrap().push(*k))
+            .build()
+            .unwrap();
+
+        let mut state = 0x2545_F491_4F6C_DD1Du64;
+        for step in 0..600u32 {
+            let r = xorshift(&mut state);
+            let key = (r >> 32) as u32 % 12;
+            match r % 11 {
+                0..=3 => {
+                    c.cache_set(key, key * 10);
+                }
+                4 => {
+                    let _ = c.cache_get(&key);
+                }
+                5 => {
+                    let _ = c.cache_remove(&key);
+                }
+                6 => c.retain(|k, _v| k % 3 != 0),
+                7 => c.retain_silent(|k, _v| *k != key),
+                8 => {
+                    if c.cache_size() > 0 {
+                        let _ = c.remove_index(c.order.back());
+                    }
+                }
+                9 => {
+                    let before = c.cache_size();
+                    let drained = c.drain_all();
+                    assert_eq!(drained.len(), before, "drain_all must return every entry");
+                    assert_eq!(c.cache_size(), 0, "drain_all must leave the cache empty");
+                }
+                _ => c.cache_clear_with_on_evict(),
+            }
+            assert_eq!(
+                c.store.len(),
+                c.order.iter_indices().count(),
+                "store/chain diverged at step {step} (op {})",
+                r % 11
+            );
+            assert!(
+                c.cache_size() <= c.capacity(),
+                "capacity exceeded at step {step}"
+            );
+            assert_store_and_order_agree(&c);
         }
     }
 }

--- a/src/stores/lru_ttl.rs
+++ b/src/stores/lru_ttl.rs
@@ -781,7 +781,14 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
         f: F,
     ) -> Result<&mut V, E> {
         let ttl = self.ttl;
-        let setter = || {
+        // Count the miss the instant the setter runs. The inner store calls the setter only
+        // when the lookup found no live entry (absent key or expired entry), so a hit never
+        // counts one; and because the increment lands before `f` returns, an `Err` factory
+        // still records the miss instead of losing it on the `?` early return below. This
+        // matches `TtlCache` and `ExpiringLruCache`'s try-path accounting (EXP-2).
+        let misses = &self.misses;
+        let setter = move || {
+            misses.fetch_add(1, Ordering::Relaxed);
             // Anchor the expiry after the factory succeeds (CORE-3); deliberately a
             // fresh clock read, not the `hit_at` sample taken before `f()` ran.
             let value = f()?;
@@ -803,14 +810,14 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
                 entry.expires_at = new_exp;
             }
             self.hits.fetch_add(1, Ordering::Relaxed);
-        } else {
-            if let Some((old_key, old)) = old_entry {
-                if let Some(on_evict) = &self.on_evict {
-                    on_evict(&old_key, &old.value);
-                }
-                self.evictions.fetch_add(1, Ordering::Relaxed);
+        } else if let Some((old_key, old)) = old_entry {
+            // The miss was already counted by `setter`. On `Err` the expired entry is left
+            // in place, so `on_evict` / `evictions` deliberately stay behind until a call
+            // actually displaces it -- firing early would double-fire for one physical entry.
+            if let Some(on_evict) = &self.on_evict {
+                on_evict(&old_key, &old.value);
             }
-            self.misses.fetch_add(1, Ordering::Relaxed);
+            self.evictions.fetch_add(1, Ordering::Relaxed);
         }
         Ok(&mut entry.value)
     }
@@ -819,9 +826,11 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
     /// An expired previous value is filtered from the return; it fires `on_evict` and counts as
     /// an eviction, matching the other removal paths.
     ///
-    /// Overwriting an existing key replaces the value in-place **without** refreshing the key's
-    /// LRU recency; the entry keeps its position in the eviction order (its expiry is still reset
-    /// from the current TTL). Read with `cache_get` first if you need to promote it.
+    /// Overwriting an existing key promotes it to most-recently-used: a write counts as an
+    /// access, so the entry moves to the front of the eviction order exactly as a fresh
+    /// insertion would (its expiry is also reset from the current TTL). Use
+    /// [`CachedPeek::cache_peek`](crate::CachedPeek::cache_peek) if you need to inspect an
+    /// entry without touching recency.
     fn cache_set(&mut self, key: K, val: V) -> Option<V> {
         let now = Instant::now();
         let expires_at = Self::compute_expires_at(self.ttl, now);
@@ -1120,7 +1129,12 @@ where
     {
         async move {
             let ttl = self.ttl;
-            let setter = || async move {
+            // Count the miss before awaiting the factory, so an `Err` still records it
+            // instead of losing it on the `?` early return below (EXP-2); see the sync
+            // `cache_try_get_or_set_with_mut` for the full rationale.
+            let misses = &self.misses;
+            let setter = move || async move {
+                misses.fetch_add(1, Ordering::Relaxed);
                 // Fresh clock read anchored after the factory resolves (CORE-3).
                 let new_val = f().await?;
                 let now = Instant::now();
@@ -1146,14 +1160,14 @@ where
                     entry.expires_at = new_exp;
                 }
                 self.hits.fetch_add(1, Ordering::Relaxed);
-            } else {
-                if let Some((old_key, old)) = old_entry {
-                    if let Some(on_evict) = &self.on_evict {
-                        on_evict(&old_key, &old.value);
-                    }
-                    self.evictions.fetch_add(1, Ordering::Relaxed);
+            } else if let Some((old_key, old)) = old_entry {
+                // The miss was already counted by `setter`; on `Err` the expired entry is
+                // still stored, so the eviction side deliberately waits for the call that
+                // actually displaces it.
+                if let Some(on_evict) = &self.on_evict {
+                    on_evict(&old_key, &old.value);
                 }
-                self.misses.fetch_add(1, Ordering::Relaxed);
+                self.evictions.fetch_add(1, Ordering::Relaxed);
             }
             Ok(&mut entry.value)
         }
@@ -1258,7 +1272,7 @@ mod tests {
     }
 
     #[test]
-    fn cache_set_over_existing_key_does_not_promote_recency() {
+    fn cache_set_over_existing_key_promotes_to_mru() {
         let mut c: LruTtlCache<u32, u32> = LruTtlCache::builder()
             .max_size(3)
             .ttl(Duration::from_secs(60))
@@ -1268,11 +1282,74 @@ mod tests {
         c.cache_set(2, 20);
         c.cache_set(3, 30);
         assert_eq!(c.key_order(), vec![3, 2, 1]);
-        // Overwriting the least-recently-used key updates the value in-place and
-        // returns the old (still-live) value, but must NOT move it to the front.
+        // Overwriting the least-recently-used key returns the old (still-live) value
+        // and promotes the entry to most-recently-used.
         assert_eq!(c.cache_set(1, 11), Some(10));
-        assert_eq!(c.key_order(), vec![3, 2, 1]);
+        assert_eq!(c.key_order(), vec![1, 3, 2]);
         assert_eq!(c.cache_get(&1), Some(&11));
+    }
+
+    #[test]
+    fn cache_set_promotion_changes_the_capacity_eviction_victim() {
+        let mut c: LruTtlCache<u32, u32> = LruTtlCache::builder()
+            .max_size(3)
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        c.cache_set(1, 10);
+        c.cache_set(2, 20);
+        c.cache_set(3, 30);
+        // 1 was the LRU victim; overwriting it makes 2 the victim instead.
+        assert_eq!(c.cache_set(1, 11), Some(10));
+        c.cache_set(4, 40);
+        assert_eq!(c.key_order(), vec![4, 1, 3]);
+        assert_eq!(c.cache_get(&2), None, "2 became the LRU victim");
+        assert_eq!(c.cache_get(&1), Some(&11));
+    }
+
+    #[test]
+    fn cache_set_over_current_mru_and_sole_entry_keep_the_list_intact() {
+        let mut c: LruTtlCache<u32, u32> = LruTtlCache::builder()
+            .max_size(3)
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        c.cache_set(1, 10);
+        c.cache_set(2, 20);
+        c.cache_set(3, 30);
+        // Overwriting the head must not corrupt the chain.
+        assert_eq!(c.cache_set(3, 33), Some(30));
+        assert_eq!(c.key_order(), vec![3, 2, 1]);
+        assert_eq!(c.value_order(), vec![33, 20, 10]);
+        assert_eq!(c.cache_size(), 3);
+
+        // Sole entry of a 1-capacity cache.
+        let mut d: LruTtlCache<u32, u32> = LruTtlCache::builder()
+            .max_size(1)
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        d.cache_set(1, 10);
+        assert_eq!(d.cache_set(1, 11), Some(10));
+        assert_eq!(d.key_order(), vec![1]);
+        assert_eq!(d.cache_size(), 1);
+    }
+
+    #[test]
+    fn cache_peek_still_does_not_promote_after_set_does() {
+        use crate::CachedPeek;
+        let mut c: LruTtlCache<u32, u32> = LruTtlCache::builder()
+            .max_size(3)
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        c.cache_set(1, 10);
+        c.cache_set(2, 20);
+        c.cache_set(3, 30);
+        assert_eq!(c.cache_peek(&1), Some(&10));
+        assert_eq!(c.key_order(), vec![3, 2, 1], "peek must not promote");
+        assert_eq!(c.cache_set(1, 11), Some(10));
+        assert_eq!(c.key_order(), vec![1, 3, 2]);
     }
 
     #[test]
@@ -2950,9 +3027,8 @@ mod tests {
 
     #[test]
     fn clock_threading_does_not_change_cache_set_recency() {
-        // `set_entry` still goes through `cache_set_returning_entry`, which replaces
-        // IN PLACE and deliberately does not promote (the documented recency trap).
-        // Threading `now` through must not have changed that.
+        // `set_entry` goes through `cache_set_returning_entry`, which promotes the
+        // overwritten key to MRU. Threading `now` through must not change that.
         let mut c = long_ttl_cache(3);
         c.cache_set(1, 10);
         c.cache_set(2, 20);
@@ -2961,16 +3037,19 @@ mod tests {
         assert_eq!(c.cache_set(1, 11), Some(10));
         assert_eq!(
             c.key_order(),
-            vec![3, 2, 1],
-            "an overwrite must not promote the entry"
+            vec![1, 3, 2],
+            "an overwrite must promote the entry to MRU"
         );
-        // ... while the get paths DO promote.
-        assert_eq!(c.cache_get(&1), Some(&11));
-        assert_eq!(c.key_order(), vec![1, 3, 2]);
-        // Overwriting an expired entry (the other `set_entry` arm) must not promote
-        // either.
+        // ... and the get paths promote too.
+        assert_eq!(c.cache_get(&2), Some(&20));
+        assert_eq!(c.key_order(), vec![2, 1, 3]);
+        // Overwriting an EXPIRED entry (the other `set_entry` arm) promotes as well;
+        // the displaced expired value is filtered from the return.
+        // (`put_raw` writes through the inner store, so it promotes too; `key_order`
+        // filters the now-expired key 3 out of the visible order.)
         put_raw(&mut c, 3, 33, Some(Instant::now()));
+        assert_eq!(c.key_order(), vec![2, 1]);
         assert_eq!(c.cache_set(3, 333), None);
-        assert_eq!(c.key_order(), vec![1, 3, 2]);
+        assert_eq!(c.key_order(), vec![3, 2, 1]);
     }
 }

--- a/src/stores/lru_ttl.rs
+++ b/src/stores/lru_ttl.rs
@@ -363,15 +363,31 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruTtlCache<K, V, S> {
         expires_at.is_none_or(|t| Instant::now() < t)
     }
 
+    /// Same as [`entry_live`](Self::entry_live) but takes an already-sampled `now`
+    /// instead of reading the clock. Lets hot paths that already have `now` in hand
+    /// (e.g. a caller that just computed a fresh expiry, or a sweep that snapshotted
+    /// the clock once for the whole pass) avoid a redundant clock read.
+    ///
+    /// The boundary convention is identical: an entry is live only while
+    /// `now < expires_at`, so `now == expires_at` is already expired.
+    #[inline]
+    pub(super) fn entry_live_at(expires_at: Option<Instant>, now: Instant) -> bool {
+        expires_at.is_none_or(|t| now < t)
+    }
+
     /// Insert `entry` for `key`, returning the previous value only if it was still live.
     ///
     /// A displaced expired value is filtered from the return (matching the get paths), so it is
     /// dropped silently from the caller's view; in that case fire `on_evict` and count an
     /// eviction. The inner `LruCache::cache_set` does not fire `on_evict` on an overwrite, so the
     /// callback fires exactly once here. The key is cloned only when a callback is configured.
-    fn set_entry(&mut self, key: K, entry: TimedEntry<V>) -> Option<V> {
+    ///
+    /// `now` is the caller's already-sampled clock reading (the same one that produced
+    /// `entry.expires_at`), used to decide whether the displaced entry was still live --
+    /// avoids a second `Instant::now()` call here.
+    fn set_entry(&mut self, key: K, entry: TimedEntry<V>, now: Instant) -> Option<V> {
         match self.store.cache_set_returning_entry(key, entry) {
-            Some((_, old)) if Self::entry_live(old.expires_at) => Some(old.value),
+            Some((_, old)) if Self::entry_live_at(old.expires_at, now) => Some(old.value),
             Some((stored_key, old)) => {
                 if let Some(on_evict) = &self.on_evict {
                     on_evict(&stored_key, &old.value);
@@ -428,21 +444,24 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruTtlCache<K, V, S> {
         K: Clone,
         V: Clone,
     {
-        self.store
-            .order
-            .iter()
-            .filter_map(|(k, entry)| {
-                let expires_at = entry.expires_at;
-                if Self::entry_live(expires_at) {
-                    Some((
-                        k.clone(),
-                        super::CacheValue::new(entry.value.clone(), expires_at),
-                    ))
-                } else {
-                    None
-                }
-            })
-            .collect()
+        // One clock reading for the whole eager pass (as in `evict`), so liveness is
+        // judged against a single consistent instant instead of a per-entry read.
+        let now = Instant::now();
+        // `LRUListIterator` has no `size_hint`, so `collect` would grow the Vec from
+        // zero; the stored entry count is a known upper bound on the live entries.
+        let mut out = Vec::with_capacity(self.store.cache_size());
+        out.extend(self.store.order.iter().filter_map(|(k, entry)| {
+            let expires_at = entry.expires_at;
+            if Self::entry_live_at(expires_at, now) {
+                Some((
+                    k.clone(),
+                    super::CacheValue::new(entry.value.clone(), expires_at),
+                ))
+            } else {
+                None
+            }
+        }));
+        out
     }
 
     /// Return a `Vec` of keys in the current order from most
@@ -453,17 +472,17 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruTtlCache<K, V, S> {
     where
         K: Clone,
     {
-        self.store
-            .order
-            .iter()
-            .filter_map(|(k, entry)| {
-                if Self::entry_live(entry.expires_at) {
-                    Some(k.clone())
-                } else {
-                    None
-                }
-            })
-            .collect()
+        // Single clock reading + pre-sized output, as in `iter_order`.
+        let now = Instant::now();
+        let mut out = Vec::with_capacity(self.store.cache_size());
+        out.extend(self.store.order.iter().filter_map(|(k, entry)| {
+            if Self::entry_live_at(entry.expires_at, now) {
+                Some(k.clone())
+            } else {
+                None
+            }
+        }));
+        out
     }
 
     /// Return a `Vec` of [`CacheValue`](super::CacheValue)-wrapped values (each
@@ -474,18 +493,18 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruTtlCache<K, V, S> {
     where
         V: Clone,
     {
-        self.store
-            .order
-            .iter()
-            .filter_map(|(_k, entry)| {
-                let expires_at = entry.expires_at;
-                if Self::entry_live(expires_at) {
-                    Some(super::CacheValue::new(entry.value.clone(), expires_at))
-                } else {
-                    None
-                }
-            })
-            .collect()
+        // Single clock reading + pre-sized output, as in `iter_order`.
+        let now = Instant::now();
+        let mut out = Vec::with_capacity(self.store.cache_size());
+        out.extend(self.store.order.iter().filter_map(|(_k, entry)| {
+            let expires_at = entry.expires_at;
+            if Self::entry_live_at(expires_at, now) {
+                Some(super::CacheValue::new(entry.value.clone(), expires_at))
+            } else {
+                None
+            }
+        }));
+        out
     }
 
     /// Returns the maximum number of entries this cache will hold before evicting.
@@ -554,7 +573,7 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruTtlCache<K, V, S> {
         let now = Instant::now();
         self.store.retain_silent(|key, entry| {
             // None means never-expires; Some(t) expires when now >= t.
-            if entry.expires_at.is_none_or(|t| now < t) {
+            if Self::entry_live_at(entry.expires_at, now) {
                 true
             } else {
                 if let Some(on_evict) = on_evict {
@@ -583,8 +602,11 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruTtlCache<K, V, S> {
     pub fn retain<F: FnMut(&K, &V) -> bool>(&mut self, mut keep: F) {
         let on_evict = &self.on_evict;
         let evictions = &self.evictions;
+        // One clock reading for the whole pass (as in `evict`): every entry is judged
+        // against the same instant instead of re-reading the clock per entry.
+        let now = Instant::now();
         self.store.retain_silent(|key, entry| {
-            let expired = !Self::entry_live(entry.expires_at);
+            let expired = !Self::entry_live_at(entry.expires_at, now);
             if expired || !keep(key, &entry.value) {
                 if let Some(on_evict) = on_evict {
                     on_evict(key, &entry.value);
@@ -608,13 +630,10 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruTtlCache<K, V, S> {
         if self.on_evict.is_none() {
             return self.cache_clear();
         }
-        let keys = self.store.key_order();
-        let mut removed = Vec::with_capacity(keys.len());
-        for k in &keys {
-            if let Some(pair) = self.store.pop_raw(k) {
-                removed.push(pair);
-            }
-        }
+        // `drain_all` walks the LRU chain once taking owned pairs (MRU -> LRU, the same
+        // order the old `key_order` + per-key `pop_raw` drain fired in) -- no key clones
+        // and no re-hashing.
+        let removed = self.store.drain_all();
         let count = removed.len() as u64;
         if count > 0 {
             self.evictions.fetch_add(count, Ordering::Relaxed);
@@ -637,12 +656,15 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
     {
         let hash = self.store.hash(key);
         if let Some(index) = self.store.get_index(hash, key) {
+            // Sample the clock ONCE for this hit and reuse it for both the liveness
+            // check and the `refresh_on_hit` expiry. Sampled after the probe so an
+            // absent-key miss reads the clock not at all.
+            let now = Instant::now();
             let entry = &self.store.order.get(index).1;
-            if Self::entry_live(entry.expires_at) {
+            if Self::entry_live_at(entry.expires_at, now) {
                 self.store.order.move_to_front(index);
                 self.hits.fetch_add(1, Ordering::Relaxed);
                 if self.refresh {
-                    let now = Instant::now();
                     let new_exp = Self::compute_expires_at(self.ttl, now).or(self
                         .store
                         .order
@@ -654,7 +676,10 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
                 Some(&self.store.order.get(index).1.value)
             } else {
                 self.misses.fetch_add(1, Ordering::Relaxed);
-                if let Some((k, entry)) = self.store.pop_raw(key) {
+                // The key's hash is already in hand from the probe above; the lazy
+                // sweep must not recompute it (this is the steady-state path -- every
+                // entry takes it exactly once).
+                if let Some((k, entry)) = self.store.pop_raw_with_hash(hash, key) {
                     if let Some(on_evict) = &self.on_evict {
                         on_evict(&k, &entry.value);
                     }
@@ -675,12 +700,13 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
     {
         let hash = self.store.hash(key);
         if let Some(index) = self.store.get_index(hash, key) {
+            // One clock reading per hit, reused by the refresh below (as in `cache_get`).
+            let now = Instant::now();
             let entry = &self.store.order.get(index).1;
-            if Self::entry_live(entry.expires_at) {
+            if Self::entry_live_at(entry.expires_at, now) {
                 self.store.order.move_to_front(index);
                 self.hits.fetch_add(1, Ordering::Relaxed);
                 if self.refresh {
-                    let now = Instant::now();
                     let new_exp = Self::compute_expires_at(self.ttl, now).or(self
                         .store
                         .order
@@ -692,7 +718,8 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
                 Some(&mut self.store.order.get_mut(index).1.value)
             } else {
                 self.misses.fetch_add(1, Ordering::Relaxed);
-                if let Some((k, entry)) = self.store.pop_raw(key) {
+                // Reuse the probe's hash for the lazy sweep (as in `cache_get`).
+                if let Some((k, entry)) = self.store.pop_raw_with_hash(hash, key) {
                     if let Some(on_evict) = &self.on_evict {
                         on_evict(&k, &entry.value);
                     }
@@ -710,21 +737,28 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
         let ttl = self.ttl;
         let setter = || {
             // Anchor the expiry AFTER the factory runs so a slow factory does
-            // not eat into the fresh entry's TTL (CORE-3).
+            // not eat into the fresh entry's TTL (CORE-3). This clock read is
+            // deliberately NOT shared with `hit_at` below: `f()` may run arbitrarily
+            // long, so the fresh expiry must be anchored once it returns.
             let value = f();
             let now = Instant::now();
             let expires_at = Self::compute_expires_at(ttl, now);
             TimedEntry { expires_at, value }
         };
+        // The store calls the validity closure only when the key is present, so sample
+        // the clock there and reuse the reading for the refresh below: one read per hit,
+        // and the insert path (which anchors its own expiry after the factory) pays none.
+        let mut hit_at: Option<Instant> = None;
         // On replacement the store returns the STORED key/entry of the displaced value, so the
         // callback sees the instance that was actually cached, not the (equal-but-distinct)
         // lookup key (C1/C8).
         let (was_present, was_valid, old_entry, entry) =
-            self.store
-                .get_or_set_with_if(key, setter, |entry| Self::entry_live(entry.expires_at));
+            self.store.get_or_set_with_if(key, setter, |entry| {
+                Self::entry_live_at(entry.expires_at, *hit_at.insert(Instant::now()))
+            });
         if was_present && was_valid {
             if self.refresh {
-                let now = Instant::now();
+                let now = hit_at.unwrap_or_else(Instant::now);
                 let new_exp = Self::compute_expires_at(self.ttl, now).or(entry.expires_at);
                 entry.expires_at = new_exp;
             }
@@ -748,19 +782,23 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
     ) -> Result<&mut V, E> {
         let ttl = self.ttl;
         let setter = || {
-            // Anchor the expiry after the factory succeeds (CORE-3).
+            // Anchor the expiry after the factory succeeds (CORE-3); deliberately a
+            // fresh clock read, not the `hit_at` sample taken before `f()` ran.
             let value = f()?;
             let now = Instant::now();
             let expires_at = Self::compute_expires_at(ttl, now);
             Ok(TimedEntry { expires_at, value })
         };
+        // One clock read per hit, shared by the liveness check and the refresh below.
+        let mut hit_at: Option<Instant> = None;
         // On replacement the store returns the STORED key/entry of the displaced value (C1/C8).
         let (was_present, was_valid, old_entry, entry) =
-            self.store
-                .try_get_or_set_with_if(key, setter, |entry| Self::entry_live(entry.expires_at))?;
+            self.store.try_get_or_set_with_if(key, setter, |entry| {
+                Self::entry_live_at(entry.expires_at, *hit_at.insert(Instant::now()))
+            })?;
         if was_present && was_valid {
             if self.refresh {
-                let now = Instant::now();
+                let now = hit_at.unwrap_or_else(Instant::now);
                 let new_exp = Self::compute_expires_at(self.ttl, now).or(entry.expires_at);
                 entry.expires_at = new_exp;
             }
@@ -787,12 +825,15 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
     fn cache_set(&mut self, key: K, val: V) -> Option<V> {
         let now = Instant::now();
         let expires_at = Self::compute_expires_at(self.ttl, now);
+        // `now` is threaded through: `set_entry` judges the displaced entry's liveness
+        // against this same reading instead of sampling the clock a second time.
         self.set_entry(
             key,
             TimedEntry {
                 expires_at,
                 value: val,
             },
+            now,
         )
     }
 
@@ -888,6 +929,12 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> CachedIter<K, V> for LruTtlCache<K
         K: 'a,
         V: 'a,
     {
+        // Deliberately per-item `entry_live` (a fresh clock read each step) rather than
+        // a snapshot taken when the iterator is built: this iterator is lazy and may be
+        // held across arbitrary time, so a construction-time `now` would be observable
+        // -- entries that expired mid-iteration would still be yielded. The eager
+        // collectors (`iter_order`/`key_order`/`value_order`) hoist their reading
+        // because they complete in one pass.
         CachedIter::iter(&self.store).filter_map(move |(k, entry)| {
             if Self::entry_live(entry.expires_at) {
                 Some((k, &entry.value))
@@ -954,8 +1001,10 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher + Clone> CloneCached<K, V>
     {
         let hash = self.store.hash(k);
         if let Some(index) = self.store.get_index(hash, k) {
+            // One clock reading per hit, reused by the refresh below (as in `cache_get`).
+            let now = Instant::now();
             let entry = &self.store.order.get(index).1;
-            let expired = !Self::entry_live(entry.expires_at);
+            let expired = !Self::entry_live_at(entry.expires_at, now);
             if expired {
                 self.misses.fetch_add(1, Ordering::Relaxed);
                 (Some(self.store.order.get(index).1.value.clone()), true)
@@ -963,7 +1012,6 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher + Clone> CloneCached<K, V>
                 self.store.order.move_to_front(index);
                 self.hits.fetch_add(1, Ordering::Relaxed);
                 if self.refresh {
-                    let now = Instant::now();
                     let new_exp = Self::compute_expires_at(self.ttl, now).or(self
                         .store
                         .order
@@ -1022,20 +1070,25 @@ where
         async move {
             let ttl = self.ttl;
             let setter = || async move {
-                // Anchor the expiry after the factory resolves (CORE-3).
+                // Anchor the expiry after the factory resolves (CORE-3); deliberately a
+                // fresh clock read, not the `hit_at` sample taken before it ran.
                 let value = f().await;
                 let now = Instant::now();
                 let expires_at = Self::compute_expires_at(ttl, now);
                 TimedEntry { expires_at, value }
             };
+            // One clock read per hit, shared by the liveness check and the refresh below.
+            let mut hit_at: Option<Instant> = None;
             // On replacement the store returns the STORED key/entry of the displaced value (C1/C8).
             let (was_present, was_valid, old_entry, entry) = self
                 .store
-                .get_or_set_with_if_async(key, setter, |entry| Self::entry_live(entry.expires_at))
+                .get_or_set_with_if_async(key, setter, |entry| {
+                    Self::entry_live_at(entry.expires_at, *hit_at.insert(Instant::now()))
+                })
                 .await;
             if was_present && was_valid {
                 if self.refresh {
-                    let now = Instant::now();
+                    let now = hit_at.unwrap_or_else(Instant::now);
                     let new_exp = Self::compute_expires_at(self.ttl, now).or(entry.expires_at);
                     entry.expires_at = new_exp;
                 }
@@ -1068,6 +1121,7 @@ where
         async move {
             let ttl = self.ttl;
             let setter = || async move {
+                // Fresh clock read anchored after the factory resolves (CORE-3).
                 let new_val = f().await?;
                 let now = Instant::now();
                 let expires_at = Self::compute_expires_at(ttl, now);
@@ -1076,16 +1130,18 @@ where
                     value: new_val,
                 })
             };
+            // One clock read per hit, shared by the liveness check and the refresh below.
+            let mut hit_at: Option<Instant> = None;
             // On replacement the store returns the STORED key/entry of the displaced value (C1/C8).
             let (was_present, was_valid, old_entry, entry) = self
                 .store
                 .try_get_or_set_with_if_async(key, setter, |entry| {
-                    Self::entry_live(entry.expires_at)
+                    Self::entry_live_at(entry.expires_at, *hit_at.insert(Instant::now()))
                 })
                 .await?;
             if was_present && was_valid {
                 if self.refresh {
-                    let now = Instant::now();
+                    let now = hit_at.unwrap_or_else(Instant::now);
                     let new_exp = Self::compute_expires_at(self.ttl, now).or(entry.expires_at);
                     entry.expires_at = new_exp;
                 }
@@ -2018,5 +2074,903 @@ mod tests {
             Some(&7),
             "entry must be live right after insert"
         );
+    }
+
+    // =====================================================================
+    // PERF-2: clock threading / eager-sweep snapshots / hash reuse.
+    //
+    // Every change under PERF-2 is internal-only, so the tests below pin the
+    // *observable* contracts that the rewrites must not disturb:
+    //   * the `now >= expires_at` expiry boundary at every converted call site,
+    //   * `refresh_on_hit` extending by the FULL ttl measured from the hit,
+    //   * a slow factory's expiry still anchored AFTER the factory returns,
+    //   * `retain`/`evict` judging every entry against ONE pass-start snapshot,
+    //   * `cache_clear_with_on_evict` firing MRU -> LRU,
+    //   * the lazy expiry sweep (now reusing the probe's hash) still removing
+    //     the entry it swept.
+    // =====================================================================
+
+    /// Insert an entry with an explicitly chosen `expires_at`, bypassing the ttl
+    /// arithmetic, so a test can pin the exact `now >= expires_at` boundary.
+    /// Writes straight into the inner `LruCache`; the outer counters are untouched.
+    fn put_raw(c: &mut LruTtlCache<u32, u32>, k: u32, v: u32, expires_at: Option<Instant>) {
+        c.store.cache_set(
+            k,
+            TimedEntry {
+                expires_at,
+                value: v,
+            },
+        );
+    }
+
+    /// Read an entry's stored `expires_at` without any read side effects
+    /// (no promotion, no refresh, no metrics).
+    fn stored_expiry(c: &LruTtlCache<u32, u32>, k: u32) -> Option<Instant> {
+        CachedPeek::cache_peek(&c.store, &k)
+            .expect("entry must be present")
+            .expires_at
+    }
+
+    fn long_ttl_cache(max_size: usize) -> LruTtlCache<u32, u32> {
+        LruTtlCache::builder()
+            .max_size(max_size)
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap()
+    }
+
+    // `entry_live_at` must preserve the exact `now >= expires_at` boundary
+    // convention of `entry_live` (which reads `Instant::now()` internally):
+    // at `now == expires_at` the entry is already expired.
+    #[test]
+    fn entry_live_at_matches_now_ge_expires_at_is_expired_convention() {
+        let now = Instant::now();
+        let future = now + Duration::from_millis(10);
+        let past = now - Duration::from_millis(10);
+
+        // `expires_at = None` never expires, regardless of `now`.
+        assert!(LruTtlCache::<u32, u32>::entry_live_at(None, now));
+        // `now < expires_at`: live.
+        assert!(LruTtlCache::<u32, u32>::entry_live_at(Some(future), now));
+        // `now == expires_at`: the boundary itself is NOT live.
+        assert!(!LruTtlCache::<u32, u32>::entry_live_at(Some(now), now));
+        // `now > expires_at`: not live.
+        assert!(!LruTtlCache::<u32, u32>::entry_live_at(Some(past), now));
+    }
+
+    // --- boundary coverage at each converted call site ---------------------
+    //
+    // Each test crafts an entry whose `expires_at` is an `Instant` sampled just
+    // before the call under test. The process clock is monotonic, so the call's
+    // own internal reading is guaranteed to be `>=` that instant: this
+    // deterministically exercises the "tie or later" edge without a mock clock.
+    // A comfortably-future `expires_at` exercises the live side and
+    // `expires_at = None` exercises "never expires".
+
+    #[test]
+    fn cache_get_boundary_matches_now_ge_expires_at_convention() {
+        let mut c = long_ttl_cache(8);
+
+        let tie = Instant::now();
+        put_raw(&mut c, 1, 100, Some(tie));
+        assert_eq!(
+            c.cache_get(&1),
+            None,
+            "tie (now >= expires_at) must be a miss"
+        );
+        assert_eq!(c.cache_size(), 0, "expired entry must be swept on access");
+
+        put_raw(
+            &mut c,
+            2,
+            200,
+            Some(Instant::now() + Duration::from_secs(60)),
+        );
+        assert_eq!(
+            c.cache_get(&2),
+            Some(&200),
+            "now < expires_at must be a hit"
+        );
+
+        put_raw(&mut c, 3, 300, None);
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        assert_eq!(
+            c.cache_get(&3),
+            Some(&300),
+            "expires_at = None never expires"
+        );
+    }
+
+    #[test]
+    fn cache_get_mut_boundary_matches_now_ge_expires_at_convention() {
+        let mut c = long_ttl_cache(8);
+
+        let tie = Instant::now();
+        put_raw(&mut c, 1, 100, Some(tie));
+        assert_eq!(
+            c.cache_get_mut(&1),
+            None,
+            "tie (now >= expires_at) must be a miss"
+        );
+        assert_eq!(c.cache_size(), 0, "expired entry must be swept on access");
+
+        put_raw(
+            &mut c,
+            2,
+            200,
+            Some(Instant::now() + Duration::from_secs(60)),
+        );
+        assert_eq!(
+            c.cache_get_mut(&2),
+            Some(&mut 200),
+            "now < expires_at must be a hit"
+        );
+
+        put_raw(&mut c, 3, 300, None);
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        assert_eq!(
+            c.cache_get_mut(&3),
+            Some(&mut 300),
+            "expires_at = None never expires"
+        );
+    }
+
+    #[test]
+    fn cache_set_boundary_matches_now_ge_expires_at_convention() {
+        // `cache_set` samples `now` once and threads it into `set_entry`, which
+        // decides whether the DISPLACED entry was still live.
+        let mut c = long_ttl_cache(8);
+
+        let tie = Instant::now();
+        put_raw(&mut c, 1, 100, Some(tie));
+        let before = c.cache_evictions().unwrap();
+        assert_eq!(
+            c.cache_set(1, 111),
+            None,
+            "displacing an entry at the tie (now >= expires_at) must return None"
+        );
+        assert_eq!(
+            c.cache_evictions().unwrap(),
+            before + 1,
+            "the displaced expired entry must count as an eviction"
+        );
+
+        put_raw(
+            &mut c,
+            2,
+            200,
+            Some(Instant::now() + Duration::from_secs(60)),
+        );
+        let before = c.cache_evictions().unwrap();
+        assert_eq!(
+            c.cache_set(2, 222),
+            Some(200),
+            "displacing a live entry must return the old value"
+        );
+        assert_eq!(
+            c.cache_evictions().unwrap(),
+            before,
+            "displacing a live entry must not count an eviction"
+        );
+
+        put_raw(&mut c, 3, 300, None);
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        assert_eq!(
+            c.cache_set(3, 333),
+            Some(300),
+            "expires_at = None never expires, so the old value is returned"
+        );
+    }
+
+    #[test]
+    fn cache_get_or_set_with_boundary_matches_now_ge_expires_at_convention() {
+        let mut c = long_ttl_cache(8);
+
+        let tie = Instant::now();
+        put_raw(&mut c, 1, 100, Some(tie));
+        assert_eq!(
+            *c.cache_get_or_set_with(1, || 999),
+            999,
+            "tie (now >= expires_at) must be treated as expired and replaced"
+        );
+
+        put_raw(
+            &mut c,
+            2,
+            200,
+            Some(Instant::now() + Duration::from_secs(60)),
+        );
+        assert_eq!(
+            *c.cache_get_or_set_with(2, || 999),
+            200,
+            "now < expires_at must be a hit, so the factory must not run"
+        );
+
+        put_raw(&mut c, 3, 300, None);
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        assert_eq!(
+            *c.cache_get_or_set_with(3, || 999),
+            300,
+            "expires_at = None never expires"
+        );
+    }
+
+    #[test]
+    fn cache_try_get_or_set_with_boundary_matches_now_ge_expires_at_convention() {
+        let mut c = long_ttl_cache(8);
+
+        let tie = Instant::now();
+        put_raw(&mut c, 1, 100, Some(tie));
+        assert_eq!(
+            c.cache_try_get_or_set_with(1, || Ok::<u32, ()>(999))
+                .copied(),
+            Ok(999),
+            "tie (now >= expires_at) must be treated as expired and replaced"
+        );
+
+        put_raw(
+            &mut c,
+            2,
+            200,
+            Some(Instant::now() + Duration::from_secs(60)),
+        );
+        assert_eq!(
+            c.cache_try_get_or_set_with(2, || Ok::<u32, ()>(999))
+                .copied(),
+            Ok(200),
+            "now < expires_at must be a hit, so the factory must not run"
+        );
+
+        put_raw(&mut c, 3, 300, None);
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        assert_eq!(
+            c.cache_try_get_or_set_with(3, || Ok::<u32, ()>(999))
+                .copied(),
+            Ok(300),
+            "expires_at = None never expires"
+        );
+    }
+
+    #[test]
+    fn cache_get_with_expiry_status_boundary_matches_now_ge_expires_at_convention() {
+        let mut c = long_ttl_cache(8);
+
+        let tie = Instant::now();
+        put_raw(&mut c, 1, 100, Some(tie));
+        assert_eq!(
+            c.cache_get_with_expiry_status(&1),
+            (Some(100), true),
+            "tie (now >= expires_at) must report expired"
+        );
+
+        put_raw(
+            &mut c,
+            2,
+            200,
+            Some(Instant::now() + Duration::from_secs(60)),
+        );
+        assert_eq!(
+            c.cache_get_with_expiry_status(&2),
+            (Some(200), false),
+            "now < expires_at must report live"
+        );
+
+        put_raw(&mut c, 3, 300, None);
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        assert_eq!(
+            c.cache_get_with_expiry_status(&3),
+            (Some(300), false),
+            "expires_at = None never expires"
+        );
+    }
+
+    #[test]
+    fn order_collectors_boundary_matches_now_ge_expires_at_convention() {
+        // `iter_order` / `key_order` / `value_order` hoist ONE clock reading for the
+        // whole pass; the boundary they apply per entry must be unchanged.
+        let mut c = long_ttl_cache(8);
+        put_raw(&mut c, 1, 100, None); // never expires
+        put_raw(
+            &mut c,
+            2,
+            200,
+            Some(Instant::now() + Duration::from_secs(60)),
+        ); // live
+        let tie = Instant::now();
+        put_raw(&mut c, 3, 300, Some(tie)); // tie -> expired
+
+        // MRU -> LRU is 3, 2, 1; the tie entry is filtered out of all three views.
+        assert_eq!(c.key_order(), vec![2, 1]);
+        assert_eq!(
+            c.iter_order()
+                .into_iter()
+                .map(|(k, v)| (k, *v))
+                .collect::<Vec<_>>(),
+            vec![(2, 200), (1, 100)]
+        );
+        assert_eq!(
+            c.value_order()
+                .into_iter()
+                .map(|v| v.into_value())
+                .collect::<Vec<_>>(),
+            vec![200, 100]
+        );
+        // The views are non-destructive: the expired entry is still stored.
+        assert_eq!(c.cache_size(), 3);
+    }
+
+    #[test]
+    fn evict_boundary_matches_now_ge_expires_at_convention() {
+        let mut c = long_ttl_cache(8);
+        put_raw(&mut c, 1, 100, None);
+        put_raw(
+            &mut c,
+            2,
+            200,
+            Some(Instant::now() + Duration::from_secs(60)),
+        );
+        let tie = Instant::now();
+        put_raw(&mut c, 3, 300, Some(tie));
+
+        assert_eq!(c.evict(), 1, "only the tie entry is expired");
+        assert_eq!(c.key_order(), vec![2, 1]);
+    }
+
+    #[test]
+    fn retain_boundary_matches_now_ge_expires_at_convention() {
+        let mut c = long_ttl_cache(8);
+        put_raw(&mut c, 1, 100, None);
+        put_raw(
+            &mut c,
+            2,
+            200,
+            Some(Instant::now() + Duration::from_secs(60)),
+        );
+        let tie = Instant::now();
+        put_raw(&mut c, 3, 300, Some(tie));
+
+        // Predicate keeps everything: only the expiry boundary decides.
+        c.retain(|_k, _v| true);
+        assert_eq!(
+            c.key_order(),
+            vec![2, 1],
+            "the tie entry (now >= expires_at) must be swept regardless of the predicate"
+        );
+    }
+
+    // --- refresh_on_hit anchoring ------------------------------------------
+
+    // With `refresh_on_hit`, a hit must extend the entry's expiry by the FULL
+    // configured ttl measured from the moment of the hit -- never by
+    // ttl-minus-epsilon from a stale/earlier clock reading. Bracketed by clock
+    // reads taken immediately before and after the hit.
+    //
+    // The ttl is deliberately far longer than the pre-hit sleep so a descheduled
+    // test thread can never let the entry expire mid-test (that would turn a real
+    // assertion failure into a flake); the sleep only has to be long enough that
+    // `before + ttl` is strictly greater than the original expiry, which is what
+    // makes "the expiry actually moved" observable.
+    const REFRESH_TTL: Duration = Duration::from_secs(30);
+    const REFRESH_GAP: std::time::Duration = std::time::Duration::from_millis(20);
+
+    fn refreshing_cache() -> LruTtlCache<u32, u32> {
+        LruTtlCache::builder()
+            .max_size(4)
+            .ttl(REFRESH_TTL)
+            .refresh_on_hit(true)
+            .build()
+            .unwrap()
+    }
+
+    /// Assert that a hit bracketed by `before`/`after` re-anchored key 1's expiry to
+    /// the hit itself, extended by the full ttl.
+    fn assert_refreshed_to_hit_time(
+        c: &LruTtlCache<u32, u32>,
+        original: Instant,
+        before: Instant,
+        after: Instant,
+    ) {
+        let expires_at = stored_expiry(c, 1).expect("finite ttl carries an expiry");
+        assert!(
+            expires_at > original,
+            "refresh_on_hit must move the expiry forward"
+        );
+        assert!(
+            expires_at >= before + REFRESH_TTL,
+            "refresh must extend by the FULL ttl measured from the hit, not less"
+        );
+        assert!(
+            expires_at <= after + REFRESH_TTL,
+            "refresh must not anchor to a clock reading taken before the hit"
+        );
+    }
+
+    #[test]
+    fn refresh_on_hit_cache_get_extends_by_full_ttl_from_hit_time() {
+        let mut c = refreshing_cache();
+        c.cache_set(1, 100);
+        let original = stored_expiry(&c, 1).expect("finite ttl carries an expiry");
+        std::thread::sleep(REFRESH_GAP);
+
+        let before = Instant::now();
+        assert_eq!(c.cache_get(&1), Some(&100));
+        let after = Instant::now();
+
+        assert_refreshed_to_hit_time(&c, original, before, after);
+    }
+
+    #[test]
+    fn refresh_on_hit_cache_get_mut_extends_by_full_ttl_from_hit_time() {
+        let mut c = refreshing_cache();
+        c.cache_set(1, 100);
+        let original = stored_expiry(&c, 1).expect("finite ttl carries an expiry");
+        std::thread::sleep(REFRESH_GAP);
+
+        let before = Instant::now();
+        assert_eq!(c.cache_get_mut(&1), Some(&mut 100));
+        let after = Instant::now();
+
+        assert_refreshed_to_hit_time(&c, original, before, after);
+    }
+
+    #[test]
+    fn refresh_on_hit_get_or_set_extends_by_full_ttl_from_hit_time() {
+        // The hit path of `cache_get_or_set_with` now reuses the clock reading taken
+        // by the store's validity check; it must still be a reading from THIS call.
+        let mut c = refreshing_cache();
+        c.cache_set(1, 100);
+        let original = stored_expiry(&c, 1).expect("finite ttl carries an expiry");
+        std::thread::sleep(REFRESH_GAP);
+
+        let before = Instant::now();
+        assert_eq!(*c.cache_get_or_set_with(1, || 999), 100);
+        let after = Instant::now();
+
+        assert_refreshed_to_hit_time(&c, original, before, after);
+    }
+
+    #[test]
+    fn refresh_on_hit_try_get_or_set_extends_by_full_ttl_from_hit_time() {
+        let mut c = refreshing_cache();
+        c.cache_set(1, 100);
+        let original = stored_expiry(&c, 1).expect("finite ttl carries an expiry");
+        std::thread::sleep(REFRESH_GAP);
+
+        let before = Instant::now();
+        assert_eq!(
+            c.cache_try_get_or_set_with(1, || Ok::<u32, ()>(999))
+                .copied(),
+            Ok(100)
+        );
+        let after = Instant::now();
+
+        assert_refreshed_to_hit_time(&c, original, before, after);
+    }
+
+    #[test]
+    fn refresh_on_hit_get_with_expiry_status_extends_by_full_ttl_from_hit_time() {
+        let mut c = refreshing_cache();
+        c.cache_set(1, 100);
+        let original = stored_expiry(&c, 1).expect("finite ttl carries an expiry");
+        std::thread::sleep(REFRESH_GAP);
+
+        let before = Instant::now();
+        assert_eq!(c.cache_get_with_expiry_status(&1), (Some(100), false));
+        let after = Instant::now();
+
+        assert_refreshed_to_hit_time(&c, original, before, after);
+    }
+
+    #[test]
+    fn refresh_on_hit_disabled_leaves_expiry_untouched() {
+        // Guard the other direction: reusing one clock reading must not start
+        // refreshing entries in a cache that never opted into refresh_on_hit.
+        let mut c: LruTtlCache<u32, u32> = LruTtlCache::builder()
+            .max_size(4)
+            .ttl(Duration::from_millis(400))
+            .build()
+            .unwrap();
+        c.cache_set(1, 100);
+        let original = stored_expiry(&c, 1).expect("finite ttl carries an expiry");
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        assert_eq!(c.cache_get(&1), Some(&100));
+        assert_eq!(*c.cache_get_or_set_with(1, || 999), 100);
+        assert_eq!(
+            stored_expiry(&c, 1),
+            Some(original),
+            "without refresh_on_hit a hit must not move the expiry"
+        );
+    }
+
+    // --- slow-factory anchoring ---------------------------------------------
+
+    // The `hit_at` reading sampled for the validity check must NOT be reused as the
+    // new entry's expiry anchor: the factory may run arbitrarily long, so the fresh
+    // expiry has to be anchored AFTER it returns. Measured directly against the
+    // stored `expires_at`, so it fails even if the factory is faster than the ttl.
+    #[test]
+    fn get_or_set_expiry_anchored_after_slow_factory_returns() {
+        let ttl = Duration::from_millis(500);
+        let mut c: LruTtlCache<u32, u32> =
+            LruTtlCache::builder().max_size(4).ttl(ttl).build().unwrap();
+        // Pre-seed an EXPIRED entry so the replacement path (validity check first,
+        // then factory) is the one exercised.
+        put_raw(&mut c, 1, 100, Some(Instant::now()));
+
+        assert_eq!(
+            *c.cache_get_or_set_with(1, || {
+                std::thread::sleep(std::time::Duration::from_millis(120));
+                7
+            }),
+            7
+        );
+        let factory_returned = Instant::now();
+        let expires_at = stored_expiry(&c, 1).expect("finite ttl carries an expiry");
+        assert!(
+            expires_at + Duration::from_millis(120) > factory_returned + ttl,
+            "the expiry must be anchored after the factory returned, not at lookup time"
+        );
+        assert_eq!(
+            c.cache_get(&1),
+            Some(&7),
+            "entry must be live right after insert"
+        );
+    }
+
+    #[test]
+    fn try_get_or_set_expiry_anchored_after_slow_factory_returns() {
+        let ttl = Duration::from_millis(500);
+        let mut c: LruTtlCache<u32, u32> =
+            LruTtlCache::builder().max_size(4).ttl(ttl).build().unwrap();
+        put_raw(&mut c, 1, 100, Some(Instant::now()));
+
+        assert_eq!(
+            c.cache_try_get_or_set_with(1, || {
+                std::thread::sleep(std::time::Duration::from_millis(120));
+                Ok::<u32, ()>(7)
+            })
+            .copied(),
+            Ok(7)
+        );
+        let factory_returned = Instant::now();
+        let expires_at = stored_expiry(&c, 1).expect("finite ttl carries an expiry");
+        assert!(
+            expires_at + Duration::from_millis(120) > factory_returned + ttl,
+            "the expiry must be anchored after the factory returned, not at lookup time"
+        );
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn async_get_or_set_expiry_anchored_after_slow_factory_returns() {
+        use crate::CachedGetOrSetAsync;
+        let ttl = Duration::from_millis(500);
+        let mut c: LruTtlCache<u32, u32> =
+            LruTtlCache::builder().max_size(4).ttl(ttl).build().unwrap();
+        put_raw(&mut c, 1, 100, Some(Instant::now()));
+
+        let v = CachedGetOrSetAsync::async_cache_get_or_set_with(&mut c, 1, || async {
+            tokio::time::sleep(std::time::Duration::from_millis(120)).await;
+            7
+        })
+        .await;
+        assert_eq!(*v, 7);
+        let factory_returned = Instant::now();
+        let expires_at = stored_expiry(&c, 1).expect("finite ttl carries an expiry");
+        assert!(
+            expires_at + Duration::from_millis(120) > factory_returned + ttl,
+            "the expiry must be anchored after the factory resolved, not at lookup time"
+        );
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn async_refresh_on_hit_extends_by_full_ttl_from_hit_time() {
+        use crate::CachedGetOrSetAsync;
+        let ttl = Duration::from_millis(200);
+        let mut c: LruTtlCache<u32, u32> = LruTtlCache::builder()
+            .max_size(4)
+            .ttl(ttl)
+            .refresh_on_hit(true)
+            .build()
+            .unwrap();
+        c.cache_set(1, 100);
+        tokio::time::sleep(std::time::Duration::from_millis(60)).await;
+
+        let before = Instant::now();
+        let v = CachedGetOrSetAsync::async_cache_get_or_set_with(&mut c, 1, || async { 999 }).await;
+        assert_eq!(*v, 100);
+        let after = Instant::now();
+
+        let expires_at = stored_expiry(&c, 1).expect("finite ttl carries an expiry");
+        assert!(
+            expires_at >= before + ttl,
+            "refresh must extend by the FULL ttl measured from the hit"
+        );
+        assert!(
+            expires_at <= after + ttl,
+            "refresh must not anchor to a clock reading taken before the hit"
+        );
+    }
+
+    // --- one snapshot per eager sweep ---------------------------------------
+
+    #[test]
+    fn retain_judges_every_entry_against_one_pass_start_snapshot() {
+        // `retain` samples the clock ONCE at the top of the pass. An entry that is
+        // live when the pass starts must survive even if it expires while the pass
+        // is still running. With a per-entry clock reading the slow predicate below
+        // would push the second entry past its expiry and sweep it.
+        let mut c = long_ttl_cache(8);
+        // MRU -> LRU order is 2, 1: entry 1 is judged AFTER the slow predicate call
+        // for entry 2.
+        put_raw(
+            &mut c,
+            1,
+            100,
+            Some(Instant::now() + Duration::from_millis(80)),
+        );
+        put_raw(&mut c, 2, 200, None);
+
+        c.retain(|_k, _v| {
+            std::thread::sleep(std::time::Duration::from_millis(200));
+            true
+        });
+
+        // `cache_size` is the RAW stored count (entry 1 has expired by now, so the
+        // expiry-filtering `key_order` would not show it).
+        assert_eq!(
+            c.cache_size(),
+            2,
+            "an entry live at the start of the pass must survive the whole pass"
+        );
+    }
+
+    #[test]
+    fn evict_judges_every_entry_against_one_pass_start_snapshot() {
+        // Same guarantee for `evict`, using a slow `on_evict` callback to stretch
+        // the pass past a later entry's expiry.
+        let mut c: LruTtlCache<u32, u32> = LruTtlCache::builder()
+            .max_size(8)
+            .ttl(Duration::from_secs(60))
+            .on_evict(|_k: &u32, _v: &u32| {
+                std::thread::sleep(std::time::Duration::from_millis(200));
+            })
+            .build()
+            .unwrap();
+        // MRU -> LRU order is 3, 2, 1: the already-expired entry 2 fires the slow
+        // callback before entry 1 is judged.
+        put_raw(
+            &mut c,
+            1,
+            100,
+            Some(Instant::now() + Duration::from_millis(80)),
+        );
+        put_raw(&mut c, 2, 200, Some(Instant::now()));
+        put_raw(&mut c, 3, 300, None);
+
+        assert_eq!(
+            c.evict(),
+            1,
+            "only the entry already expired at the start of the pass may be swept"
+        );
+        assert_eq!(c.cache_size(), 2);
+    }
+
+    // --- cache_clear_with_on_evict ------------------------------------------
+
+    #[test]
+    fn cache_clear_with_on_evict_fires_mru_to_lru() {
+        use std::sync::Mutex;
+        let fired: Arc<Mutex<Vec<(u32, u32)>>> = Arc::new(Mutex::new(Vec::new()));
+        let fired2 = fired.clone();
+        let mut c = LruTtlCache::builder()
+            .max_size(5)
+            .ttl(Duration::from_secs(60))
+            .on_evict(move |k: &u32, v: &u32| {
+                fired2.lock().unwrap().push((*k, *v));
+            })
+            .build()
+            .unwrap();
+        c.cache_set(1, 10);
+        c.cache_set(2, 20);
+        c.cache_set(3, 30);
+        // Promote 1 so the MRU -> LRU order is 1, 3, 2 (not simply insertion order).
+        assert_eq!(c.cache_get(&1), Some(&10));
+        assert_eq!(c.key_order(), vec![1, 3, 2]);
+
+        c.cache_clear_with_on_evict();
+
+        assert_eq!(
+            fired.lock().unwrap().as_slice(),
+            &[(1, 10), (3, 30), (2, 20)],
+            "on_evict must fire in MRU -> LRU order"
+        );
+        assert_eq!(c.cache_size(), 0);
+    }
+
+    #[test]
+    fn cache_clear_with_on_evict_fires_for_expired_entries_too() {
+        // The clear is expiry-blind: every stored entry fires the callback and is
+        // counted, whether or not it had already expired.
+        let count = Arc::new(AtomicUsize::new(0));
+        let count2 = count.clone();
+        let mut c = LruTtlCache::builder()
+            .max_size(5)
+            .ttl(Duration::from_secs(60))
+            .on_evict(move |_k: &u32, _v: &u32| {
+                count2.fetch_add(1, AtomicOrdering::Relaxed);
+            })
+            .build()
+            .unwrap();
+        c.store.cache_set(
+            1,
+            TimedEntry {
+                expires_at: Some(Instant::now()),
+                value: 10,
+            },
+        );
+        c.store.cache_set(
+            2,
+            TimedEntry {
+                expires_at: None,
+                value: 20,
+            },
+        );
+
+        c.cache_clear_with_on_evict();
+        assert_eq!(count.load(AtomicOrdering::Relaxed), 2);
+        assert_eq!(c.evictions.load(AtomicOrdering::Relaxed), 2);
+        assert_eq!(c.cache_size(), 0);
+    }
+
+    #[test]
+    fn cache_clear_with_on_evict_leaves_cache_reusable() {
+        // `drain_all` resets the LRU slab's sentinels; the cache must behave
+        // normally afterwards (inserts, recency order, capacity eviction).
+        let mut c = LruTtlCache::builder()
+            .max_size(2)
+            .ttl(Duration::from_secs(60))
+            .on_evict(|_k: &u32, _v: &u32| {})
+            .build()
+            .unwrap();
+        c.cache_set(1, 10);
+        c.cache_set(2, 20);
+        c.cache_clear_with_on_evict();
+        assert_eq!(c.cache_size(), 0);
+        assert_eq!(c.key_order(), Vec::<u32>::new());
+
+        c.cache_set(3, 30);
+        c.cache_set(4, 40);
+        assert_eq!(c.key_order(), vec![4, 3]);
+        assert_eq!(c.cache_get(&3), Some(&30));
+        c.cache_set(5, 50); // evicts the LRU entry (4)
+        assert_eq!(c.cache_size(), 2);
+        assert_eq!(c.cache_get(&4), None);
+        assert_eq!(c.cache_get(&3), Some(&30));
+    }
+
+    #[test]
+    fn cache_clear_with_on_evict_without_callback_is_a_plain_clear() {
+        let mut c = long_ttl_cache(4);
+        c.cache_set(1, 10);
+        c.cache_set(2, 20);
+        let before = c.cache_evictions().unwrap();
+        c.cache_clear_with_on_evict();
+        assert_eq!(c.cache_size(), 0);
+        assert_eq!(
+            c.cache_evictions().unwrap(),
+            before,
+            "without a callback this is a plain clear: no eviction accounting"
+        );
+    }
+
+    // --- lazy expiry sweep reuses the probe's hash ---------------------------
+
+    #[test]
+    fn cache_get_lazy_sweep_removes_the_expired_entry() {
+        // The expired branch pops with the hash already computed for the probe. A
+        // mismatched hash would silently miss and leave the entry in the store.
+        let count = Arc::new(AtomicUsize::new(0));
+        let count2 = count.clone();
+        let mut c = LruTtlCache::builder()
+            .max_size(4)
+            .ttl(Duration::from_secs(60))
+            .on_evict(move |_k: &u32, _v: &u32| {
+                count2.fetch_add(1, AtomicOrdering::Relaxed);
+            })
+            .build()
+            .unwrap();
+        c.store.cache_set(
+            1,
+            TimedEntry {
+                expires_at: Some(Instant::now()),
+                value: 10,
+            },
+        );
+        assert_eq!(c.cache_size(), 1);
+        assert_eq!(c.cache_get(&1), None);
+        assert_eq!(c.cache_size(), 0, "the expired entry must be removed");
+        assert_eq!(count.load(AtomicOrdering::Relaxed), 1);
+        assert_eq!(c.evictions.load(AtomicOrdering::Relaxed), 1);
+        // A second get is a plain absent-key miss.
+        assert_eq!(c.cache_get(&1), None);
+        assert_eq!(count.load(AtomicOrdering::Relaxed), 1);
+    }
+
+    #[test]
+    fn cache_get_mut_lazy_sweep_removes_the_expired_entry() {
+        let mut c: LruTtlCache<u32, u32> = LruTtlCache::builder()
+            .max_size(4)
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        c.store.cache_set(
+            1,
+            TimedEntry {
+                expires_at: Some(Instant::now()),
+                value: 10,
+            },
+        );
+        assert_eq!(c.cache_get_mut(&1), None);
+        assert_eq!(c.cache_size(), 0, "the expired entry must be removed");
+    }
+
+    #[test]
+    fn cache_get_lazy_sweep_removes_borrowed_key_entry() {
+        // Borrowed lookup form (`K = String`, `Q = str`): the hash reused by the
+        // lazy sweep is the one computed from `&str`, which must still locate the
+        // `String`-keyed entry.
+        let mut c: LruTtlCache<String, u32> = LruTtlCache::builder()
+            .max_size(4)
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        c.store.cache_set(
+            "alpha".to_string(),
+            TimedEntry {
+                expires_at: Some(Instant::now()),
+                value: 10,
+            },
+        );
+        assert_eq!(c.cache_get("alpha"), None);
+        assert_eq!(
+            c.cache_size(),
+            0,
+            "the expired entry must be removed via the borrowed-key hash"
+        );
+
+        // The live path over the same borrowed form still works.
+        c.cache_set("beta".to_string(), 20);
+        assert_eq!(c.cache_get("beta"), Some(&20));
+        assert_eq!(c.cache_get_mut("beta"), Some(&mut 20));
+    }
+
+    // --- recency preserved ---------------------------------------------------
+
+    #[test]
+    fn clock_threading_does_not_change_cache_set_recency() {
+        // `set_entry` still goes through `cache_set_returning_entry`, which replaces
+        // IN PLACE and deliberately does not promote (the documented recency trap).
+        // Threading `now` through must not have changed that.
+        let mut c = long_ttl_cache(3);
+        c.cache_set(1, 10);
+        c.cache_set(2, 20);
+        c.cache_set(3, 30);
+        assert_eq!(c.key_order(), vec![3, 2, 1]);
+        assert_eq!(c.cache_set(1, 11), Some(10));
+        assert_eq!(
+            c.key_order(),
+            vec![3, 2, 1],
+            "an overwrite must not promote the entry"
+        );
+        // ... while the get paths DO promote.
+        assert_eq!(c.cache_get(&1), Some(&11));
+        assert_eq!(c.key_order(), vec![1, 3, 2]);
+        // Overwriting an expired entry (the other `set_entry` arm) must not promote
+        // either.
+        put_raw(&mut c, 3, 33, Some(Instant::now()));
+        assert_eq!(c.cache_set(3, 333), None);
+        assert_eq!(c.key_order(), vec![1, 3, 2]);
     }
 }

--- a/src/stores/mod.rs
+++ b/src/stores/mod.rs
@@ -100,6 +100,16 @@ impl StripedCounter {
             .fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Increment slot 0 by one, without a thread-local lookup or an atomic RMW.
+    ///
+    /// Only valid where the caller statically holds `&mut self` (exclusive access),
+    /// e.g. behind an existing lock or an owning `&mut` receiver. `load()` sums all
+    /// slots regardless of which slot was bumped, so the aggregate stays correct.
+    #[inline]
+    pub(super) fn increment_mut(&mut self) {
+        *self.slots[0].0.get_mut() += 1;
+    }
+
     /// Sum across all stripes.
     pub(super) fn load(&self) -> u64 {
         self.slots.iter().map(|s| s.0.load(Ordering::Relaxed)).sum()
@@ -596,6 +606,51 @@ pub trait ConcurrentCacheEvict {
 /// Cache store tests
 mod tests {
     use super::*;
+
+    // `increment_mut` (the exclusive-access, non-atomic fast path used by `&mut self`
+    // call sites) and `increment` (the striped, thread-local-indexed atomic path used by
+    // `CachedRead`'s shared-reference call sites) must both feed the same aggregate: a mix
+    // of the two, in either order, sums to the total call count under `load()`.
+    #[test]
+    fn increment_mut_and_increment_agree_on_aggregate() {
+        let mut counter = StripedCounter::new();
+        assert_eq!(counter.load(), 0);
+
+        // Mix `increment_mut` and `increment` calls; every call, regardless of which
+        // method, must contribute exactly 1 to the aggregate.
+        counter.increment_mut();
+        counter.increment();
+        counter.increment_mut();
+        counter.increment();
+        counter.increment();
+        counter.increment_mut();
+
+        assert_eq!(counter.load(), 6);
+
+        // `reset()` still zeroes everything, including whatever `increment_mut` wrote to
+        // slot 0 and whatever `increment` scattered across the striped slots.
+        counter.reset();
+        assert_eq!(counter.load(), 0);
+
+        // After reset, further mixed increments still land correctly.
+        for _ in 0..10 {
+            counter.increment_mut();
+        }
+        for _ in 0..10 {
+            counter.increment();
+        }
+        assert_eq!(counter.load(), 20);
+
+        // `snapshot()` carries the aggregate (from a mix of both increment paths) across
+        // a clone, collapsed into a fresh counter's slot 0.
+        let snap = counter.snapshot();
+        assert_eq!(snap.load(), 20);
+        // The snapshot is independent: incrementing it must not affect the original.
+        let mut snap = snap;
+        snap.increment_mut();
+        assert_eq!(snap.load(), 21);
+        assert_eq!(counter.load(), 20);
+    }
 
     #[test]
     fn hashmap() {

--- a/src/stores/sharded/expiring.rs
+++ b/src/stores/sharded/expiring.rs
@@ -2328,7 +2328,10 @@ mod tests {
     }
 
     /// Index of the shard that owns `k`.
-    fn owning_shard<K, V, H: ShardHasher<K>>(c: &ShardedExpiringCacheBase<K, V, H>, k: &K) -> usize {
+    fn owning_shard<K, V, H: ShardHasher<K>>(
+        c: &ShardedExpiringCacheBase<K, V, H>,
+        k: &K,
+    ) -> usize {
         shard_index(c.inner.hasher.shard_hash(k), c.inner.shard_mask)
     }
 
@@ -2347,7 +2350,9 @@ mod tests {
 
     /// Every stored entry as `(key, value, expired)`, sorted, for a full cross-cache
     /// state comparison.
-    fn entry_snapshot<H: ShardHasher<u32>>(c: &ShardedExpiringCacheBase<u32, Val, H>) -> Vec<(u32, u32, bool)> {
+    fn entry_snapshot<H: ShardHasher<u32>>(
+        c: &ShardedExpiringCacheBase<u32, Val, H>,
+    ) -> Vec<(u32, u32, bool)> {
         let mut out: Vec<(u32, u32, bool)> = Vec::new();
         for shard in c.inner.shards.iter() {
             let guard = shard.lock.read();
@@ -2507,7 +2512,8 @@ mod tests {
         // Gap: assert the callback (extract_if) and no-callback (retain + length-delta)
         // evict() branches return identical counts and leave identical state for the same
         // input, including a multi-shard mix where some shards have nothing expired.
-        let fired: Arc<std::sync::Mutex<Vec<(u32, u32)>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let fired: Arc<std::sync::Mutex<Vec<(u32, u32)>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
         let fired2 = fired.clone();
         let with_cb = ShardedExpiringCacheBase::<u32, Val>::builder()
             .shards(4)
@@ -2557,7 +2563,10 @@ mod tests {
 
         let removed_cb = with_cb.evict();
         let removed_plain = no_cb.evict();
-        assert_eq!(removed_cb, 8, "only the eight backdated entries are expired");
+        assert_eq!(
+            removed_cb, 8,
+            "only the eight backdated entries are expired"
+        );
         assert_eq!(
             removed_plain, removed_cb,
             "the retain + length-delta branch must return the same count as the extract_if branch"
@@ -2701,14 +2710,13 @@ mod tests {
                     let k = r % KEYS;
                     // Unique id per stored value lets on_evict distinguish "this exact
                     // stored entry" from "a same-key entry that replaced it".
-                    let id = u32::try_from(next_id.fetch_add(1, Ordering::Relaxed) % 1_000_000)
-                        .unwrap();
+                    let id =
+                        u32::try_from(next_id.fetch_add(1, Ordering::Relaxed) % 1_000_000).unwrap();
                     // A third of inserts are born already-expired, so cache_set's
                     // displaced-expired-entry branch races cache_remove and evict() for
                     // the very same entries.
                     let expired = id % 3 == 0;
-                    let _ =
-                        SyncConcurrentCached::cache_set(&c, k, Val { v: id, expired }).unwrap();
+                    let _ = SyncConcurrentCached::cache_set(&c, k, Val { v: id, expired }).unwrap();
                 }
             }));
         }

--- a/src/stores/sharded/expiring.rs
+++ b/src/stores/sharded/expiring.rs
@@ -163,6 +163,7 @@ impl<K: Clone + Hash + Eq, V: Clone + Expires, H: ShardHasher<K>>
                     lock: parking_lot::RwLock::new(store_copy),
                     hits: AtomicU64::new(hits),
                     misses: AtomicU64::new(misses),
+                    evictions: AtomicU64::new(0),
                 };
                 CachePadded(shard)
             })

--- a/src/stores/sharded/expiring.rs
+++ b/src/stores/sharded/expiring.rs
@@ -32,7 +32,6 @@ struct ExpiringInner<K, V, H> {
     shard_mask: usize,
     hasher: H,
     on_evict: Option<OnEvict<K, V>>,
-    evictions: AtomicU64,
 }
 
 /// A fully-concurrent, partitioned, unbounded in-memory cache with per-value expiry.
@@ -78,9 +77,15 @@ impl<K, V, H> Clone for ShardedExpiringCacheBase<K, V, H> {
 
 impl<K, V, H> std::fmt::Debug for ShardedExpiringCacheBase<K, V, H> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let evictions: u64 = self
+            .inner
+            .shards
+            .iter()
+            .map(|s| s.evictions.load(Ordering::Relaxed))
+            .sum();
         f.debug_struct("ShardedExpiringCache")
             .field("shards", &self.inner.shards.len())
-            .field("evictions", &self.inner.evictions.load(Ordering::Relaxed))
+            .field("evictions", &evictions)
             .finish_non_exhaustive()
     }
 }
@@ -151,19 +156,20 @@ impl<K: Clone + Hash + Eq, V: Clone + Expires, H: ShardHasher<K>>
         let n = self.inner.shards.len();
         let shards = (0..n)
             .map(|i| {
-                // Load the hit/miss counters under the read lock so the metrics snapshot is
-                // consistent with the entry snapshot (B4: loading after drop(guard) could yield
-                // counters newer than the cloned entries).
+                // Load the hit/miss/eviction counters under the read lock so the metrics
+                // snapshot is consistent with the entry snapshot (B4: loading after
+                // drop(guard) could yield counters newer than the cloned entries).
                 let guard = self.inner.shards[i].lock.read();
                 let store_copy = guard.clone();
                 let hits = self.inner.shards[i].hits.load(Ordering::Relaxed);
                 let misses = self.inner.shards[i].misses.load(Ordering::Relaxed);
+                let evictions = self.inner.shards[i].evictions.load(Ordering::Relaxed);
                 drop(guard);
                 let shard = Shard {
                     lock: parking_lot::RwLock::new(store_copy),
                     hits: AtomicU64::new(hits),
                     misses: AtomicU64::new(misses),
-                    evictions: AtomicU64::new(0),
+                    evictions: AtomicU64::new(evictions),
                 };
                 CachePadded(shard)
             })
@@ -175,7 +181,6 @@ impl<K: Clone + Hash + Eq, V: Clone + Expires, H: ShardHasher<K>>
                 shard_mask: self.inner.shard_mask,
                 hasher: self.inner.hasher.clone(),
                 on_evict: self.inner.on_evict.clone(),
-                evictions: AtomicU64::new(self.inner.evictions.load(Ordering::Relaxed)),
             }),
         }
     }
@@ -278,16 +283,18 @@ where
     pub fn metrics(&self) -> CacheMetrics {
         let mut hits = 0u64;
         let mut misses = 0u64;
+        let mut evictions = 0u64;
         let mut size = 0usize;
         for shard in self.inner.shards.iter() {
             hits += shard.hits.load(Ordering::Relaxed);
             misses += shard.misses.load(Ordering::Relaxed);
+            evictions += shard.evictions.load(Ordering::Relaxed);
             size += shard.lock.read().len();
         }
         CacheMetrics {
             hits: Some(hits),
             misses: Some(misses),
-            evictions: Some(self.inner.evictions.load(Ordering::Relaxed)),
+            evictions: Some(evictions),
             entry_count: Some(size),
             capacity: None,
         }
@@ -336,10 +343,22 @@ where
     /// (`metrics().evictions`) whether or not an `on_evict` callback is configured; the callback
     /// fires only when one is set.
     pub fn cache_clear_with_on_evict(&self) {
+        if self.inner.on_evict.is_none() {
+            for shard in self.inner.shards.iter() {
+                let mut guard = shard.lock.write();
+                let n = guard.len();
+                guard.clear();
+                drop(guard);
+                if n > 0 {
+                    shard.evictions.fetch_add(n as u64, Ordering::Relaxed);
+                }
+            }
+            return;
+        }
         for shard in self.inner.shards.iter() {
             let removed: Vec<(K, V)> = shard.lock.write().drain().collect();
             if !removed.is_empty() {
-                self.inner
+                shard
                     .evictions
                     .fetch_add(removed.len() as u64, Ordering::Relaxed);
                 if let Some(on_evict) = &self.inner.on_evict {
@@ -359,26 +378,34 @@ where
         K: Clone,
     {
         let mut total = 0;
-        for shard in self.inner.shards.iter() {
-            let removed = {
+        if self.inner.on_evict.is_none() {
+            // No callback: nothing needs the removed keys/values, so avoid cloning any
+            // key and skip building a `Vec` entirely — `retain` plus a length delta.
+            for shard in self.inner.shards.iter() {
                 let mut guard = shard.lock.write();
-                let expired_keys: Vec<K> = guard
-                    .iter()
-                    .filter(|(_, v)| v.is_expired())
-                    .map(|(k, _)| k.clone())
-                    .collect();
-                let mut removed = Vec::new();
-                for k in expired_keys {
-                    if let Some((key, v)) = guard.remove_entry(&k) {
-                        removed.push((key, v));
-                    }
+                let before = guard.len();
+                guard.retain(|_, v| !v.is_expired());
+                let removed = before - guard.len();
+                drop(guard);
+                if removed > 0 {
+                    shard.evictions.fetch_add(removed as u64, Ordering::Relaxed);
+                    total += removed;
                 }
-                removed
+            }
+            return total;
+        }
+        for shard in self.inner.shards.iter() {
+            // Single-pass sweep: `extract_if` removes matching entries in place without
+            // cloning keys or re-probing the map. Collect under the write lock, fire
+            // callbacks after releasing it.
+            let removed: Vec<(K, V)> = {
+                let mut guard = shard.lock.write();
+                guard.extract_if(|_, v| v.is_expired()).collect()
             };
 
             total += removed.len();
             if !removed.is_empty() {
-                self.inner
+                shard
                     .evictions
                     .fetch_add(removed.len() as u64, Ordering::Relaxed);
                 if let Some(on_evict) = &self.inner.on_evict {
@@ -422,7 +449,7 @@ where
                     .collect()
             };
             if !removed.is_empty() {
-                self.inner
+                shard
                     .evictions
                     .fetch_add(removed.len() as u64, Ordering::Relaxed);
                 if let Some(on_evict) = &self.inner.on_evict {
@@ -468,7 +495,13 @@ where
     }
 
     fn cache_evictions(&self) -> Option<u64> {
-        Some(self.inner.evictions.load(Ordering::Relaxed))
+        Some(
+            self.inner
+                .shards
+                .iter()
+                .map(|s| s.evictions.load(Ordering::Relaxed))
+                .sum(),
+        )
     }
 }
 
@@ -490,6 +523,7 @@ where
                     (expired, val)
                 }
                 None => {
+                    drop(guard);
                     shard.misses.fetch_add(1, Ordering::Relaxed);
                     return Ok(None);
                 }
@@ -514,7 +548,7 @@ where
             let removed = guard.remove_entry(k);
             drop(guard);
             if let Some((stored_k, v)) = removed {
-                self.inner.evictions.fetch_add(1, Ordering::Relaxed);
+                shard.evictions.fetch_add(1, Ordering::Relaxed);
                 if let Some(on_evict) = &self.inner.on_evict {
                     on_evict(&stored_k, &v);
                 }
@@ -554,7 +588,7 @@ where
                 if let (Some(cb), Some(key)) = (&self.inner.on_evict, &key) {
                     cb(key, &old_v);
                 }
-                self.inner.evictions.fetch_add(1, Ordering::Relaxed);
+                shard.evictions.fetch_add(1, Ordering::Relaxed);
                 Ok(None)
             }
             Some((_, old_v, false)) => Ok(Some(old_v)),
@@ -570,7 +604,7 @@ where
         let shard = self.shard_of(k);
         let removed = shard.lock.write().remove_entry(k);
         if let Some((stored_k, v)) = removed {
-            self.inner.evictions.fetch_add(1, Ordering::Relaxed);
+            shard.evictions.fetch_add(1, Ordering::Relaxed);
             if let Some(on_evict) = &self.inner.on_evict {
                 on_evict(&stored_k, &v);
             }
@@ -591,7 +625,7 @@ where
         let shard = self.shard_of(k);
         let removed = shard.lock.write().remove_entry(k);
         if let Some((ref stored_k, ref v)) = removed {
-            self.inner.evictions.fetch_add(1, Ordering::Relaxed);
+            shard.evictions.fetch_add(1, Ordering::Relaxed);
             if let Some(on_evict) = &self.inner.on_evict {
                 on_evict(stored_k, v);
             }
@@ -613,8 +647,8 @@ where
         for shard in self.inner.shards.iter() {
             shard.hits.store(0, Ordering::Relaxed);
             shard.misses.store(0, Ordering::Relaxed);
+            shard.evictions.store(0, Ordering::Relaxed);
         }
-        self.inner.evictions.store(0, Ordering::Relaxed);
         Ok(())
     }
 
@@ -875,7 +909,6 @@ impl<K, V, H> ShardedExpiringCacheBuilder<K, V, H> {
                     .hasher
                     .expect("hasher is always initialized via Default or .hasher()"),
                 on_evict: self.on_evict,
-                evictions: AtomicU64::new(0),
             }),
         })
     }
@@ -1965,6 +1998,296 @@ mod tests {
         );
     }
 
+    // --- Per-shard evictions counter aggregation (internal-only refactor coverage) ---
+
+    #[test]
+    fn evictions_aggregate_across_multiple_shards_via_metrics_and_cache_evictions() {
+        // Force many shards so evictions land on distinct per-shard counters, then
+        // confirm both metrics().evictions and the trait-level cache_evictions()
+        // sum every shard exactly (no double counting, no dropped counts).
+        let c = ShardedExpiringCacheBase::<u32, Val>::builder()
+            .shards(8)
+            .build()
+            .unwrap();
+        for i in 0..64u32 {
+            SyncConcurrentCached::cache_set(
+                &c,
+                i,
+                Val {
+                    v: i,
+                    expired: false,
+                },
+            )
+            .expect("insert must succeed");
+        }
+        // Remove every entry — cache_remove increments the per-shard evictions
+        // counter for whichever shard the key hashes into.
+        for i in 0..64u32 {
+            SyncConcurrentCached::cache_remove(&c, &i).expect("remove must succeed");
+        }
+        assert_eq!(
+            c.metrics().evictions,
+            Some(64),
+            "metrics().evictions must sum every shard's counter"
+        );
+        assert_eq!(
+            ConcurrentCacheBase::cache_evictions(&c),
+            Some(64),
+            "cache_evictions() must sum every shard's counter"
+        );
+        // Sanity: with 8 shards and 64 distinct keys, more than one shard must have
+        // actually recorded an eviction (otherwise this test would pass trivially
+        // even if only shard 0's counter were summed).
+        let nonzero_shards = c
+            .inner
+            .shards
+            .iter()
+            .filter(|s| s.evictions.load(Ordering::Relaxed) > 0)
+            .count();
+        assert!(
+            nonzero_shards > 1,
+            "evictions must be spread across multiple shards for this to be a meaningful test"
+        );
+    }
+
+    #[test]
+    fn evictions_aggregate_correctly_after_deep_clone() {
+        // deep_clone must carry each shard's evictions counter into the corresponding
+        // cloned shard so the aggregate reported by the clone matches the source.
+        let c = ShardedExpiringCacheBase::<u32, Val>::builder()
+            .shards(8)
+            .build()
+            .unwrap();
+        for i in 0..64u32 {
+            SyncConcurrentCached::cache_set(
+                &c,
+                i,
+                Val {
+                    v: i,
+                    expired: false,
+                },
+            )
+            .expect("insert must succeed");
+        }
+        // Evict half of them (odd keys) so several shards record nonzero evictions.
+        for i in (0..64u32).step_by(2) {
+            SyncConcurrentCached::cache_remove(&c, &i).expect("remove must succeed");
+        }
+        let before = c.metrics().evictions.unwrap();
+        assert_eq!(before, 32);
+
+        let clone = c.deep_clone();
+        assert_eq!(
+            clone.metrics().evictions,
+            Some(32),
+            "deep_clone must carry the summed evictions count through unchanged"
+        );
+        // Per-shard carry-over: every shard's evictions counter in the clone must match
+        // the corresponding source shard, not just the aggregate.
+        for (src, cloned) in c.inner.shards.iter().zip(clone.inner.shards.iter()) {
+            assert_eq!(
+                src.evictions.load(Ordering::Relaxed),
+                cloned.evictions.load(Ordering::Relaxed),
+                "deep_clone must carry each shard's evictions counter individually"
+            );
+        }
+
+        // The clone and the source must be independent from here on.
+        SyncConcurrentCached::cache_remove(&clone, &1u32).expect("remove must succeed");
+        assert_eq!(
+            clone.metrics().evictions,
+            Some(33),
+            "post-clone evictions on the clone must not affect the source"
+        );
+        assert_eq!(
+            c.metrics().evictions,
+            Some(32),
+            "post-clone evictions on the clone must not leak back to the source"
+        );
+    }
+
+    // --- One-pass evict() coverage ---
+
+    #[test]
+    fn evict_with_callback_fires_exactly_once_per_removed_entry_with_correct_pairs() {
+        use std::sync::Mutex;
+
+        let seen: Arc<Mutex<Vec<(u32, u32)>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen2 = seen.clone();
+        let c = ShardedExpiringCacheBase::<u32, Val>::builder()
+            .shards(4)
+            .on_evict(move |k, v| {
+                seen2.lock().unwrap().push((*k, v.v));
+            })
+            .build()
+            .unwrap();
+
+        // Live entries that must survive the sweep.
+        for i in 0..10u32 {
+            SyncConcurrentCached::cache_set(
+                &c,
+                i,
+                Val {
+                    v: i * 100,
+                    expired: false,
+                },
+            )
+            .expect("insert must succeed");
+        }
+        // Expired entries that must be swept, with distinguishable values.
+        for i in 10..20u32 {
+            SyncConcurrentCached::cache_set(
+                &c,
+                i,
+                Val {
+                    v: i * 100,
+                    expired: true,
+                },
+            )
+            .expect("insert must succeed");
+        }
+
+        let removed_count = c.evict();
+        assert_eq!(removed_count, 10, "evict must report exactly 10 removed");
+        assert_eq!(
+            c.len(),
+            10,
+            "only the 10 expired entries must have been removed"
+        );
+
+        let mut got = seen.lock().unwrap().clone();
+        got.sort_unstable();
+        let mut expected: Vec<(u32, u32)> = (10..20u32).map(|i| (i, i * 100)).collect();
+        expected.sort_unstable();
+        assert_eq!(
+            got, expected,
+            "on_evict must fire exactly once per removed entry with the correct (k, v) pair"
+        );
+
+        // Live entries must all still be retrievable.
+        for i in 0..10u32 {
+            assert_eq!(
+                SyncConcurrentCached::cache_get(&c, &i)
+                    .expect("cache_get must succeed")
+                    .map(|v| v.v),
+                Some(i * 100),
+                "live entry {i} must survive evict()"
+            );
+        }
+
+        // A second evict() call finds nothing left to remove.
+        assert_eq!(c.evict(), 0, "a second evict() call must be a no-op");
+        assert_eq!(seen.lock().unwrap().len(), 10, "no further callbacks fire");
+    }
+
+    #[test]
+    fn evict_without_callback_returns_correct_count_and_removes_entries() {
+        // No on_evict configured: the single-pass retain+len-delta branch must still
+        // return the correct count, physically remove the expired entries, and
+        // increment the per-shard evictions counters aggregated via metrics().
+        let c = ShardedExpiringCacheBase::<u32, Val>::builder()
+            .shards(4)
+            .build()
+            .unwrap();
+        for i in 0..10u32 {
+            SyncConcurrentCached::cache_set(
+                &c,
+                i,
+                Val {
+                    v: i,
+                    expired: false,
+                },
+            )
+            .expect("insert must succeed");
+        }
+        for i in 10..25u32 {
+            SyncConcurrentCached::cache_set(
+                &c,
+                i,
+                Val {
+                    v: i,
+                    expired: true,
+                },
+            )
+            .expect("insert must succeed");
+        }
+        assert_eq!(c.len(), 25);
+
+        let before_evictions = c.metrics().evictions.unwrap();
+        let removed_count = c.evict();
+        assert_eq!(
+            removed_count, 15,
+            "evict must report exactly the 15 expired entries removed"
+        );
+        assert_eq!(
+            c.len(),
+            10,
+            "expired entries must be physically removed from the map"
+        );
+        assert_eq!(
+            c.metrics().evictions.unwrap() - before_evictions,
+            15,
+            "evictions must be counted through the no-callback branch too"
+        );
+
+        for i in 0..10u32 {
+            assert!(
+                SyncConcurrentCached::cache_get(&c, &i)
+                    .expect("cache_get must succeed")
+                    .is_some(),
+                "live entry {i} must survive evict() with no callback"
+            );
+        }
+
+        assert_eq!(
+            c.evict(),
+            0,
+            "a second evict() call with no callback must be a no-op"
+        );
+    }
+
+    // --- cache_clear_with_on_evict early-return (no-callback) path ---
+
+    #[test]
+    fn cache_clear_with_on_evict_no_callback_counts_via_early_return_across_shards() {
+        // Exercises the item-3 early-return branch across multiple shards, confirming
+        // it still counts every removed entry as an eviction (via the per-shard
+        // counters summed in metrics()/cache_evictions()) without ever building a
+        // Vec of the removed entries.
+        let c = ShardedExpiringCacheBase::<u32, Val>::builder()
+            .shards(8)
+            .build()
+            .unwrap();
+        for i in 0..40u32 {
+            SyncConcurrentCached::cache_set(
+                &c,
+                i,
+                Val {
+                    v: i,
+                    expired: false,
+                },
+            )
+            .expect("insert must succeed");
+        }
+        let before = c.metrics().evictions.unwrap();
+        c.cache_clear_with_on_evict();
+        assert_eq!(
+            c.len(),
+            0,
+            "cache must be empty after the early-return path"
+        );
+        assert_eq!(
+            c.metrics().evictions.unwrap() - before,
+            40,
+            "every removed entry must be counted even via the no-callback early return"
+        );
+        assert_eq!(
+            ConcurrentCacheBase::cache_evictions(&c),
+            Some(40),
+            "cache_evictions() must reflect the early-return path's counts too"
+        );
+    }
+
     #[test]
     fn inherent_and_trait_methods_coexist_via_fully_qualified_path() {
         fn use_trait<C>(cache: &C, k: u32, v: Val)
@@ -1983,6 +2306,460 @@ mod tests {
                 v: 42,
                 expired: false,
             },
+        );
+    }
+
+    // --- Certification: adversarial coverage of the per-shard eviction counter rewrite ---
+    //
+    // The rewrite removed `ExpiringInner.evictions: AtomicU64` in favor of one counter per
+    // shard, and turned `evict()` into a single-pass sweep. These tests approach that from
+    // the outside: per-shard placement (not just the aggregate), the two `evict` branches
+    // agreeing exactly, `deep_clone` after a mix of eviction paths, and concurrent
+    // evict()/cache_remove()/cache_set() hitting many shards at once without losing or
+    // double-counting an eviction.
+
+    /// Raw per-shard eviction counters, in shard order.
+    fn shard_eviction_counters<K, V, H>(c: &ShardedExpiringCacheBase<K, V, H>) -> Vec<u64> {
+        c.inner
+            .shards
+            .iter()
+            .map(|s| s.evictions.load(Ordering::Relaxed))
+            .collect()
+    }
+
+    /// Index of the shard that owns `k`.
+    fn owning_shard<K, V, H: ShardHasher<K>>(c: &ShardedExpiringCacheBase<K, V, H>, k: &K) -> usize {
+        shard_index(c.inner.hasher.shard_hash(k), c.inner.shard_mask)
+    }
+
+    /// Deterministic shard placement for cross-cache comparisons. `DefaultShardHasher` is
+    /// randomly seeded per instance, so two independently built caches would scatter the
+    /// same keys onto different shards and a shard-for-shard comparison between them would
+    /// be meaningless.
+    #[derive(Clone)]
+    struct FixedShardHasher;
+
+    impl ShardHasher<u32> for FixedShardHasher {
+        fn shard_hash(&self, key: &u32) -> u64 {
+            u64::from(*key).wrapping_mul(0x9e37_79b9_7f4a_7c15)
+        }
+    }
+
+    /// Every stored entry as `(key, value, expired)`, sorted, for a full cross-cache
+    /// state comparison.
+    fn entry_snapshot<H: ShardHasher<u32>>(c: &ShardedExpiringCacheBase<u32, Val, H>) -> Vec<(u32, u32, bool)> {
+        let mut out: Vec<(u32, u32, bool)> = Vec::new();
+        for shard in c.inner.shards.iter() {
+            let guard = shard.lock.read();
+            for (k, v) in guard.iter() {
+                out.push((*k, v.v, v.expired));
+            }
+        }
+        out.sort_unstable();
+        out
+    }
+
+    #[test]
+    fn evict_is_callable_through_both_entry_points_under_the_key_clone_bound() {
+        // The one-pass rewrite no longer clones keys internally, but the public `K: Clone`
+        // bound on the inherent `evict` and on the `ConcurrentCacheEvict` impl was
+        // deliberately kept (relaxing a public bound was explicitly out of scope for this
+        // refactor). A passing test cannot prove a bound is still *required* (that needs a
+        // compile-fail harness), so this pins the callable surface: both entry points
+        // resolve for a `K: Clone` key and agree on the swept count.
+        fn evict_both_ways<K: Clone + Hash + Eq, V: Clone + Expires>(
+            c: &ShardedExpiringCache<K, V>,
+        ) -> usize {
+            let via_inherent = ShardedExpiringCacheBase::evict(c);
+            let via_trait = ConcurrentCacheEvict::evict(c);
+            via_inherent + via_trait
+        }
+        let c = ShardedExpiringCache::<u32, Val>::builder().build().unwrap();
+        SyncConcurrentCached::cache_set(
+            &c,
+            1,
+            Val {
+                v: 10,
+                expired: false,
+            },
+        )
+        .unwrap();
+        assert_eq!(evict_both_ways(&c), 0, "nothing is expired");
+        assert_eq!(c.len(), 1);
+    }
+
+    #[test]
+    fn cache_set_displaced_expired_entry_counts_land_on_the_owning_shard() {
+        // Gap: the displaced-expired-entry branch of cache_set was only exercised on a
+        // single default-shard-count cache, asserting only the aggregate. Here 32 distinct
+        // keys spread over 8 shards each get an expired entry displaced by cache_set, and
+        // every shard's *own* counter (not just the sum) must move by exactly the right
+        // amount -- a bug that bumped the wrong shard's counter would still pass an
+        // aggregate-only assertion.
+        let c = ShardedExpiringCacheBase::<u32, Val>::builder()
+            .shards(8)
+            .build()
+            .unwrap();
+        let keys: Vec<u32> = (0..32u32).collect();
+        for &k in &keys {
+            SyncConcurrentCached::cache_set(
+                &c,
+                k,
+                Val {
+                    v: k,
+                    expired: true,
+                },
+            )
+            .unwrap();
+        }
+        let mut expected = vec![0u64; c.shards()];
+        for &k in &keys {
+            let idx = owning_shard(&c, &k);
+            let result = SyncConcurrentCached::cache_set(
+                &c,
+                k,
+                Val {
+                    v: k + 1000,
+                    expired: false,
+                },
+            )
+            .unwrap();
+            assert_eq!(
+                result.map(|v| v.v),
+                None,
+                "displacing an expired entry must return None for key {k}"
+            );
+            expected[idx] += 1;
+        }
+        assert_eq!(
+            shard_eviction_counters(&c),
+            expected,
+            "cache_set displacing an expired entry must count on the key's own shard"
+        );
+        assert!(
+            expected.iter().filter(|&&n| n > 0).count() >= 2,
+            "the 32 keys must spread over more than one shard: {expected:?}"
+        );
+        assert_eq!(c.metrics().evictions, Some(expected.iter().sum::<u64>()));
+    }
+
+    #[test]
+    fn evict_no_callback_zero_expired_shard_counter_stays_exactly_zero() {
+        // Gap: the guards are `if removed > 0` / `if !removed.is_empty()`, but nothing
+        // asserted a specific *untouched* shard's counter stays exactly 0 while a sibling
+        // shard's counter moves -- an aggregate-only assertion cannot catch a spurious
+        // per-shard bump. FixedShardHasher pins two disjoint 4-key buckets, one per shard,
+        // so shard 1 (all-live) is guaranteed to see zero evictions.
+        let c = ShardedExpiringCacheBase::<u32, Val>::builder()
+            .shards(2)
+            .hasher(FixedShardHasher)
+            .build()
+            .unwrap();
+        let mut buckets: Vec<Vec<u32>> = vec![Vec::new(); 2];
+        for k in 0..256u32 {
+            let idx = owning_shard(&c, &k);
+            if buckets[idx].len() < 4 {
+                buckets[idx].push(k);
+            }
+        }
+        assert!(
+            buckets.iter().all(|b| b.len() == 4),
+            "both shards must receive keys: {buckets:?}"
+        );
+        for &k in &buckets[0] {
+            SyncConcurrentCached::cache_set(
+                &c,
+                k,
+                Val {
+                    v: k,
+                    expired: true,
+                },
+            )
+            .unwrap();
+        }
+        for &k in &buckets[1] {
+            SyncConcurrentCached::cache_set(
+                &c,
+                k,
+                Val {
+                    v: k,
+                    expired: false,
+                },
+            )
+            .unwrap();
+        }
+
+        assert_eq!(c.evict(), 4, "only shard 0's entries are expired");
+        assert_eq!(
+            shard_eviction_counters(&c),
+            vec![4, 0],
+            "the emptied shard counts four, the untouched shard's counter must be exactly zero"
+        );
+        assert_eq!(
+            c.shard_sizes(),
+            vec![0, 4],
+            "the all-expired shard is emptied, the none-expired shard is untouched"
+        );
+    }
+
+    #[test]
+    fn evict_callback_and_no_callback_branches_agree_exactly() {
+        // Gap: assert the callback (extract_if) and no-callback (retain + length-delta)
+        // evict() branches return identical counts and leave identical state for the same
+        // input, including a multi-shard mix where some shards have nothing expired.
+        let fired: Arc<std::sync::Mutex<Vec<(u32, u32)>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let fired2 = fired.clone();
+        let with_cb = ShardedExpiringCacheBase::<u32, Val>::builder()
+            .shards(4)
+            .hasher(FixedShardHasher)
+            .on_evict(move |k: &u32, v: &Val| {
+                fired2.lock().expect("callback lock").push((*k, v.v));
+            })
+            .build()
+            .unwrap();
+        let no_cb = ShardedExpiringCacheBase::<u32, Val>::builder()
+            .shards(4)
+            .hasher(FixedShardHasher)
+            .build()
+            .unwrap();
+
+        // Keys 0..8 expired, 8..24 live -- spread across all 4 shards via FixedShardHasher,
+        // with at least one shard ending up with nothing expired.
+        for c in [&with_cb, &no_cb] {
+            for i in 0..8u32 {
+                SyncConcurrentCached::cache_set(
+                    c,
+                    i,
+                    Val {
+                        v: i * 10,
+                        expired: true,
+                    },
+                )
+                .unwrap();
+            }
+            for i in 8..24u32 {
+                SyncConcurrentCached::cache_set(
+                    c,
+                    i,
+                    Val {
+                        v: i * 10,
+                        expired: false,
+                    },
+                )
+                .unwrap();
+            }
+        }
+        assert_eq!(
+            entry_snapshot(&with_cb),
+            entry_snapshot(&no_cb),
+            "the two caches must start from identical state"
+        );
+
+        let removed_cb = with_cb.evict();
+        let removed_plain = no_cb.evict();
+        assert_eq!(removed_cb, 8, "only the eight backdated entries are expired");
+        assert_eq!(
+            removed_plain, removed_cb,
+            "the retain + length-delta branch must return the same count as the extract_if branch"
+        );
+        assert_eq!(
+            entry_snapshot(&with_cb),
+            entry_snapshot(&no_cb),
+            "both branches must leave identical state"
+        );
+        assert_eq!(
+            shard_eviction_counters(&with_cb),
+            shard_eviction_counters(&no_cb),
+            "both branches must move the same per-shard counters"
+        );
+        let mut fired_keys = fired.lock().expect("callback lock").clone();
+        fired_keys.sort_unstable();
+        assert_eq!(
+            fired_keys,
+            (0..8u32).map(|i| (i, i * 10)).collect::<Vec<_>>(),
+            "on_evict must fire once per expired entry"
+        );
+
+        // A second, zero-removal sweep: both branches at their empty extreme, no counter
+        // moves for either.
+        let counters = shard_eviction_counters(&with_cb);
+        assert_eq!(with_cb.evict(), 0, "nothing is left to expire");
+        assert_eq!(no_cb.evict(), 0, "nothing is left to expire");
+        assert_eq!(shard_eviction_counters(&with_cb), counters);
+        assert_eq!(shard_eviction_counters(&no_cb), counters);
+        assert_eq!(
+            fired.lock().expect("callback lock").len(),
+            8,
+            "a no-op sweep must not fire on_evict"
+        );
+    }
+
+    #[test]
+    fn deep_clone_carries_per_shard_counts_after_a_mix_of_evict_and_cache_remove() {
+        // Gap: the author only tested deep_clone after cache_remove-only accrual. Mix
+        // evict() (sweeping a third of the entries) with cache_remove_entry (removing half
+        // of what's left) before cloning, and confirm every shard's counter -- not just the
+        // aggregate -- carries over exactly, and that the clone is independent afterward.
+        let c = ShardedExpiringCacheBase::<u32, Val>::builder()
+            .shards(8)
+            .build()
+            .unwrap();
+        for i in 0..64u32 {
+            SyncConcurrentCached::cache_set(
+                &c,
+                i,
+                Val {
+                    v: i,
+                    expired: i % 3 == 0,
+                },
+            )
+            .expect("insert must succeed");
+        }
+        let via_evict = u64::try_from(c.evict()).unwrap();
+        assert!(via_evict > 0, "some entries must have been expired");
+
+        let mut removed_via_remove = 0u64;
+        for i in (1..64u32).step_by(2) {
+            if SyncConcurrentCached::cache_remove_entry(&c, &i)
+                .expect("cache_remove_entry must succeed")
+                .is_some()
+            {
+                removed_via_remove += 1;
+            }
+        }
+        let expected_total = via_evict + removed_via_remove;
+        let source_counters = shard_eviction_counters(&c);
+        assert_eq!(source_counters.iter().sum::<u64>(), expected_total);
+        assert_eq!(c.metrics().evictions, Some(expected_total));
+
+        let clone = c.deep_clone();
+        assert_eq!(
+            shard_eviction_counters(&clone),
+            source_counters,
+            "deep_clone must carry each shard's counter shard-for-shard after a mix of \
+             evict() and cache_remove()"
+        );
+        assert_eq!(clone.metrics().evictions, Some(expected_total));
+        assert_eq!(clone.len(), c.len());
+
+        // The copy is independent: a further eviction on the clone does not move the source.
+        SyncConcurrentCached::cache_remove(&clone, &2u32).expect("key must still be present");
+        assert_eq!(clone.metrics().evictions, Some(expected_total + 1));
+        assert_eq!(c.metrics().evictions, Some(expected_total));
+    }
+
+    #[test]
+    fn concurrent_evict_cache_remove_and_cache_set_do_not_lose_or_double_count_evictions() {
+        // Gap: nothing exercised evict() / cache_remove() / cache_set() hitting different
+        // shards simultaneously. Per-shard relaxed loads mean a *mid-flight* aggregate can
+        // be torn, so the only things asserted here are conservation identities checked
+        // after every worker has joined, not timing-sensitive exact interleavings:
+        // (1) on_evict never fires twice for the same stored value (no double-count/double-
+        // fire), (2) the total fire count exactly matches the total eviction-counter
+        // movement, (3) the raw per-shard sum agrees with metrics(), and (4) no shard is
+        // left in a torn state (shard_sizes sums to len()).
+        use std::collections::HashSet;
+        use std::sync::{Barrier, Mutex};
+
+        const SHARDS: usize = 8;
+        const KEYS: u32 = 32;
+        const ROUNDS: u32 = 200;
+        const WRITERS: usize = 4;
+        const REMOVERS: usize = 2;
+
+        let next_id = Arc::new(AtomicU64::new(0));
+        let fired_ids: Arc<Mutex<HashSet<u64>>> = Arc::new(Mutex::new(HashSet::new()));
+        let fired_count = Arc::new(AtomicU64::new(0));
+        let fired_ids2 = fired_ids.clone();
+        let fired_count2 = fired_count.clone();
+        let c = ShardedExpiringCacheBase::<u32, Val>::builder()
+            .shards(SHARDS)
+            .on_evict(move |_k: &u32, v: &Val| {
+                let mut seen = fired_ids2.lock().expect("fired recorder poisoned");
+                assert!(
+                    seen.insert(u64::from(v.v)),
+                    "on_evict fired twice for the same stored value {} -- double-fire under \
+                     concurrent evict/cache_remove/cache_set",
+                    v.v
+                );
+                fired_count2.fetch_add(1, Ordering::Relaxed);
+            })
+            .build()
+            .unwrap();
+        let evictions_before = c.metrics().evictions.unwrap();
+
+        let gate = Arc::new(Barrier::new(WRITERS + REMOVERS + 1));
+        let mut handles = Vec::new();
+
+        for _ in 0..WRITERS {
+            let c = c.clone();
+            let gate = gate.clone();
+            let next_id = next_id.clone();
+            handles.push(std::thread::spawn(move || {
+                gate.wait();
+                for r in 0..ROUNDS {
+                    let k = r % KEYS;
+                    // Unique id per stored value lets on_evict distinguish "this exact
+                    // stored entry" from "a same-key entry that replaced it".
+                    let id = u32::try_from(next_id.fetch_add(1, Ordering::Relaxed) % 1_000_000)
+                        .unwrap();
+                    // A third of inserts are born already-expired, so cache_set's
+                    // displaced-expired-entry branch races cache_remove and evict() for
+                    // the very same entries.
+                    let expired = id % 3 == 0;
+                    let _ =
+                        SyncConcurrentCached::cache_set(&c, k, Val { v: id, expired }).unwrap();
+                }
+            }));
+        }
+        for _ in 0..REMOVERS {
+            let c = c.clone();
+            let gate = gate.clone();
+            handles.push(std::thread::spawn(move || {
+                gate.wait();
+                for r in 0..ROUNDS {
+                    let k = r % KEYS;
+                    let _ = SyncConcurrentCached::cache_remove(&c, &k).unwrap();
+                }
+            }));
+        }
+        {
+            let c = c.clone();
+            let gate = gate.clone();
+            handles.push(std::thread::spawn(move || {
+                gate.wait();
+                for _ in 0..ROUNDS {
+                    let _ = c.evict();
+                }
+            }));
+        }
+
+        for h in handles {
+            h.join().expect("worker thread must not panic");
+        }
+
+        let fired = fired_count.load(Ordering::Relaxed);
+        let evictions_after = c.metrics().evictions.unwrap();
+        assert_eq!(
+            fired,
+            evictions_after - evictions_before,
+            "on_evict must fire exactly once per counted eviction across the whole race, no \
+             matter how evict()/cache_remove()/cache_set() interleaved"
+        );
+        assert_eq!(
+            shard_eviction_counters(&c).iter().sum::<u64>(),
+            evictions_after,
+            "the raw per-shard counters must sum to the same total metrics() reports"
+        );
+        assert_eq!(
+            ConcurrentCacheBase::cache_evictions(&c),
+            Some(evictions_after),
+            "cache_evictions() must agree with metrics() after the race"
+        );
+        assert_eq!(
+            c.shard_sizes().iter().sum::<usize>(),
+            c.len(),
+            "post-race shard sizes must still sum to the total length (no torn shard)"
         );
     }
 }

--- a/src/stores/sharded/expiring_lru.rs
+++ b/src/stores/sharded/expiring_lru.rs
@@ -21,13 +21,46 @@ use crate::stores::{BuildError, LruCache};
 
 type OnEvict<K, V> = Arc<dyn Fn(&K, &V) + Send + Sync>;
 
+/// Insert or replace an entry in a shard's inner [`LruCache`], returning the **stored** `(K, V)`
+/// pair of the displaced entry (or `None` for a fresh insertion), and leaving the entry at the
+/// most-recently-used position either way.
+///
+/// This replaces the `pop_raw(&k)` + `cache_set(k, v)` pair that `cache_set` used purely to
+/// recover the owned stored key for `on_evict`: that pair hashed and probed the shard twice and
+/// churned the LRU slab (free the slot, then push a fresh one).
+///
+/// # Recency trap
+///
+/// The obvious one-lookup replacement, `LruCache::cache_set_returning_entry`, replaces in place
+/// via `order.set` and does **NOT** promote to MRU, whereas the remove-then-insert it replaces
+/// *does* (the re-insert goes through `push_front`). Dropping the promotion would silently
+/// change which entry a later capacity eviction picks. `get_or_set_with_if` with a never-valid
+/// predicate is exactly "`order.set` + `order.move_to_front`" for an existing key (and
+/// `push_front` + capacity check for a new one) in a single hash + probe, so the promotion is
+/// preserved. Pinned by `cache_set_with_on_evict_promotes_overwritten_entry_to_mru`.
+///
+/// The caller must have disabled hit/miss tracking on the inner cache (every sharded store
+/// does): `get_or_set_with_if` would otherwise record a miss for each overwrite.
+fn set_entry_promoting<K, V>(cache: &mut LruCache<K, V>, key: K, val: V) -> Option<(K, V)>
+where
+    K: Hash + Eq + Clone,
+{
+    debug_assert!(
+        !cache.track_hit_miss,
+        "set_entry_promoting requires hit/miss tracking to be disabled on the inner cache"
+    );
+    // `|_| false` (never valid) forces the replace arm for an existing key; that arm's
+    // `old_val` is the stored `(K, V)` pair.
+    let (_, _, displaced, _) = cache.get_or_set_with_if(key, || val, |_| false);
+    displaced
+}
+
 #[allow(clippy::type_complexity)]
 struct ExpiringLruInner<K, V, H> {
     shards: Box<[CachePadded<Shard<LruCache<K, V>>>]>,
     shard_mask: usize,
     hasher: H,
     on_evict: Option<OnEvict<K, V>>,
-    evictions: AtomicU64,
     /// Total logical capacity (sum of per-shard caps). Stored as `AtomicUsize` so
     /// [`set_max_size`](ShardedExpiringLruCacheBase::set_max_size) can update it from `&self`.
     total_capacity: AtomicUsize,
@@ -74,6 +107,27 @@ impl<K, V, H> Clone for ShardedExpiringLruCacheBase<K, V, H> {
     }
 }
 
+impl<K, V, H> ShardedExpiringLruCacheBase<K, V, H> {
+    /// Sum of the per-shard counters for evictions **not** driven by LRU capacity pressure:
+    /// expired entries dropped lazily on [`cache_get`](ConcurrentCached::cache_get) or swept by
+    /// [`evict`](ShardedExpiringLruCacheBase::evict), [`retain`](Self::retain), and
+    /// [`cache_clear_with_on_evict`](Self::cache_clear_with_on_evict).
+    ///
+    /// These live in [`Shard::evictions`], one atomic per shard (like `hits`/`misses`), rather
+    /// than in a single process-wide counter on `Arc<Inner>`: a thread bumping it has just held
+    /// that shard's lock, so the line is already owned exclusively and no cross-core traffic is
+    /// added. LRU **capacity** evictions (plus explicit removes, which are counted there for
+    /// historical reasons) remain in each shard's inner `LruCache::evictions`;
+    /// [`metrics`](Self::metrics) sums the two families.
+    fn non_capacity_evictions(&self) -> u64 {
+        self.inner
+            .shards
+            .iter()
+            .map(|s| s.evictions.load(Ordering::Relaxed))
+            .sum()
+    }
+}
+
 impl<K, V, H> std::fmt::Debug for ShardedExpiringLruCacheBase<K, V, H> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ShardedExpiringLruCache")
@@ -82,7 +136,9 @@ impl<K, V, H> std::fmt::Debug for ShardedExpiringLruCacheBase<K, V, H> {
                 "capacity",
                 &self.inner.total_capacity.load(Ordering::Relaxed),
             )
-            .field("evictions", &self.inner.evictions.load(Ordering::Relaxed))
+            // Same quantity as before the counter moved per-shard: the non-capacity
+            // eviction total (LRU capacity evictions live in the inner stores).
+            .field("evictions", &self.non_capacity_evictions())
             .finish_non_exhaustive()
     }
 }
@@ -157,12 +213,16 @@ impl<K: Clone + Hash + Eq, V: Clone + Expires, H: ShardHasher<K>>
                 let store_copy = guard.clone();
                 let hits = self.inner.shards[i].hits.load(Ordering::Relaxed);
                 let misses = self.inner.shards[i].misses.load(Ordering::Relaxed);
+                // Carry the shard's non-capacity eviction count across too (it used to live
+                // in a single process-wide counter that `deep_clone` copied wholesale), so
+                // the clone's `metrics().evictions` matches the source's.
+                let evictions = self.inner.shards[i].evictions.load(Ordering::Relaxed);
                 drop(guard);
                 let shard = Shard {
                     lock: parking_lot::RwLock::new(store_copy),
                     hits: AtomicU64::new(hits),
                     misses: AtomicU64::new(misses),
-                    evictions: AtomicU64::new(0),
+                    evictions: AtomicU64::new(evictions),
                 };
                 CachePadded(shard)
             })
@@ -174,7 +234,6 @@ impl<K: Clone + Hash + Eq, V: Clone + Expires, H: ShardHasher<K>>
                 shard_mask: self.inner.shard_mask,
                 hasher: self.inner.hasher.clone(),
                 on_evict: self.inner.on_evict.clone(),
-                evictions: AtomicU64::new(self.inner.evictions.load(Ordering::Relaxed)),
                 total_capacity: AtomicUsize::new(self.inner.total_capacity.load(Ordering::Relaxed)),
             }),
         }
@@ -291,10 +350,15 @@ where
         let mut hits = 0u64;
         let mut misses = 0u64;
         let mut inner_evictions = 0u64;
+        let mut non_capacity_evictions = 0u64;
         let mut size = 0usize;
         for shard in self.inner.shards.iter() {
             hits += shard.hits.load(Ordering::Relaxed);
             misses += shard.misses.load(Ordering::Relaxed);
+            // Per-shard non-capacity evictions (lazy expiry / evict / retain / clear); the
+            // inner `LruCache` counter below holds this shard's capacity evictions and its
+            // explicit removes. The two families are disjoint, so summing cannot double-count.
+            non_capacity_evictions += shard.evictions.load(Ordering::Relaxed);
             let guard = shard.lock.read();
             if let Some(e) = guard.cache_evictions() {
                 inner_evictions += e;
@@ -304,7 +368,7 @@ where
         CacheMetrics {
             hits: Some(hits),
             misses: Some(misses),
-            evictions: Some(inner_evictions + self.inner.evictions.load(Ordering::Relaxed)),
+            evictions: Some(inner_evictions + non_capacity_evictions),
             entry_count: Some(size),
             // Acquire, like `capacity()`: a caller that just resized on this thread sees
             // the new total here too, not a stale value alongside a fresh `capacity()`.
@@ -365,13 +429,11 @@ where
         for shard in self.inner.shards.iter() {
             let removed: Vec<(K, V)> = {
                 let mut guard = shard.lock.write();
-                let keys: Vec<K> = guard.iter().map(|(k, _)| k.clone()).collect();
-                let mut removed = Vec::with_capacity(keys.len());
-                for k in keys {
-                    if let Some(pair) = guard.pop_raw(&k) {
-                        removed.push(pair);
-                    }
-                }
+                // `drain_all` walks each shard's LRU chain once taking owned pairs in
+                // MRU -> LRU order -- the same order the old "clone every key, then
+                // `pop_raw` each one" drain fired in, but with zero key clones and zero
+                // re-hashing.
+                let removed = guard.drain_all();
                 if !removed.is_empty() {
                     guard
                         .evictions
@@ -425,7 +487,7 @@ where
                 removed
             };
             if !removed.is_empty() {
-                self.inner
+                shard
                     .evictions
                     .fetch_add(removed.len() as u64, Ordering::Relaxed);
                 if let Some(on_evict) = &self.inner.on_evict {
@@ -577,7 +639,7 @@ where
                 inner_evictions += e;
             }
         }
-        Some(inner_evictions + self.inner.evictions.load(Ordering::Relaxed))
+        Some(inner_evictions + self.non_capacity_evictions())
     }
 }
 
@@ -590,41 +652,42 @@ where
     fn cache_get(&self, k: &K) -> Result<Option<V>, Self::Error> {
         let shard = self.shard_of(k);
         let mut guard = shard.lock.write();
-        let expired = match guard.cache_peek(k) {
-            None => {
-                shard.misses.fetch_add(1, Ordering::Relaxed);
-                return Ok(None);
-            }
-            Some(v) => v.is_expired(),
-        };
-
-        if expired {
-            let removed = guard.pop_raw(k);
+        // The common case (a live hit) resolves in a SINGLE hash + probe: `get_if` promotes
+        // LRU recency only when the predicate reports the value live, so an expired entry is
+        // neither promoted nor removed here -- exactly the intent of the old peek-then-get
+        // pair, at half the lookups. `track_hit_miss` is disabled on the inner `LruCache`, so
+        // this probe touches no counter.
+        let val = guard.get_if(k, |v| !v.is_expired()).cloned();
+        if let Some(val) = val {
             drop(guard);
-            if let Some((ref key, ref val)) = removed {
-                // `pop_raw` removes the entry without bumping the inner LRU eviction counter,
-                // so track expired-on-access removals in the outer counter instead. Explicit
-                // removes via `cache_remove` bump the inner LRU counter (`guard.evictions`).
-                // Both paths feed into `metrics().evictions` via the combined sum in `metrics()`.
-                self.inner.evictions.fetch_add(1, Ordering::Relaxed);
-                if let Some(on_evict) = &self.inner.on_evict {
-                    on_evict(key, val);
-                }
-            }
-            shard.misses.fetch_add(1, Ordering::Relaxed);
-            Ok(None)
-        } else {
-            // Live hit — update LRU recency and extract value
-            let val = guard.cache_get(k).cloned();
             shard.hits.fetch_add(1, Ordering::Relaxed);
-            Ok(val)
+            return Ok(Some(val));
         }
+
+        // Not a live hit: either expired (still stored) or absent. `pop_raw` distinguishes
+        // them -- `Some` means it was expired and is now removed, `None` means absent. This
+        // costs the (rarer) miss path one extra probe to spare every hit one.
+        let removed = guard.pop_raw(k);
+        drop(guard);
+        if let Some((ref key, ref val)) = removed {
+            // `pop_raw` removes the entry without bumping the inner LRU eviction counter, so
+            // track expired-on-access removals in the shard's non-capacity counter instead.
+            // Explicit removes via `cache_remove` bump the inner LRU counter
+            // (`guard.evictions`). Both feed `metrics().evictions` via its combined sum.
+            shard.evictions.fetch_add(1, Ordering::Relaxed);
+            if let Some(on_evict) = &self.inner.on_evict {
+                on_evict(key, val);
+            }
+        }
+        shard.misses.fetch_add(1, Ordering::Relaxed);
+        Ok(None)
     }
 
     fn cache_set(&self, k: K, v: V) -> Result<Option<V>, Self::Error> {
         let shard = self.shard_of(&k);
-        // With a callback, pop-then-set (`pop_raw` is silent and yields the owned key) so
-        // on_evict can fire after the lock is released; otherwise a plain set. A displaced
+        // With a callback we need the *stored* key to hand to it, so the write goes through
+        // `set_entry_promoting` (one lookup, no LRU slot churn, and it restores the MRU
+        // promotion the old pop-then-set got for free); otherwise a plain set. A displaced
         // expired value is counted as an eviction under the lock (matching cache_remove) and
         // filtered from the return; a live displaced value is returned to the caller unchanged.
         // `is_expired()` is evaluated exactly once, while the write lock is still held, and the
@@ -634,9 +697,7 @@ where
         let old: Option<(Option<K>, V, bool)> = {
             let mut guard = shard.lock.write();
             let old = if self.inner.on_evict.is_some() {
-                let removed = guard.pop_raw(&k);
-                guard.cache_set(k, v);
-                removed.map(|(ok, ov)| {
+                set_entry_promoting(&mut guard, k, v).map(|(ok, ov)| {
                     let expired = ov.is_expired();
                     (Some(ok), ov, expired)
                 })
@@ -648,8 +709,8 @@ where
             };
             if matches!(&old, Some((_, _, true))) {
                 // `guard.evictions` is the inner LRU counter (unlike expired-on-access removals
-                // in `cache_get`, which use the outer `self.inner.evictions` because `pop_raw`
-                // bypasses the inner counter). Both feed the combined sum in `metrics()`.
+                // in `cache_get`, which use the shard's non-capacity counter because `pop_raw`
+                // bypasses the inner one). Both feed the combined sum in `metrics()`.
                 guard.evictions.fetch_add(1, Ordering::Relaxed);
             }
             old
@@ -729,10 +790,11 @@ where
         for shard in self.inner.shards.iter() {
             shard.hits.store(0, Ordering::Relaxed);
             shard.misses.store(0, Ordering::Relaxed);
+            // The shard's non-capacity eviction counter (lazy expiry / evict / retain / clear).
+            shard.evictions.store(0, Ordering::Relaxed);
             // Zero the per-shard inner store's metrics, including its LRU capacity-eviction counter.
             shard.lock.write().cache_reset_metrics();
         }
-        self.inner.evictions.store(0, Ordering::Relaxed);
         Ok(())
     }
 
@@ -842,7 +904,7 @@ where
 
             total += removed.len();
             if !removed.is_empty() {
-                self.inner
+                shard
                     .evictions
                     .fetch_add(removed.len() as u64, Ordering::Relaxed);
                 if let Some(on_evict) = &self.inner.on_evict {
@@ -1132,7 +1194,6 @@ impl<K, V, H> ShardedExpiringLruCacheBuilder<K, V, H> {
                     .hasher
                     .expect("hasher is always initialized via Default or .hasher()"),
                 on_evict: self.on_evict,
-                evictions: AtomicU64::new(0),
                 total_capacity: AtomicUsize::new(total_cap),
             }),
         })
@@ -2289,8 +2350,8 @@ mod tests {
     }
 
     /// Counter-wiring contract (the main correctness trap for this store): `retain` must
-    /// bump the outer `ExpiringLruInner::evictions` counter, NOT the inner `LruCache`'s own
-    /// capacity-eviction counter (`guard.evictions`).
+    /// bump the per-shard non-capacity eviction counter (`Shard::evictions`), NOT the inner
+    /// `LruCache`'s own capacity-eviction counter (`guard.evictions`).
     #[test]
     fn retain_wires_to_outer_evictions_not_inner_lru_counter() {
         let c = ShardedExpiringLruCacheBase::<u32, Val>::builder()
@@ -2314,7 +2375,7 @@ mod tests {
             .read()
             .evictions
             .load(Ordering::Relaxed);
-        let outer_before = c.inner.evictions.load(Ordering::Relaxed);
+        let outer_before = c.non_capacity_evictions();
 
         c.retain(|k, _| k % 2 == 0);
 
@@ -2323,7 +2384,7 @@ mod tests {
             .read()
             .evictions
             .load(Ordering::Relaxed);
-        let outer_after = c.inner.evictions.load(Ordering::Relaxed);
+        let outer_after = c.non_capacity_evictions();
 
         assert_eq!(
             inner_after, inner_before,
@@ -2332,11 +2393,429 @@ mod tests {
         assert_eq!(
             outer_after - outer_before,
             5,
-            "retain must count each removal via the outer evictions counter"
+            "retain must count each removal via the per-shard non-capacity counter"
         );
         assert_eq!(
             c.metrics().evictions.unwrap() - (inner_before + outer_before),
             5
         );
+    }
+
+    // --- single-lookup `cache_get`, per-shard eviction counters, and the recency trap ---
+
+    fn live(v: u32) -> Val {
+        Val { v, expired: false }
+    }
+
+    /// Raw per-shard non-capacity eviction counters, in shard order.
+    fn shard_eviction_counters<K, V, H>(c: &ShardedExpiringLruCacheBase<K, V, H>) -> Vec<u64> {
+        c.inner
+            .shards
+            .iter()
+            .map(|s| s.evictions.load(Ordering::Relaxed))
+            .collect()
+    }
+
+    /// Index of the shard that owns `k`.
+    fn owning_shard<K, V, H: ShardHasher<K>>(
+        c: &ShardedExpiringLruCacheBase<K, V, H>,
+        k: &K,
+    ) -> usize {
+        shard_index(c.inner.hasher.shard_hash(k), c.inner.shard_mask)
+    }
+
+    /// Keys of one shard in MRU -> LRU order.
+    fn shard_key_order<K: Clone + Hash + Eq, V: Clone, H>(
+        c: &ShardedExpiringLruCacheBase<K, V, H>,
+        shard: usize,
+    ) -> Vec<K> {
+        c.inner.shards[shard]
+            .lock
+            .read()
+            .iter_order_raw()
+            .into_iter()
+            .map(|(k, _)| k)
+            .collect()
+    }
+
+    /// `cache_get` resolves a live hit in a single hash + probe (`get_if`) and falls through to
+    /// `pop_raw` only when that probe fails. All three outcomes must keep their old semantics:
+    /// live hit -> value + hit; absent -> None + miss, nothing removed; expired -> None + miss,
+    /// entry removed, one eviction counted, `on_evict` fired with the stored key/value.
+    #[test]
+    fn cache_get_single_lookup_keeps_hit_miss_expired_and_absent_semantics() {
+        use std::sync::Mutex;
+        let seen: Arc<Mutex<Vec<(u32, u32)>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen2 = Arc::clone(&seen);
+        let c = ShardedExpiringLruCacheBase::<u32, Val>::builder()
+            .shards(1)
+            .max_size(8)
+            .on_evict(move |k: &u32, v: &Val| seen2.lock().unwrap().push((*k, v.v)))
+            .build()
+            .unwrap();
+
+        // Live hit.
+        SyncConcurrentCached::cache_set(&c, 1, live(10)).unwrap();
+        assert_eq!(
+            SyncConcurrentCached::cache_get(&c, &1)
+                .unwrap()
+                .map(|v| v.v),
+            Some(10)
+        );
+        assert_eq!(c.metrics().hits, Some(1));
+        assert_eq!(c.metrics().misses, Some(0));
+        assert_eq!(c.len(), 1, "a live hit must not remove anything");
+
+        // Absent key: a miss, and the fall-through `pop_raw` must remove nothing.
+        assert!(SyncConcurrentCached::cache_get(&c, &404).unwrap().is_none());
+        assert_eq!(c.metrics().hits, Some(1));
+        assert_eq!(c.metrics().misses, Some(1));
+        assert_eq!(c.len(), 1);
+        assert!(seen.lock().unwrap().is_empty(), "no eviction yet");
+        let evictions_before = c.metrics().evictions.expect("evictions tracked");
+
+        // Expired value: a miss, removed from the store, counted, callback fired.
+        SyncConcurrentCached::cache_set(
+            &c,
+            2,
+            Val {
+                v: 20,
+                expired: true,
+            },
+        )
+        .unwrap();
+        assert!(SyncConcurrentCached::cache_get(&c, &2).unwrap().is_none());
+        assert_eq!(c.metrics().misses, Some(2));
+        assert_eq!(c.len(), 1, "the expired entry must be removed on access");
+        assert_eq!(*seen.lock().unwrap(), vec![(2, 20)]);
+        assert_eq!(
+            c.metrics().evictions.expect("evictions tracked") - evictions_before,
+            1,
+            "lazy expiry must count exactly one eviction"
+        );
+        // A second read of the now-absent key is a plain miss with no extra eviction.
+        assert!(SyncConcurrentCached::cache_get(&c, &2).unwrap().is_none());
+        assert_eq!(c.metrics().misses, Some(3));
+        assert_eq!(
+            c.metrics().evictions.expect("evictions tracked") - evictions_before,
+            1
+        );
+        // The live entry is untouched throughout.
+        assert_eq!(
+            SyncConcurrentCached::cache_get(&c, &1)
+                .unwrap()
+                .map(|v| v.v),
+            Some(10)
+        );
+    }
+
+    /// The single-lookup path must still promote what it reads: `get_if` moves the entry to
+    /// MRU when (and only when) the predicate reports the value live. Checked directly on the
+    /// recency chain and through the capacity eviction it decides.
+    #[test]
+    fn cache_get_promotes_recency_through_the_single_lookup_path() {
+        let c = ShardedExpiringLruCacheBase::<u32, Val>::builder()
+            .shards(1)
+            .max_size(2)
+            .build()
+            .unwrap();
+        SyncConcurrentCached::cache_set(&c, 1, live(10)).unwrap();
+        SyncConcurrentCached::cache_set(&c, 2, live(20)).unwrap();
+        assert_eq!(shard_key_order(&c, 0), vec![2, 1]);
+
+        assert_eq!(
+            SyncConcurrentCached::cache_get(&c, &1)
+                .unwrap()
+                .map(|v| v.v),
+            Some(10)
+        );
+        assert_eq!(
+            shard_key_order(&c, 0),
+            vec![1, 2],
+            "a live read must promote the entry to MRU"
+        );
+
+        // ... so the next capacity eviction claims key 2, not the just-read key 1.
+        SyncConcurrentCached::cache_set(&c, 3, live(30)).unwrap();
+        assert!(SyncConcurrentCached::cache_contains(&c, &1).unwrap());
+        assert!(!SyncConcurrentCached::cache_contains(&c, &2).unwrap());
+    }
+
+    /// THE RECENCY TRAP. `cache_set` with an `on_evict` callback no longer does
+    /// `pop_raw` + `cache_set` (two lookups plus LRU slab churn) to recover the stored key --
+    /// it uses `set_entry_promoting`. The removed pop-then-insert promoted the overwritten
+    /// entry to MRU for free (the re-insert went through `push_front`); a plain in-place
+    /// `order.set` (i.e. `cache_set_returning_entry`) does NOT. This test fails if that
+    /// promotion is dropped.
+    #[test]
+    fn cache_set_with_on_evict_promotes_overwritten_entry_to_mru() {
+        let c = ShardedExpiringLruCacheBase::<u32, Val>::builder()
+            .shards(1)
+            .max_size(2)
+            .on_evict(|_, _| {})
+            .build()
+            .unwrap();
+        SyncConcurrentCached::cache_set(&c, 1, live(10)).unwrap();
+        SyncConcurrentCached::cache_set(&c, 2, live(20)).unwrap();
+        assert_eq!(shard_key_order(&c, 0), vec![2, 1]);
+
+        // Overwrite the LRU entry: it must come back as MRU, and return the old value.
+        assert_eq!(
+            SyncConcurrentCached::cache_set(&c, 1, live(11))
+                .unwrap()
+                .map(|v| v.v),
+            Some(10),
+            "overwrite must return the displaced live value"
+        );
+        assert_eq!(
+            shard_key_order(&c, 0),
+            vec![1, 2],
+            "overwriting an entry must promote it to MRU (as pop-then-insert did)"
+        );
+        assert_eq!(c.len(), 2, "an overwrite must not change the entry count");
+
+        // The promotion decides the next capacity eviction victim.
+        SyncConcurrentCached::cache_set(&c, 3, live(30)).unwrap();
+        assert_eq!(
+            SyncConcurrentCached::cache_get(&c, &1)
+                .unwrap()
+                .map(|v| v.v),
+            Some(11),
+            "the promoted (overwritten) entry must survive the capacity eviction"
+        );
+        assert!(!SyncConcurrentCached::cache_contains(&c, &2).unwrap());
+    }
+
+    /// The `on_evict`-free `cache_set` path is a plain `LruCache::cache_set`, which replaces
+    /// in place and does **not** promote. That asymmetry predates the single-lookup rewrite;
+    /// this pins it so the two paths are not silently unified in either direction.
+    #[test]
+    fn cache_set_without_on_evict_does_not_promote_overwritten_entry() {
+        let c = ShardedExpiringLruCacheBase::<u32, Val>::builder()
+            .shards(1)
+            .max_size(2)
+            .build()
+            .unwrap();
+        SyncConcurrentCached::cache_set(&c, 1, live(10)).unwrap();
+        SyncConcurrentCached::cache_set(&c, 2, live(20)).unwrap();
+        assert_eq!(
+            SyncConcurrentCached::cache_set(&c, 1, live(11))
+                .unwrap()
+                .map(|v| v.v),
+            Some(10)
+        );
+        assert_eq!(
+            shard_key_order(&c, 0),
+            vec![2, 1],
+            "without on_evict, an overwrite replaces in place and does not promote"
+        );
+    }
+
+    /// Every eviction counted outside the inner LRU counter lands on the shard that owns the
+    /// key, and `metrics()` aggregates the per-shard counters together with the inner LRU
+    /// counters without double-counting.
+    #[test]
+    fn every_eviction_path_counts_on_the_owning_shard() {
+        let c = ShardedExpiringLruCacheBase::<u32, Val>::builder()
+            .shards(8)
+            .per_shard_max_size(8)
+            .build()
+            .unwrap();
+        let mut expected = vec![0u64; 8];
+        let expired = |v: u32| Val { v, expired: true };
+
+        // 1) Lazy expiry through cache_get.
+        SyncConcurrentCached::cache_set(&c, 1, expired(10)).unwrap();
+        assert!(SyncConcurrentCached::cache_get(&c, &1).unwrap().is_none());
+        expected[owning_shard(&c, &1)] += 1;
+        assert_eq!(
+            shard_eviction_counters(&c),
+            expected,
+            "cache_get lazy expiry"
+        );
+
+        // 2) evict() sweep.
+        SyncConcurrentCached::cache_set(&c, 2, expired(20)).unwrap();
+        SyncConcurrentCached::cache_set(&c, 3, expired(30)).unwrap();
+        assert_eq!(ConcurrentCacheEvict::evict(&c), 2);
+        expected[owning_shard(&c, &2)] += 1;
+        expected[owning_shard(&c, &3)] += 1;
+        assert_eq!(shard_eviction_counters(&c), expected, "evict");
+
+        // 3) retain().
+        SyncConcurrentCached::cache_set(&c, 4, live(40)).unwrap();
+        c.retain(|_k, _v| false);
+        expected[owning_shard(&c, &4)] += 1;
+        assert_eq!(shard_eviction_counters(&c), expected, "retain");
+
+        // 4) Explicit removes stay on the INNER per-shard LruCache counter (unchanged split).
+        SyncConcurrentCached::cache_set(&c, 5, live(50)).unwrap();
+        let non_capacity_before = shard_eviction_counters(&c);
+        let total_before = c.metrics().evictions.expect("evictions tracked");
+        assert!(
+            SyncConcurrentCached::cache_remove(&c, &5)
+                .unwrap()
+                .is_some()
+        );
+        assert_eq!(
+            shard_eviction_counters(&c),
+            non_capacity_before,
+            "cache_remove must keep counting on the inner LRU counter"
+        );
+        assert_eq!(
+            c.metrics().evictions,
+            Some(total_before + 1),
+            "the removal must still show up in the aggregate exactly once"
+        );
+
+        // 5) cache_clear_with_on_evict also counts on the inner counter for this store.
+        SyncConcurrentCached::cache_set(&c, 6, live(60)).unwrap();
+        let non_capacity_before = shard_eviction_counters(&c);
+        let total_before = c.metrics().evictions.expect("evictions tracked");
+        c.cache_clear_with_on_evict();
+        assert_eq!(shard_eviction_counters(&c), non_capacity_before);
+        assert_eq!(c.metrics().evictions, Some(total_before + 1));
+
+        // 6) Capacity evictions: inner counter only, added on top by metrics().
+        let victims: Vec<u32> = (0..1000u32)
+            .filter(|i| owning_shard(&c, i) == 0)
+            .take(20)
+            .collect();
+        assert_eq!(victims.len(), 20, "need 20 keys landing on shard 0");
+        let non_capacity_before = shard_eviction_counters(&c);
+        let total_before = c.metrics().evictions.expect("evictions tracked");
+        for k in &victims {
+            SyncConcurrentCached::cache_set(&c, *k, live(*k)).unwrap();
+        }
+        assert_eq!(
+            shard_eviction_counters(&c),
+            non_capacity_before,
+            "capacity evictions must NOT touch the non-capacity counters"
+        );
+        assert_eq!(
+            c.metrics().evictions,
+            Some(total_before + 12),
+            "metrics() must sum capacity and non-capacity evictions without double counting"
+        );
+
+        // cache_reset_metrics zeroes both families.
+        ConcurrentCached::cache_reset_metrics(&c).unwrap();
+        assert_eq!(shard_eviction_counters(&c), vec![0u64; 8]);
+        assert_eq!(c.metrics().evictions, Some(0));
+    }
+
+    /// `deep_clone` used to copy one process-wide eviction counter; with the counters
+    /// per-shard it must copy each shard's, so the clone reports the same totals.
+    #[test]
+    fn deep_clone_preserves_per_shard_eviction_counts() {
+        let c = ShardedExpiringLruCacheBase::<u32, Val>::builder()
+            .shards(4)
+            .per_shard_max_size(4)
+            .build()
+            .unwrap();
+        // Non-capacity evictions (lazy expiry) plus capacity evictions from overfilling.
+        for i in 0..4u32 {
+            SyncConcurrentCached::cache_set(
+                &c,
+                i,
+                Val {
+                    v: i,
+                    expired: true,
+                },
+            )
+            .unwrap();
+            assert!(SyncConcurrentCached::cache_get(&c, &i).unwrap().is_none());
+        }
+        for i in 100..140u32 {
+            SyncConcurrentCached::cache_set(&c, i, live(i)).unwrap();
+        }
+        let before = c.metrics().evictions.expect("evictions tracked");
+        let per_shard_before = shard_eviction_counters(&c);
+        assert_eq!(per_shard_before.iter().sum::<u64>(), 4);
+        assert!(
+            before > 4,
+            "the fixture must also produce capacity evictions"
+        );
+
+        let cloned = c.deep_clone();
+        assert_eq!(
+            shard_eviction_counters(&cloned),
+            per_shard_before,
+            "each shard's non-capacity counter must carry across a deep_clone"
+        );
+        assert_eq!(
+            cloned.metrics().evictions,
+            Some(before),
+            "the clone must report the same eviction total"
+        );
+
+        // The clone is independent: further non-capacity evictions do not touch the source.
+        SyncConcurrentCached::cache_set(
+            &cloned,
+            999,
+            Val {
+                v: 999,
+                expired: true,
+            },
+        )
+        .unwrap();
+        assert!(
+            SyncConcurrentCached::cache_get(&cloned, &999)
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(
+            shard_eviction_counters(&cloned).iter().sum::<u64>(),
+            5,
+            "the lazy expiry must count on the clone's own shard counter"
+        );
+        assert_eq!(
+            shard_eviction_counters(&c),
+            per_shard_before,
+            "the source's per-shard counters must be untouched by the clone"
+        );
+        assert_eq!(
+            c.metrics().evictions,
+            Some(before),
+            "the source's totals must be untouched by the clone"
+        );
+    }
+
+    /// `cache_clear_with_on_evict` drains each shard with `LruCache::drain_all` (no key clones,
+    /// no re-hashing); the callbacks must still arrive most-recently-used first, per shard.
+    #[test]
+    fn cache_clear_with_on_evict_fires_mru_to_lru_per_shard() {
+        use std::sync::Mutex;
+        let seen: Arc<Mutex<Vec<u32>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen2 = Arc::clone(&seen);
+        let c = ShardedExpiringLruCacheBase::<u32, Val>::builder()
+            .shards(1)
+            .max_size(64)
+            .on_evict(move |k: &u32, _v: &Val| seen2.lock().unwrap().push(*k))
+            .build()
+            .unwrap();
+        for i in 0..6u32 {
+            SyncConcurrentCached::cache_set(&c, i, live(i)).unwrap();
+        }
+        assert!(SyncConcurrentCached::cache_get(&c, &0).unwrap().is_some());
+        assert!(SyncConcurrentCached::cache_get(&c, &2).unwrap().is_some());
+        let expected = shard_key_order(&c, 0);
+        assert_eq!(
+            expected,
+            vec![2, 0, 5, 4, 3, 1],
+            "precondition: MRU -> LRU chain after the two re-reads"
+        );
+
+        c.cache_clear_with_on_evict();
+
+        assert_eq!(
+            *seen.lock().unwrap(),
+            expected,
+            "on_evict must fire in MRU -> LRU order"
+        );
+        assert!(c.is_empty());
+        // The drained shard stays usable.
+        SyncConcurrentCached::cache_set(&c, 42, live(42)).unwrap();
+        assert!(SyncConcurrentCached::cache_get(&c, &42).unwrap().is_some());
     }
 }

--- a/src/stores/sharded/expiring_lru.rs
+++ b/src/stores/sharded/expiring_lru.rs
@@ -21,40 +21,6 @@ use crate::stores::{BuildError, LruCache};
 
 type OnEvict<K, V> = Arc<dyn Fn(&K, &V) + Send + Sync>;
 
-/// Insert or replace an entry in a shard's inner [`LruCache`], returning the **stored** `(K, V)`
-/// pair of the displaced entry (or `None` for a fresh insertion), and leaving the entry at the
-/// most-recently-used position either way.
-///
-/// This replaces the `pop_raw(&k)` + `cache_set(k, v)` pair that `cache_set` used purely to
-/// recover the owned stored key for `on_evict`: that pair hashed and probed the shard twice and
-/// churned the LRU slab (free the slot, then push a fresh one).
-///
-/// # Recency trap
-///
-/// The obvious one-lookup replacement, `LruCache::cache_set_returning_entry`, replaces in place
-/// via `order.set` and does **NOT** promote to MRU, whereas the remove-then-insert it replaces
-/// *does* (the re-insert goes through `push_front`). Dropping the promotion would silently
-/// change which entry a later capacity eviction picks. `get_or_set_with_if` with a never-valid
-/// predicate is exactly "`order.set` + `order.move_to_front`" for an existing key (and
-/// `push_front` + capacity check for a new one) in a single hash + probe, so the promotion is
-/// preserved. Pinned by `cache_set_with_on_evict_promotes_overwritten_entry_to_mru`.
-///
-/// The caller must have disabled hit/miss tracking on the inner cache (every sharded store
-/// does): `get_or_set_with_if` would otherwise record a miss for each overwrite.
-fn set_entry_promoting<K, V>(cache: &mut LruCache<K, V>, key: K, val: V) -> Option<(K, V)>
-where
-    K: Hash + Eq + Clone,
-{
-    debug_assert!(
-        !cache.track_hit_miss,
-        "set_entry_promoting requires hit/miss tracking to be disabled on the inner cache"
-    );
-    // `|_| false` (never valid) forces the replace arm for an existing key; that arm's
-    // `old_val` is the stored `(K, V)` pair.
-    let (_, _, displaced, _) = cache.get_or_set_with_if(key, || val, |_| false);
-    displaced
-}
-
 #[allow(clippy::type_complexity)]
 struct ExpiringLruInner<K, V, H> {
     shards: Box<[CachePadded<Shard<LruCache<K, V>>>]>,
@@ -686,8 +652,8 @@ where
     fn cache_set(&self, k: K, v: V) -> Result<Option<V>, Self::Error> {
         let shard = self.shard_of(&k);
         // With a callback we need the *stored* key to hand to it, so the write goes through
-        // `set_entry_promoting` (one lookup, no LRU slot churn, and it restores the MRU
-        // promotion the old pop-then-set got for free); otherwise a plain set. A displaced
+        // `cache_set_returning_entry`; otherwise a plain set. Both promote an overwritten key to
+        // MRU, so the two branches agree on eviction order. A displaced
         // expired value is counted as an eviction under the lock (matching cache_remove) and
         // filtered from the return; a live displaced value is returned to the caller unchanged.
         // `is_expired()` is evaluated exactly once, while the write lock is still held, and the
@@ -697,7 +663,7 @@ where
         let old: Option<(Option<K>, V, bool)> = {
             let mut guard = shard.lock.write();
             let old = if self.inner.on_evict.is_some() {
-                set_entry_promoting(&mut guard, k, v).map(|(ok, ov)| {
+                guard.cache_set_returning_entry(k, v).map(|(ok, ov)| {
                     let expired = ov.is_expired();
                     (Some(ok), ov, expired)
                 })
@@ -2401,7 +2367,7 @@ mod tests {
         );
     }
 
-    // --- single-lookup `cache_get`, per-shard eviction counters, and the recency trap ---
+    // --- single-lookup `cache_get`, per-shard eviction counters, and write recency ---
 
     fn live(v: u32) -> Val {
         Val { v, expired: false }
@@ -2541,12 +2507,9 @@ mod tests {
         assert!(!SyncConcurrentCached::cache_contains(&c, &2).unwrap());
     }
 
-    /// THE RECENCY TRAP. `cache_set` with an `on_evict` callback no longer does
-    /// `pop_raw` + `cache_set` (two lookups plus LRU slab churn) to recover the stored key --
-    /// it uses `set_entry_promoting`. The removed pop-then-insert promoted the overwritten
-    /// entry to MRU for free (the re-insert went through `push_front`); a plain in-place
-    /// `order.set` (i.e. `cache_set_returning_entry`) does NOT. This test fails if that
-    /// promotion is dropped.
+    /// `cache_set` with an `on_evict` callback recovers the stored key through
+    /// `cache_set_returning_entry`, which promotes the overwritten entry to MRU. This test
+    /// fails if that promotion is dropped.
     #[test]
     fn cache_set_with_on_evict_promotes_overwritten_entry_to_mru() {
         let c = ShardedExpiringLruCacheBase::<u32, Val>::builder()
@@ -2586,11 +2549,11 @@ mod tests {
         assert!(!SyncConcurrentCached::cache_contains(&c, &2).unwrap());
     }
 
-    /// The `on_evict`-free `cache_set` path is a plain `LruCache::cache_set`, which replaces
-    /// in place and does **not** promote. That asymmetry predates the single-lookup rewrite;
-    /// this pins it so the two paths are not silently unified in either direction.
+    /// The `on_evict`-free `cache_set` path is a plain `LruCache::cache_set`, which now
+    /// promotes on overwrite just like the `on_evict` path's `cache_set_returning_entry`.
+    /// Attaching a purely observational callback must not change eviction order.
     #[test]
-    fn cache_set_without_on_evict_does_not_promote_overwritten_entry() {
+    fn cache_set_without_on_evict_promotes_overwritten_entry() {
         let c = ShardedExpiringLruCacheBase::<u32, Val>::builder()
             .shards(1)
             .max_size(2)
@@ -2606,9 +2569,79 @@ mod tests {
         );
         assert_eq!(
             shard_key_order(&c, 0),
-            vec![2, 1],
-            "without on_evict, an overwrite replaces in place and does not promote"
+            vec![1, 2],
+            "an overwrite promotes to MRU with or without an on_evict callback"
         );
+
+        // ... and the promotion decides the next capacity eviction victim, exactly as it
+        // does on the `on_evict` path.
+        SyncConcurrentCached::cache_set(&c, 3, live(30)).unwrap();
+        assert!(SyncConcurrentCached::cache_contains(&c, &1).unwrap());
+        assert!(!SyncConcurrentCached::cache_contains(&c, &2).unwrap());
+    }
+
+    /// Overwriting the current MRU entry (already the head of the LRU chain) must leave it
+    /// at the head with the chain intact, on both `cache_set` branches.
+    #[test]
+    fn cache_set_over_current_mru_keeps_it_at_the_front() {
+        for with_on_evict in [false, true] {
+            let builder = ShardedExpiringLruCacheBase::<u32, Val>::builder()
+                .shards(1)
+                .max_size(3);
+            let c = if with_on_evict {
+                builder.on_evict(|_, _| {}).build().unwrap()
+            } else {
+                builder.build().unwrap()
+            };
+            for k in 1..=3u32 {
+                SyncConcurrentCached::cache_set(&c, k, live(k * 10)).unwrap();
+            }
+            assert_eq!(shard_key_order(&c, 0), vec![3, 2, 1]);
+            assert_eq!(
+                SyncConcurrentCached::cache_set(&c, 3, live(33))
+                    .unwrap()
+                    .map(|v| v.v),
+                Some(30)
+            );
+            assert_eq!(
+                shard_key_order(&c, 0),
+                vec![3, 2, 1],
+                "on_evict={with_on_evict}: overwriting the head must keep it at the head"
+            );
+            assert_eq!(c.len(), 3);
+            // The chain is intact: the LRU victim is still key 1.
+            SyncConcurrentCached::cache_set(&c, 4, live(40)).unwrap();
+            assert_eq!(shard_key_order(&c, 0), vec![4, 3, 2]);
+            assert!(!SyncConcurrentCached::cache_contains(&c, &1).unwrap());
+        }
+    }
+
+    /// A 1-capacity shard: overwriting the sole entry must not corrupt the chain.
+    #[test]
+    fn cache_set_over_sole_entry_of_capacity_one_shard() {
+        for with_on_evict in [false, true] {
+            let builder = ShardedExpiringLruCacheBase::<u32, Val>::builder()
+                .shards(1)
+                .max_size(1);
+            let c = if with_on_evict {
+                builder.on_evict(|_, _| {}).build().unwrap()
+            } else {
+                builder.build().unwrap()
+            };
+            SyncConcurrentCached::cache_set(&c, 1, live(10)).unwrap();
+            assert_eq!(
+                SyncConcurrentCached::cache_set(&c, 1, live(11))
+                    .unwrap()
+                    .map(|v| v.v),
+                Some(10),
+                "on_evict={with_on_evict}"
+            );
+            assert_eq!(shard_key_order(&c, 0), vec![1]);
+            assert_eq!(c.len(), 1);
+            SyncConcurrentCached::cache_set(&c, 2, live(20)).unwrap();
+            assert_eq!(shard_key_order(&c, 0), vec![2]);
+            assert_eq!(c.len(), 1);
+        }
     }
 
     /// Every eviction counted outside the inner LRU counter lands on the shard that owns the

--- a/src/stores/sharded/expiring_lru.rs
+++ b/src/stores/sharded/expiring_lru.rs
@@ -76,8 +76,7 @@ impl<K, V, H> Clone for ShardedExpiringLruCacheBase<K, V, H> {
 impl<K, V, H> ShardedExpiringLruCacheBase<K, V, H> {
     /// Sum of the per-shard counters for evictions **not** driven by LRU capacity pressure:
     /// expired entries dropped lazily on [`cache_get`](ConcurrentCached::cache_get) or swept by
-    /// [`evict`](ShardedExpiringLruCacheBase::evict), [`retain`](Self::retain), and
-    /// [`cache_clear_with_on_evict`](Self::cache_clear_with_on_evict).
+    /// [`evict`](ShardedExpiringLruCacheBase::evict) or [`retain`](Self::retain).
     ///
     /// These live in [`Shard::evictions`], one atomic per shard (like `hits`/`misses`), rather
     /// than in a single process-wide counter on `Arc<Inner>`: a thread bumping it has just held
@@ -321,7 +320,7 @@ where
         for shard in self.inner.shards.iter() {
             hits += shard.hits.load(Ordering::Relaxed);
             misses += shard.misses.load(Ordering::Relaxed);
-            // Per-shard non-capacity evictions (lazy expiry / evict / retain / clear); the
+            // Per-shard non-capacity evictions (lazy expiry / evict / retain); the
             // inner `LruCache` counter below holds this shard's capacity evictions and its
             // explicit removes. The two families are disjoint, so summing cannot double-count.
             non_capacity_evictions += shard.evictions.load(Ordering::Relaxed);

--- a/src/stores/sharded/expiring_lru.rs
+++ b/src/stores/sharded/expiring_lru.rs
@@ -417,9 +417,10 @@ where
     /// Remove every entry that is expired (per [`Expires::is_expired`]) **or** for which `keep`
     /// returns `false` — expired entries are removed regardless of `keep`, matching
     /// [`ExpiringLruCache::retain`](crate::ExpiringLruCache::retain) semantics. `on_evict` fires
-    /// (if configured) and `metrics().evictions` increments once per removed entry (via the outer
-    /// eviction counter, the same one used by [`evict`](Self::evict)). The LRU recency order of
-    /// the surviving entries in each shard is unchanged.
+    /// (if configured) and `metrics().evictions` increments once per removed entry (via the
+    /// per-shard eviction counter (`Shard::evictions`), the same one used by
+    /// [`evict`](Self::evict)). The LRU recency order of the surviving entries in each shard is
+    /// unchanged.
     ///
     /// Shards are processed one at a time under their own write lock, so this is **not atomic**
     /// across shards: a concurrent reader may observe some shards already filtered and others not

--- a/src/stores/sharded/expiring_lru.rs
+++ b/src/stores/sharded/expiring_lru.rs
@@ -162,6 +162,7 @@ impl<K: Clone + Hash + Eq, V: Clone + Expires, H: ShardHasher<K>>
                     lock: parking_lot::RwLock::new(store_copy),
                     hits: AtomicU64::new(hits),
                     misses: AtomicU64::new(misses),
+                    evictions: AtomicU64::new(0),
                 };
                 CachePadded(shard)
             })

--- a/src/stores/sharded/lru.rs
+++ b/src/stores/sharded/lru.rs
@@ -147,6 +147,7 @@ impl<K: Clone + Hash + Eq, V: Clone, H: ShardHasher<K>> ShardedLruCacheBase<K, V
                     lock: parking_lot::RwLock::new(store_copy),
                     hits: AtomicU64::new(hits),
                     misses: AtomicU64::new(misses),
+                    evictions: AtomicU64::new(0),
                 };
                 CachePadded(shard)
             })

--- a/src/stores/sharded/lru.rs
+++ b/src/stores/sharded/lru.rs
@@ -346,13 +346,11 @@ where
         for shard in self.inner.shards.iter() {
             let removed: Vec<(K, V)> = {
                 let mut guard = shard.lock.write();
-                let keys: Vec<K> = guard.iter().map(|(k, _)| k.clone()).collect();
-                let mut removed = Vec::with_capacity(keys.len());
-                for k in keys {
-                    if let Some(pair) = guard.pop_raw(&k) {
-                        removed.push(pair);
-                    }
-                }
+                // `drain_all` walks each shard's LRU chain once taking owned pairs in
+                // MRU -> LRU order -- the same order the old "clone every key, then
+                // `pop_raw` each one" drain fired in, but with zero key clones and zero
+                // re-hashing.
+                let removed = guard.drain_all();
                 if !removed.is_empty() {
                     guard
                         .evictions
@@ -561,9 +559,13 @@ where
     fn cache_get(&self, k: &K) -> Result<Option<V>, Self::Error> {
         let shard = self.shard_of(k);
         let mut guard = shard.lock.write();
-        match guard.cache_get(k) {
+        let value = guard.cache_get(k).cloned();
+        // Release the shard lock before touching the counters: the atomics are
+        // shard-local but there is no reason to hold the write lock across them
+        // (the `drop(guard)`-first pattern used by the other sharded stores).
+        drop(guard);
+        match value {
             Some(v) => {
-                let v = v.clone();
                 shard.hits.fetch_add(1, Ordering::Relaxed);
                 Ok(Some(v))
             }
@@ -1496,6 +1498,80 @@ mod tests {
             before, after,
             "surviving entries must keep their relative MRU order"
         );
+    }
+
+    /// `cache_clear_with_on_evict` drains each shard with `LruCache::drain_all` (no key
+    /// clones, no re-hashing) instead of "collect every key, then `pop_raw` each one". The
+    /// firing order is load-bearing: `drain_all` walks the LRU chain, so callbacks must still
+    /// arrive most-recently-used first, per shard.
+    #[test]
+    fn cache_clear_with_on_evict_fires_mru_to_lru_per_shard() {
+        use std::sync::Mutex;
+        let seen: Arc<Mutex<Vec<u32>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen2 = Arc::clone(&seen);
+        let c = ShardedLruCacheBase::<u32, u32>::builder()
+            .shards(1) // one shard: a single, fully deterministic recency chain
+            .max_size(64)
+            .on_evict(move |k: &u32, _v: &u32| seen2.lock().unwrap().push(*k))
+            .build()
+            .unwrap();
+        for i in 0..6u32 {
+            SyncConcurrentCached::cache_set(&c, i, i).expect("insert must succeed");
+        }
+        // Re-read 0 and 2 so the recency chain is not simply insertion order reversed.
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &0).unwrap(), Some(0));
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &2).unwrap(), Some(2));
+        let expected: Vec<u32> = c.inner.shards[0]
+            .lock
+            .read()
+            .iter_order_raw()
+            .into_iter()
+            .map(|(k, _)| k)
+            .collect();
+        assert_eq!(
+            expected,
+            vec![2, 0, 5, 4, 3, 1],
+            "precondition: MRU -> LRU chain after the two re-reads"
+        );
+
+        c.cache_clear_with_on_evict();
+
+        assert_eq!(
+            *seen.lock().unwrap(),
+            expected,
+            "on_evict must fire in MRU -> LRU order"
+        );
+        assert!(c.is_empty(), "every entry must be drained");
+        // The drained shard is immediately reusable (drain_all resets the slab sentinels).
+        SyncConcurrentCached::cache_set(&c, 42, 42).expect("insert must succeed");
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &42).unwrap(), Some(42));
+        assert_eq!(c.len(), 1);
+    }
+
+    /// `cache_get` clones the value and releases the shard lock before bumping the
+    /// hit/miss counters; the counters must still be exact for both outcomes, and a hit
+    /// must still promote LRU recency.
+    #[test]
+    fn cache_get_counts_and_promotes_after_releasing_the_lock() {
+        let c = ShardedLruCacheBase::<u32, u32>::builder()
+            .shards(1)
+            .max_size(2)
+            .build()
+            .unwrap();
+        SyncConcurrentCached::cache_set(&c, 1, 10).expect("insert must succeed");
+        SyncConcurrentCached::cache_set(&c, 2, 20).expect("insert must succeed");
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &1).unwrap(), Some(10));
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &99).unwrap(), None);
+        let m = c.metrics();
+        assert_eq!(m.hits, Some(1));
+        assert_eq!(m.misses, Some(1));
+        // The hit promoted key 1, so the capacity eviction must claim key 2.
+        SyncConcurrentCached::cache_set(&c, 3, 30).expect("insert must succeed");
+        assert!(
+            SyncConcurrentCached::cache_contains(&c, &1).unwrap(),
+            "the entry read via cache_get must have been promoted to MRU"
+        );
+        assert!(!SyncConcurrentCached::cache_contains(&c, &2).unwrap());
     }
 
     /// Counter-wiring contract: `retain`'s eviction count on the plain LRU sharded store

--- a/src/stores/sharded/lru_ttl.rs
+++ b/src/stores/sharded/lru_ttl.rs
@@ -22,40 +22,6 @@ use crate::{Cached, CachedIter, CachedPeek};
 
 type OnEvict<K, V> = Arc<dyn Fn(&K, &V) + Send + Sync>;
 
-/// Insert or replace an entry in a shard's inner [`LruCache`], returning the **stored** `(K, V)`
-/// pair of the displaced entry (or `None` for a fresh insertion), and leaving the entry at the
-/// most-recently-used position either way.
-///
-/// This replaces the `pop_raw(&k)` + `cache_set(k, v)` pair that `cache_set` used purely to
-/// recover the owned stored key for `on_evict`: that pair hashed and probed the shard twice and
-/// churned the LRU slab (free the slot, then push a fresh one).
-///
-/// # Recency trap
-///
-/// The obvious one-lookup replacement, `LruCache::cache_set_returning_entry`, replaces in place
-/// via `order.set` and does **NOT** promote to MRU, whereas the remove-then-insert it replaces
-/// *does* (the re-insert goes through `push_front`). Dropping the promotion would silently
-/// change which entry a later capacity eviction picks. `get_or_set_with_if` with a never-valid
-/// predicate is exactly "`order.set` + `order.move_to_front`" for an existing key (and
-/// `push_front` + capacity check for a new one) in a single hash + probe, so the promotion is
-/// preserved. Pinned by `cache_set_with_on_evict_promotes_overwritten_entry_to_mru`.
-///
-/// The caller must have disabled hit/miss tracking on the inner cache (every sharded store
-/// does): `get_or_set_with_if` would otherwise record a miss for each overwrite.
-fn set_entry_promoting<K, V>(cache: &mut LruCache<K, V>, key: K, val: V) -> Option<(K, V)>
-where
-    K: Hash + Eq + Clone,
-{
-    debug_assert!(
-        !cache.track_hit_miss,
-        "set_entry_promoting requires hit/miss tracking to be disabled on the inner cache"
-    );
-    // `|_| false` (never valid) forces the replace arm for an existing key; that arm's
-    // `old_val` is the stored `(K, V)` pair.
-    let (_, _, displaced, _) = cache.get_or_set_with_if(key, || val, |_| false);
-    displaced
-}
-
 #[allow(clippy::type_complexity)]
 struct LruTtlInner<K, V, H> {
     shards: Box<[CachePadded<Shard<LruCache<K, TimedEntry<V>>>>]>,
@@ -836,15 +802,17 @@ where
         // this operation (B2: a single sample, taken before the lock, cannot see the entry
         // cross the expiry threshold part-way through the op). When an `on_evict` callback is
         // configured we need the *stored* key to hand to it, so the write goes through
-        // `set_entry_promoting` (one lookup, no LRU slot churn, and it restores the MRU
-        // promotion the old pop-then-set got for free); otherwise a plain set. The entry count
-        // is unchanged, no capacity eviction is triggered.
+        // `cache_set_returning_entry`; otherwise a plain set. Both promote an overwritten key
+        // to MRU, so the two branches agree on eviction order. The entry count is unchanged,
+        // no capacity eviction is triggered.
         let old: Option<(Option<K>, TimedEntry<V>, bool)> = if self.inner.on_evict.is_some() {
             let mut guard = shard.lock.write();
-            set_entry_promoting(&mut guard, k, new_entry).map(|(ok, e)| {
-                let expired = e.expires_at.is_some_and(|t| now >= t);
-                (Some(ok), e, expired)
-            })
+            guard
+                .cache_set_returning_entry(k, new_entry)
+                .map(|(ok, e)| {
+                    let expired = e.expires_at.is_some_and(|t| now >= t);
+                    (Some(ok), e, expired)
+                })
         } else {
             shard.lock.write().cache_set(k, new_entry).map(|e| {
                 let expired = e.expires_at.is_some_and(|t| now >= t);
@@ -2725,7 +2693,7 @@ mod tests {
         );
     }
 
-    // --- single-lookup `cache_get`, per-shard eviction counters, and the recency trap ---
+    // --- single-lookup `cache_get`, per-shard eviction counters, and write recency ---
 
     /// Raw per-shard non-capacity eviction counters, in shard order.
     fn shard_eviction_counters<K, V, H>(c: &ShardedLruTtlCacheBase<K, V, H>) -> Vec<u64> {
@@ -2872,12 +2840,9 @@ mod tests {
         );
     }
 
-    /// THE RECENCY TRAP. `cache_set` with an `on_evict` callback no longer does
-    /// `pop_raw` + `cache_set` (two lookups plus LRU slab churn) to recover the stored key --
-    /// it uses `set_entry_promoting`. The removed pop-then-insert promoted the overwritten
-    /// entry to MRU for free (the re-insert went through `push_front`); a plain in-place
-    /// `order.set` (i.e. `cache_set_returning_entry`) does NOT. This test fails if that
-    /// promotion is dropped.
+    /// `cache_set` with an `on_evict` callback recovers the stored key through
+    /// `cache_set_returning_entry`, which promotes the overwritten entry to MRU. This test
+    /// fails if that promotion is dropped.
     #[test]
     fn cache_set_with_on_evict_promotes_overwritten_entry_to_mru() {
         let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
@@ -2914,11 +2879,11 @@ mod tests {
         assert!(!SyncConcurrentCached::cache_contains(&c, &2).unwrap());
     }
 
-    /// The `on_evict`-free `cache_set` path is a plain `LruCache::cache_set`, which replaces
-    /// in place and does **not** promote. That asymmetry predates the single-lookup rewrite;
-    /// this pins it so the two paths are not silently unified in either direction.
+    /// The `on_evict`-free `cache_set` path is a plain `LruCache::cache_set`, which now
+    /// promotes on overwrite just like the `on_evict` path's `cache_set_returning_entry`.
+    /// Attaching a purely observational callback must not change eviction order.
     #[test]
-    fn cache_set_without_on_evict_does_not_promote_overwritten_entry() {
+    fn cache_set_without_on_evict_promotes_overwritten_entry() {
         let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
             .shards(1)
             .max_size(2)
@@ -2933,9 +2898,77 @@ mod tests {
         );
         assert_eq!(
             shard_key_order(&c, 0),
-            vec![2, 1],
-            "without on_evict, an overwrite replaces in place and does not promote"
+            vec![1, 2],
+            "an overwrite promotes to MRU with or without an on_evict callback"
         );
+
+        // ... and the promotion decides the next capacity eviction victim, exactly as it
+        // does on the `on_evict` path.
+        SyncConcurrentCached::cache_set(&c, 3, 30).expect("insert must succeed");
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &1).unwrap(), Some(11));
+        assert!(!SyncConcurrentCached::cache_contains(&c, &2).unwrap());
+    }
+
+    /// Overwriting the current MRU entry (already the head of the LRU chain) must leave it
+    /// at the head with the chain intact, on both `cache_set` branches.
+    #[test]
+    fn cache_set_over_current_mru_keeps_it_at_the_front() {
+        for with_on_evict in [false, true] {
+            let builder = ShardedLruTtlCacheBase::<u32, u32>::builder()
+                .shards(1)
+                .max_size(3)
+                .ttl(Duration::from_secs(3600));
+            let c = if with_on_evict {
+                builder.on_evict(|_, _| {}).build().unwrap()
+            } else {
+                builder.build().unwrap()
+            };
+            for k in 1..=3u32 {
+                SyncConcurrentCached::cache_set(&c, k, k * 10).expect("insert must succeed");
+            }
+            assert_eq!(shard_key_order(&c, 0), vec![3, 2, 1]);
+            assert_eq!(
+                SyncConcurrentCached::cache_set(&c, 3, 33).unwrap(),
+                Some(30)
+            );
+            assert_eq!(
+                shard_key_order(&c, 0),
+                vec![3, 2, 1],
+                "on_evict={with_on_evict}: overwriting the head must keep it at the head"
+            );
+            assert_eq!(c.len(), 3);
+            // The chain is intact: the LRU victim is still key 1.
+            SyncConcurrentCached::cache_set(&c, 4, 40).expect("insert must succeed");
+            assert_eq!(shard_key_order(&c, 0), vec![4, 3, 2]);
+            assert_eq!(SyncConcurrentCached::cache_get(&c, &1).unwrap(), None);
+        }
+    }
+
+    /// A 1-capacity shard: overwriting the sole entry must not corrupt the chain.
+    #[test]
+    fn cache_set_over_sole_entry_of_capacity_one_shard() {
+        for with_on_evict in [false, true] {
+            let builder = ShardedLruTtlCacheBase::<u32, u32>::builder()
+                .shards(1)
+                .max_size(1)
+                .ttl(Duration::from_secs(3600));
+            let c = if with_on_evict {
+                builder.on_evict(|_, _| {}).build().unwrap()
+            } else {
+                builder.build().unwrap()
+            };
+            SyncConcurrentCached::cache_set(&c, 1, 10).expect("insert must succeed");
+            assert_eq!(
+                SyncConcurrentCached::cache_set(&c, 1, 11).unwrap(),
+                Some(10),
+                "on_evict={with_on_evict}"
+            );
+            assert_eq!(shard_key_order(&c, 0), vec![1]);
+            assert_eq!(c.len(), 1);
+            SyncConcurrentCached::cache_set(&c, 2, 20).expect("insert must succeed");
+            assert_eq!(shard_key_order(&c, 0), vec![2]);
+            assert_eq!(c.len(), 1);
+        }
     }
 
     /// Every non-capacity eviction is counted on the shard that owns the key, and `metrics()`
@@ -3057,9 +3090,14 @@ mod tests {
     /// per-shard it must copy each shard's, so the clone reports the same totals.
     #[test]
     fn deep_clone_preserves_per_shard_eviction_counts() {
+        // `per_shard_max_size` must be >= the 8 seed keys: the shard hasher is seeded per
+        // process, so any smaller cap lets an unlucky distribution (5+ of the 8 landing in one
+        // shard) capacity-evict a key before the `cache_remove` loop below reaches it. That
+        // remove would then find nothing, count no non-capacity eviction, and the exact
+        // assertion further down would fail on roughly one run in eight.
         let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
             .shards(4)
-            .per_shard_max_size(4)
+            .per_shard_max_size(8)
             .ttl(Duration::from_secs(3600))
             .build()
             .unwrap();

--- a/src/stores/sharded/lru_ttl.rs
+++ b/src/stores/sharded/lru_ttl.rs
@@ -210,6 +210,7 @@ impl<K: Clone + Hash + Eq, V: Clone, H: ShardHasher<K>> ShardedLruTtlCacheBase<K
                     lock: parking_lot::RwLock::new(store_copy),
                     hits: AtomicU64::new(hits),
                     misses: AtomicU64::new(misses),
+                    evictions: AtomicU64::new(0),
                 };
                 CachePadded(shard)
             })

--- a/src/stores/sharded/lru_ttl.rs
+++ b/src/stores/sharded/lru_ttl.rs
@@ -22,6 +22,40 @@ use crate::{Cached, CachedIter, CachedPeek};
 
 type OnEvict<K, V> = Arc<dyn Fn(&K, &V) + Send + Sync>;
 
+/// Insert or replace an entry in a shard's inner [`LruCache`], returning the **stored** `(K, V)`
+/// pair of the displaced entry (or `None` for a fresh insertion), and leaving the entry at the
+/// most-recently-used position either way.
+///
+/// This replaces the `pop_raw(&k)` + `cache_set(k, v)` pair that `cache_set` used purely to
+/// recover the owned stored key for `on_evict`: that pair hashed and probed the shard twice and
+/// churned the LRU slab (free the slot, then push a fresh one).
+///
+/// # Recency trap
+///
+/// The obvious one-lookup replacement, `LruCache::cache_set_returning_entry`, replaces in place
+/// via `order.set` and does **NOT** promote to MRU, whereas the remove-then-insert it replaces
+/// *does* (the re-insert goes through `push_front`). Dropping the promotion would silently
+/// change which entry a later capacity eviction picks. `get_or_set_with_if` with a never-valid
+/// predicate is exactly "`order.set` + `order.move_to_front`" for an existing key (and
+/// `push_front` + capacity check for a new one) in a single hash + probe, so the promotion is
+/// preserved. Pinned by `cache_set_with_on_evict_promotes_overwritten_entry_to_mru`.
+///
+/// The caller must have disabled hit/miss tracking on the inner cache (every sharded store
+/// does): `get_or_set_with_if` would otherwise record a miss for each overwrite.
+fn set_entry_promoting<K, V>(cache: &mut LruCache<K, V>, key: K, val: V) -> Option<(K, V)>
+where
+    K: Hash + Eq + Clone,
+{
+    debug_assert!(
+        !cache.track_hit_miss,
+        "set_entry_promoting requires hit/miss tracking to be disabled on the inner cache"
+    );
+    // `|_| false` (never valid) forces the replace arm for an existing key; that arm's
+    // `old_val` is the stored `(K, V)` pair.
+    let (_, _, displaced, _) = cache.get_or_set_with_if(key, || val, |_| false);
+    displaced
+}
+
 #[allow(clippy::type_complexity)]
 struct LruTtlInner<K, V, H> {
     shards: Box<[CachePadded<Shard<LruCache<K, TimedEntry<V>>>>]>,
@@ -33,12 +67,6 @@ struct LruTtlInner<K, V, H> {
     /// `ttl_set` flag. `unset_ttl`/`set_ttl(0)` store `0`; `set_ttl(nonzero)` stores the ttl.
     ttl_nanos: AtomicU64,
     refresh: AtomicBool,
-    /// Evictions not driven by LRU capacity pressure: TTL expiry (via [`evict`](ShardedLruTtlCacheBase::evict)),
-    /// explicit removes ([`cache_remove`](ConcurrentCached::cache_remove) /
-    /// [`cache_remove_entry`](ConcurrentCached::cache_remove_entry)), and
-    /// [`cache_clear_with_on_evict`](ShardedLruTtlCacheBase::cache_clear_with_on_evict).
-    /// LRU capacity evictions are tracked per-shard in the inner `LruCache`.
-    non_capacity_evictions: AtomicU64,
     /// Total logical capacity (sum of per-shard caps). Stored as `AtomicUsize` so
     /// [`set_max_size`](ShardedLruTtlCacheBase::set_max_size) can update it from `&self`.
     total_capacity: AtomicUsize,
@@ -102,6 +130,27 @@ impl<K, V, H> ShardedLruTtlCacheBase<K, V, H> {
     #[inline]
     fn ttl_duration_impl(&self) -> Option<Duration> {
         decode_ttl(self.inner.ttl_nanos.load(Ordering::Relaxed))
+    }
+
+    /// Sum of the per-shard counters for evictions **not** driven by LRU capacity pressure:
+    /// TTL expiry (lazily on [`cache_get`](ConcurrentCached::cache_get) or in bulk via
+    /// [`evict`](ShardedLruTtlCacheBase::evict)), explicit removes
+    /// ([`cache_remove`](ConcurrentCached::cache_remove) /
+    /// [`cache_remove_entry`](ConcurrentCached::cache_remove_entry)),
+    /// [`retain`](ShardedLruTtlCacheBase::retain), and
+    /// [`cache_clear_with_on_evict`](ShardedLruTtlCacheBase::cache_clear_with_on_evict).
+    ///
+    /// These live in [`Shard::evictions`], one atomic per shard (like `hits`/`misses`), rather
+    /// than in a single process-wide counter on `Arc<Inner>`: a thread bumping it has just held
+    /// that shard's lock, so the line is already owned exclusively and no cross-core traffic is
+    /// added. LRU **capacity** evictions remain in each shard's inner `LruCache::evictions`;
+    /// [`metrics`](ShardedLruTtlCacheBase::metrics) sums the two families.
+    fn non_capacity_evictions(&self) -> u64 {
+        self.inner
+            .shards
+            .iter()
+            .map(|s| s.evictions.load(Ordering::Relaxed))
+            .sum()
     }
 }
 
@@ -205,12 +254,16 @@ impl<K: Clone + Hash + Eq, V: Clone, H: ShardHasher<K>> ShardedLruTtlCacheBase<K
                 let store_copy = guard.clone();
                 let hits = self.inner.shards[i].hits.load(Ordering::Relaxed);
                 let misses = self.inner.shards[i].misses.load(Ordering::Relaxed);
+                // Carry the shard's non-capacity eviction count across too (it used to live
+                // in a single process-wide counter that `deep_clone` copied wholesale), so
+                // the clone's `metrics().evictions` matches the source's.
+                let evictions = self.inner.shards[i].evictions.load(Ordering::Relaxed);
                 drop(guard);
                 let shard = Shard {
                     lock: parking_lot::RwLock::new(store_copy),
                     hits: AtomicU64::new(hits),
                     misses: AtomicU64::new(misses),
-                    evictions: AtomicU64::new(0),
+                    evictions: AtomicU64::new(evictions),
                 };
                 CachePadded(shard)
             })
@@ -224,9 +277,6 @@ impl<K: Clone + Hash + Eq, V: Clone, H: ShardHasher<K>> ShardedLruTtlCacheBase<K
                 on_evict: self.inner.on_evict.clone(),
                 ttl_nanos: AtomicU64::new(self.inner.ttl_nanos.load(Ordering::Relaxed)),
                 refresh: AtomicBool::new(self.inner.refresh.load(Ordering::Relaxed)),
-                non_capacity_evictions: AtomicU64::new(
-                    self.inner.non_capacity_evictions.load(Ordering::Relaxed),
-                ),
                 total_capacity: AtomicUsize::new(self.inner.total_capacity.load(Ordering::Relaxed)),
             }),
         }
@@ -338,10 +388,15 @@ where
         let mut hits = 0u64;
         let mut misses = 0u64;
         let mut lru_evictions = 0u64;
+        let mut non_capacity_evictions = 0u64;
         let mut size = 0usize;
         for shard in self.inner.shards.iter() {
             hits += shard.hits.load(Ordering::Relaxed);
             misses += shard.misses.load(Ordering::Relaxed);
+            // Per-shard non-capacity evictions (expiry / removes / retain / clear); the
+            // inner `LruCache` counter below holds this shard's capacity evictions. The two
+            // families are disjoint, so summing them cannot double-count.
+            non_capacity_evictions += shard.evictions.load(Ordering::Relaxed);
             let guard = shard.lock.read();
             if let Some(e) = guard.cache_evictions() {
                 lru_evictions += e;
@@ -351,9 +406,7 @@ where
         CacheMetrics {
             hits: Some(hits),
             misses: Some(misses),
-            evictions: Some(
-                lru_evictions + self.inner.non_capacity_evictions.load(Ordering::Relaxed),
-            ),
+            evictions: Some(lru_evictions + non_capacity_evictions),
             entry_count: Some(size),
             // Acquire, like `capacity()`: a caller that just resized on this thread sees
             // the new total here too, not a stale value alongside a fresh `capacity()`.
@@ -414,18 +467,15 @@ where
         for shard in self.inner.shards.iter() {
             let removed: Vec<(K, TimedEntry<V>)> = {
                 let mut guard = shard.lock.write();
-                let keys: Vec<K> = guard.iter().map(|(k, _)| k.clone()).collect();
-                let mut removed = Vec::with_capacity(keys.len());
-                for k in keys {
-                    if let Some(pair) = guard.pop_raw(&k) {
-                        removed.push(pair);
-                    }
-                }
-                removed
+                // `drain_all` walks each shard's LRU chain once taking owned pairs in
+                // MRU -> LRU order -- the same order the old "clone every key, then
+                // `pop_raw` each one" drain fired in, but with zero key clones and zero
+                // re-hashing.
+                guard.drain_all()
             };
             if !removed.is_empty() {
-                self.inner
-                    .non_capacity_evictions
+                shard
+                    .evictions
                     .fetch_add(removed.len() as u64, Ordering::Relaxed);
                 if let Some(on_evict) = &self.inner.on_evict {
                     for (k, entry) in &removed {
@@ -439,8 +489,8 @@ where
     /// Remove every entry that is TTL-expired **or** for which `keep` returns `false` — expired
     /// entries are removed regardless of `keep`, matching
     /// [`LruTtlCache::retain`](crate::LruTtlCache::retain) semantics. `on_evict` fires (if
-    /// configured) and `metrics().evictions` increments once per removed entry (via
-    /// `non_capacity_evictions`, the same counter used by [`evict`](Self::evict)). The LRU recency
+    /// configured) and `metrics().evictions` increments once per removed entry (via the per-shard
+    /// non-capacity eviction counter, the same one used by [`evict`](Self::evict)). The LRU recency
     /// order of the surviving entries in each shard is unchanged.
     ///
     /// Shards are processed one at a time under their own write lock, so this is **not atomic**
@@ -476,8 +526,8 @@ where
                 removed
             };
             if !removed.is_empty() {
-                self.inner
-                    .non_capacity_evictions
+                shard
+                    .evictions
                     .fetch_add(removed.len() as u64, Ordering::Relaxed);
                 if let Some(on_evict) = &self.inner.on_evict {
                     for (k, entry) in &removed {
@@ -612,8 +662,8 @@ where
 
             total += removed.len();
             if !removed.is_empty() {
-                self.inner
-                    .non_capacity_evictions
+                shard
+                    .evictions
                     .fetch_add(removed.len() as u64, Ordering::Relaxed);
                 if let Some(cb) = &self.inner.on_evict {
                     for (k, entry) in &removed {
@@ -681,7 +731,7 @@ where
                 lru_evictions += e;
             }
         }
-        Some(lru_evictions + self.inner.non_capacity_evictions.load(Ordering::Relaxed))
+        Some(lru_evictions + self.non_capacity_evictions())
     }
 }
 
@@ -726,51 +776,52 @@ where
     fn cache_get(&self, k: &K) -> Result<Option<V>, Self::Error> {
         let shard = self.shard_of(k);
         let refresh = self.inner.refresh.load(Ordering::Relaxed);
+        // One clock sample per operation, taken before the lock: it decides expiry and (when
+        // refreshing) seeds the new `expires_at`, so the critical section contains no
+        // `Instant::now()` syscall at all.
+        let now = Instant::now();
 
         let mut guard = shard.lock.write();
 
-        // Peek first (no LRU promotion) to check expiry before committing recency.
-        // This avoids promoting entries that will be immediately evicted as expired.
-        let expired = match guard.cache_peek(k) {
-            None => {
-                shard.misses.fetch_add(1, Ordering::Relaxed);
-                return Ok(None);
-            }
-            // expired = None (never-expires) -> false; Some(t) -> expired if now >= t
-            Some(entry) => entry.expires_at.is_some_and(|t| Instant::now() >= t),
+        // The common case (a live hit) resolves in a SINGLE hash + probe:
+        // `get_if`/`get_mut_if` promote LRU recency only when the predicate reports the entry
+        // live, so an expired entry is neither promoted nor removed here -- exactly the intent
+        // of the old peek-then-get pair, at half the lookups. `track_hit_miss` is disabled on
+        // the inner `LruCache`, so no counter is touched by this probe.
+        // expired = None (never-expires) -> live; Some(t) -> live while now < t
+        let value = if refresh {
+            guard
+                .get_mut_if(k, |e| e.expires_at.is_none_or(|t| now < t))
+                .map(|e| {
+                    e.expires_at = self.compute_expires_at(now).or(e.expires_at);
+                    e.value.clone()
+                })
+        } else {
+            guard
+                .get_if(k, |e| e.expires_at.is_none_or(|t| now < t))
+                .map(|e| e.value.clone())
         };
-
-        if expired {
-            // Use pop_raw (bypasses on_evict, unlike cache_remove_entry); we fire
-            // on_evict manually below after releasing the shard lock.
-            let removed = guard.pop_raw(k);
+        if let Some(value) = value {
             drop(guard);
-            if let Some((ref ek, ref entry)) = removed {
-                if let Some(cb) = &self.inner.on_evict {
-                    cb(ek, &entry.value);
-                }
-                self.inner
-                    .non_capacity_evictions
-                    .fetch_add(1, Ordering::Relaxed);
-            }
-            shard.misses.fetch_add(1, Ordering::Relaxed);
-            return Ok(None);
+            shard.hits.fetch_add(1, Ordering::Relaxed);
+            return Ok(Some(value));
         }
 
-        // Live hit — update LRU recency and extract value.
-        // Use a single mutable access when refresh is enabled to avoid double
-        // LRU promotion and double-incrementing LruCache's internal hit counter.
-        let value = if refresh {
-            guard.cache_get_mut(k).map(|e| {
-                let now = Instant::now();
-                e.expires_at = self.compute_expires_at(now).or(e.expires_at);
-                e.value.clone()
-            })
-        } else {
-            guard.cache_get(k).map(|e| e.value.clone())
-        };
-        shard.hits.fetch_add(1, Ordering::Relaxed);
-        Ok(value)
+        // Not a live hit: either expired (still stored) or absent. `pop_raw` distinguishes
+        // them -- `Some` means it was expired and is now removed, `None` means absent. This
+        // costs the (rarer) miss path one extra probe to spare every hit one.
+        // `pop_raw` bypasses `on_evict` (unlike `cache_remove_entry`); we fire the callback
+        // manually below, after releasing the shard lock.
+        let removed = guard.pop_raw(k);
+        drop(guard);
+        if let Some((ref ek, ref entry)) = removed {
+            if let Some(cb) = &self.inner.on_evict {
+                cb(ek, &entry.value);
+            }
+            shard.evictions.fetch_add(1, Ordering::Relaxed);
+        }
+        shard.misses.fetch_add(1, Ordering::Relaxed);
+        Ok(None)
     }
 
     fn cache_set(&self, k: K, v: V) -> Result<Option<V>, Self::Error> {
@@ -781,22 +832,22 @@ where
             expires_at,
             value: v,
         };
-        // Capture the displaced entry and evaluate expiry while the write lock is still held
-        // (B2: avoids a TOCTOU where the entry crosses the expiry threshold between unlock and
-        // the check). When an `on_evict` callback is configured, pop-then-set (`pop_raw` is
-        // silent and returns the owned key) so the callback can fire after the lock is released;
-        // otherwise a plain set. The entry count is unchanged, no capacity eviction is triggered.
+        // Capture the displaced entry and evaluate expiry against the `now` sampled above for
+        // this operation (B2: a single sample, taken before the lock, cannot see the entry
+        // cross the expiry threshold part-way through the op). When an `on_evict` callback is
+        // configured we need the *stored* key to hand to it, so the write goes through
+        // `set_entry_promoting` (one lookup, no LRU slot churn, and it restores the MRU
+        // promotion the old pop-then-set got for free); otherwise a plain set. The entry count
+        // is unchanged, no capacity eviction is triggered.
         let old: Option<(Option<K>, TimedEntry<V>, bool)> = if self.inner.on_evict.is_some() {
             let mut guard = shard.lock.write();
-            let removed = guard.pop_raw(&k);
-            guard.cache_set(k, new_entry);
-            removed.map(|(ok, e)| {
-                let expired = e.expires_at.is_some_and(|t| Instant::now() >= t);
+            set_entry_promoting(&mut guard, k, new_entry).map(|(ok, e)| {
+                let expired = e.expires_at.is_some_and(|t| now >= t);
                 (Some(ok), e, expired)
             })
         } else {
             shard.lock.write().cache_set(k, new_entry).map(|e| {
-                let expired = e.expires_at.is_some_and(|t| Instant::now() >= t);
+                let expired = e.expires_at.is_some_and(|t| now >= t);
                 (None, e, expired)
             })
         };
@@ -807,9 +858,7 @@ where
                 if let (Some(on_evict), Some(key)) = (&self.inner.on_evict, &key) {
                     on_evict(key, &entry.value);
                 }
-                self.inner
-                    .non_capacity_evictions
-                    .fetch_add(1, Ordering::Relaxed);
+                shard.evictions.fetch_add(1, Ordering::Relaxed);
                 Ok(None)
             }
             Some((_, entry, false)) => Ok(Some(entry.value)),
@@ -821,9 +870,7 @@ where
         let shard = self.shard_of(k);
         let removed = shard.lock.write().pop_raw(k);
         if let Some((key, entry)) = removed {
-            self.inner
-                .non_capacity_evictions
-                .fetch_add(1, Ordering::Relaxed);
+            shard.evictions.fetch_add(1, Ordering::Relaxed);
             if let Some(on_evict) = &self.inner.on_evict {
                 on_evict(&key, &entry.value);
             }
@@ -841,9 +888,7 @@ where
         let shard = self.shard_of(k);
         let removed = shard.lock.write().pop_raw(k);
         if let Some((ref stored_k, ref entry)) = removed {
-            self.inner
-                .non_capacity_evictions
-                .fetch_add(1, Ordering::Relaxed);
+            shard.evictions.fetch_add(1, Ordering::Relaxed);
             if let Some(on_evict) = &self.inner.on_evict {
                 on_evict(stored_k, &entry.value);
             }
@@ -865,12 +910,11 @@ where
         for shard in self.inner.shards.iter() {
             shard.hits.store(0, Ordering::Relaxed);
             shard.misses.store(0, Ordering::Relaxed);
+            // The shard's non-capacity eviction counter (expiry / removes / retain / clear).
+            shard.evictions.store(0, Ordering::Relaxed);
             // Zero the per-shard inner store's metrics, including its LRU capacity-eviction counter.
             shard.lock.write().cache_reset_metrics();
         }
-        self.inner
-            .non_capacity_evictions
-            .store(0, Ordering::Relaxed);
         Ok(())
     }
 
@@ -1231,7 +1275,6 @@ impl<K, V, H> ShardedLruTtlCacheBuilder<K, V, NoEvict, H> {
                 on_evict: None,
                 ttl_nanos: AtomicU64::new(encode_ttl(ttl)),
                 refresh: AtomicBool::new(self.refresh),
-                non_capacity_evictions: AtomicU64::new(0),
                 total_capacity: AtomicUsize::new(total_cap),
             }),
         })
@@ -1326,7 +1369,6 @@ impl<K, V, H> ShardedLruTtlCacheBuilder<K, V, HasEvict, H> {
                 on_evict: self.on_evict,
                 ttl_nanos: AtomicU64::new(encode_ttl(ttl)),
                 refresh: AtomicBool::new(self.refresh),
-                non_capacity_evictions: AtomicU64::new(0),
                 total_capacity: AtomicUsize::new(total_cap),
             }),
         })
@@ -1408,6 +1450,8 @@ where
     fn cache_get_with_expiry_status(&self, k: &K) -> (Option<V>, bool) {
         let shard = self.shard_of(k);
         let refresh = self.inner.refresh.load(Ordering::Relaxed);
+        // One clock sample per operation, taken before the lock (see `cache_get`).
+        let now = Instant::now();
         let mut guard = shard.lock.write();
         // Common case (live hit) in a single lookup: `get_if`/`get_mut_if` promote LRU
         // recency only when the predicate reports the entry live, and leave it in place
@@ -1415,15 +1459,14 @@ where
         // case then takes one extra peek to recover the stale value without removing it.
         let live = if refresh {
             guard
-                .get_mut_if(k, |e| e.expires_at.is_none_or(|t| Instant::now() < t))
+                .get_mut_if(k, |e| e.expires_at.is_none_or(|t| now < t))
                 .map(|e| {
-                    let now = Instant::now();
                     e.expires_at = self.compute_expires_at(now).or(e.expires_at);
                     e.value.clone()
                 })
         } else {
             guard
-                .get_if(k, |e| e.expires_at.is_none_or(|t| Instant::now() < t))
+                .get_if(k, |e| e.expires_at.is_none_or(|t| now < t))
                 .map(|e| e.value.clone())
         };
         if let Some(value) = live {
@@ -2585,8 +2628,9 @@ mod tests {
     }
 
     /// Counter-wiring contract (the main correctness trap for this store): `retain` must
-    /// bump `LruTtlInner::non_capacity_evictions`, NOT the inner `LruCache`'s own
-    /// capacity-eviction counter (`guard.evictions`), which `evict()` also leaves untouched.
+    /// bump the per-shard non-capacity eviction counter (`Shard::evictions`), NOT the inner
+    /// `LruCache`'s own capacity-eviction counter (`guard.evictions`), which `evict()` also
+    /// leaves untouched.
     #[test]
     fn retain_wires_to_non_capacity_evictions_not_inner_lru_counter() {
         let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
@@ -2603,7 +2647,7 @@ mod tests {
             .read()
             .evictions
             .load(Ordering::Relaxed);
-        let outer_before = c.inner.non_capacity_evictions.load(Ordering::Relaxed);
+        let outer_before = c.non_capacity_evictions();
 
         c.retain(|k, _| k % 2 == 0);
 
@@ -2612,7 +2656,7 @@ mod tests {
             .read()
             .evictions
             .load(Ordering::Relaxed);
-        let outer_after = c.inner.non_capacity_evictions.load(Ordering::Relaxed);
+        let outer_after = c.non_capacity_evictions();
 
         assert_eq!(
             inner_after, inner_before,
@@ -2679,5 +2723,432 @@ mod tests {
             "an entry whose expires_at is the just-sampled now must be swept by retain() too, \
              even under a keep-everything predicate"
         );
+    }
+
+    // --- single-lookup `cache_get`, per-shard eviction counters, and the recency trap ---
+
+    /// Raw per-shard non-capacity eviction counters, in shard order.
+    fn shard_eviction_counters<K, V, H>(c: &ShardedLruTtlCacheBase<K, V, H>) -> Vec<u64> {
+        c.inner
+            .shards
+            .iter()
+            .map(|s| s.evictions.load(Ordering::Relaxed))
+            .collect()
+    }
+
+    /// Index of the shard that owns `k`.
+    fn owning_shard<K, V, H: ShardHasher<K>>(c: &ShardedLruTtlCacheBase<K, V, H>, k: &K) -> usize {
+        shard_index(c.inner.hasher.shard_hash(k), c.inner.shard_mask)
+    }
+
+    /// Keys of one shard in MRU -> LRU order.
+    fn shard_key_order<K: Clone + Hash + Eq, V: Clone, H>(
+        c: &ShardedLruTtlCacheBase<K, V, H>,
+        shard: usize,
+    ) -> Vec<K> {
+        c.inner.shards[shard]
+            .lock
+            .read()
+            .iter_order_raw()
+            .into_iter()
+            .map(|(k, _)| k)
+            .collect()
+    }
+
+    /// `cache_get` resolves a live hit in a single hash + probe (`get_if`) and falls through to
+    /// `pop_raw` only when that probe fails. All four outcomes must keep their old semantics:
+    /// live hit -> value + hit; absent -> None + miss, nothing removed; expired -> None + miss,
+    /// entry removed, one eviction counted, `on_evict` fired with the stored key.
+    #[test]
+    fn cache_get_single_lookup_keeps_hit_miss_expired_and_absent_semantics() {
+        use std::sync::Mutex;
+        let seen: Arc<Mutex<Vec<(u32, u32)>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen2 = Arc::clone(&seen);
+        let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
+            .shards(1)
+            .max_size(8)
+            .ttl(Duration::from_millis(20))
+            .on_evict(move |k: &u32, v: &u32| seen2.lock().unwrap().push((*k, *v)))
+            .build()
+            .unwrap();
+
+        // Live hit.
+        SyncConcurrentCached::cache_set(&c, 1, 10).expect("insert must succeed");
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &1).unwrap(), Some(10));
+        assert_eq!(c.metrics().hits, Some(1));
+        assert_eq!(c.metrics().misses, Some(0));
+        assert_eq!(c.len(), 1, "a live hit must not remove anything");
+
+        // Absent key: a miss, and the fall-through `pop_raw` must remove nothing.
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &404).unwrap(), None);
+        assert_eq!(c.metrics().hits, Some(1));
+        assert_eq!(c.metrics().misses, Some(1));
+        assert_eq!(c.len(), 1);
+        assert!(seen.lock().unwrap().is_empty(), "no eviction yet");
+        let evictions_before = c.metrics().evictions.expect("evictions tracked");
+
+        // Expired key: a miss, removed from the store, counted, callback fired.
+        std::thread::sleep(std::time::Duration::from_millis(60));
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &1).unwrap(), None);
+        assert_eq!(c.metrics().hits, Some(1));
+        assert_eq!(c.metrics().misses, Some(2));
+        assert_eq!(c.len(), 0, "the expired entry must be removed on access");
+        assert_eq!(*seen.lock().unwrap(), vec![(1, 10)]);
+        assert_eq!(
+            c.metrics().evictions.expect("evictions tracked") - evictions_before,
+            1,
+            "lazy expiry must count exactly one eviction"
+        );
+        // A second read of the now-absent key is a plain miss with no extra eviction.
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &1).unwrap(), None);
+        assert_eq!(c.metrics().misses, Some(3));
+        assert_eq!(
+            c.metrics().evictions.expect("evictions tracked") - evictions_before,
+            1
+        );
+    }
+
+    /// The single-lookup path must still promote what it reads: `get_if`/`get_mut_if` move the
+    /// entry to MRU when (and only when) the predicate reports it live. Checked directly on the
+    /// recency chain and through the capacity eviction it decides, with and without
+    /// `refresh_on_hit`.
+    #[test]
+    fn cache_get_promotes_recency_through_the_single_lookup_path() {
+        for refresh in [false, true] {
+            let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
+                .shards(1)
+                .max_size(2)
+                .ttl(Duration::from_secs(3600))
+                .refresh_on_hit(refresh)
+                .build()
+                .unwrap();
+            SyncConcurrentCached::cache_set(&c, 1, 10).expect("insert must succeed");
+            SyncConcurrentCached::cache_set(&c, 2, 20).expect("insert must succeed");
+            assert_eq!(shard_key_order(&c, 0), vec![2, 1]);
+
+            assert_eq!(SyncConcurrentCached::cache_get(&c, &1).unwrap(), Some(10));
+            assert_eq!(
+                shard_key_order(&c, 0),
+                vec![1, 2],
+                "refresh_on_hit={refresh}: a live read must promote the entry to MRU"
+            );
+
+            // ... so the next capacity eviction claims key 2, not the just-read key 1.
+            SyncConcurrentCached::cache_set(&c, 3, 30).expect("insert must succeed");
+            assert!(SyncConcurrentCached::cache_contains(&c, &1).unwrap());
+            assert!(!SyncConcurrentCached::cache_contains(&c, &2).unwrap());
+        }
+    }
+
+    /// With `refresh_on_hit`, the live-hit probe is `get_mut_if` and must still renew the
+    /// entry's expiry from the operation's single clock sample.
+    ///
+    /// The timings leave a wide margin (300 ms TTL vs 100 ms between hits) so a loaded
+    /// machine oversleeping a gap cannot make the entry expire mid-loop; the total elapsed
+    /// time still exceeds the TTL several times over, so a *missing* refresh fails the loop.
+    #[test]
+    fn cache_get_refreshes_expiry_through_the_single_lookup_path() {
+        let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
+            .shards(1)
+            .max_size(8)
+            .ttl(Duration::from_millis(300))
+            .refresh_on_hit(true)
+            .build()
+            .unwrap();
+        SyncConcurrentCached::cache_set(&c, 1, 10).expect("insert must succeed");
+        for _ in 0..5 {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            assert_eq!(
+                SyncConcurrentCached::cache_get(&c, &1).unwrap(),
+                Some(10),
+                "each hit must push the expiry out, so the entry never expires"
+            );
+        }
+        std::thread::sleep(std::time::Duration::from_millis(600));
+        assert_eq!(
+            SyncConcurrentCached::cache_get(&c, &1).unwrap(),
+            None,
+            "without a hit the refreshed expiry must still elapse"
+        );
+    }
+
+    /// THE RECENCY TRAP. `cache_set` with an `on_evict` callback no longer does
+    /// `pop_raw` + `cache_set` (two lookups plus LRU slab churn) to recover the stored key --
+    /// it uses `set_entry_promoting`. The removed pop-then-insert promoted the overwritten
+    /// entry to MRU for free (the re-insert went through `push_front`); a plain in-place
+    /// `order.set` (i.e. `cache_set_returning_entry`) does NOT. This test fails if that
+    /// promotion is dropped.
+    #[test]
+    fn cache_set_with_on_evict_promotes_overwritten_entry_to_mru() {
+        let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
+            .shards(1)
+            .max_size(2)
+            .ttl(Duration::from_secs(3600))
+            .on_evict(|_, _| {})
+            .build()
+            .unwrap();
+        SyncConcurrentCached::cache_set(&c, 1, 10).expect("insert must succeed");
+        SyncConcurrentCached::cache_set(&c, 2, 20).expect("insert must succeed");
+        assert_eq!(shard_key_order(&c, 0), vec![2, 1]);
+
+        // Overwrite the LRU entry: it must come back as MRU, and return the old value.
+        assert_eq!(
+            SyncConcurrentCached::cache_set(&c, 1, 11).unwrap(),
+            Some(10),
+            "overwrite must return the displaced live value"
+        );
+        assert_eq!(
+            shard_key_order(&c, 0),
+            vec![1, 2],
+            "overwriting an entry must promote it to MRU (as pop-then-insert did)"
+        );
+        assert_eq!(c.len(), 2, "an overwrite must not change the entry count");
+
+        // The promotion decides the next capacity eviction victim.
+        SyncConcurrentCached::cache_set(&c, 3, 30).expect("insert must succeed");
+        assert_eq!(
+            SyncConcurrentCached::cache_get(&c, &1).unwrap(),
+            Some(11),
+            "the promoted (overwritten) entry must survive the capacity eviction"
+        );
+        assert!(!SyncConcurrentCached::cache_contains(&c, &2).unwrap());
+    }
+
+    /// The `on_evict`-free `cache_set` path is a plain `LruCache::cache_set`, which replaces
+    /// in place and does **not** promote. That asymmetry predates the single-lookup rewrite;
+    /// this pins it so the two paths are not silently unified in either direction.
+    #[test]
+    fn cache_set_without_on_evict_does_not_promote_overwritten_entry() {
+        let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
+            .shards(1)
+            .max_size(2)
+            .ttl(Duration::from_secs(3600))
+            .build()
+            .unwrap();
+        SyncConcurrentCached::cache_set(&c, 1, 10).expect("insert must succeed");
+        SyncConcurrentCached::cache_set(&c, 2, 20).expect("insert must succeed");
+        assert_eq!(
+            SyncConcurrentCached::cache_set(&c, 1, 11).unwrap(),
+            Some(10)
+        );
+        assert_eq!(
+            shard_key_order(&c, 0),
+            vec![2, 1],
+            "without on_evict, an overwrite replaces in place and does not promote"
+        );
+    }
+
+    /// Every non-capacity eviction is counted on the shard that owns the key, and `metrics()`
+    /// aggregates the per-shard counters together with the inner LRU capacity counters without
+    /// double-counting.
+    #[test]
+    fn every_eviction_path_counts_on_the_owning_shard() {
+        let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
+            .shards(8)
+            .per_shard_max_size(8)
+            .ttl(Duration::from_millis(20))
+            .build()
+            .unwrap();
+        let mut expected = vec![0u64; 8];
+
+        // 1) Lazy expiry through cache_get.
+        SyncConcurrentCached::cache_set(&c, 1, 10).expect("insert must succeed");
+        std::thread::sleep(std::time::Duration::from_millis(60));
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &1).unwrap(), None);
+        expected[owning_shard(&c, &1)] += 1;
+        assert_eq!(
+            shard_eviction_counters(&c),
+            expected,
+            "cache_get lazy expiry"
+        );
+
+        // 2) cache_remove.
+        SyncConcurrentCached::cache_set(&c, 2, 20).expect("insert must succeed");
+        assert_eq!(
+            SyncConcurrentCached::cache_remove(&c, &2).unwrap(),
+            Some(20)
+        );
+        expected[owning_shard(&c, &2)] += 1;
+        assert_eq!(shard_eviction_counters(&c), expected, "cache_remove");
+
+        // 3) cache_remove_entry.
+        SyncConcurrentCached::cache_set(&c, 3, 30).expect("insert must succeed");
+        assert_eq!(
+            SyncConcurrentCached::cache_remove_entry(&c, &3).unwrap(),
+            Some((3, 30))
+        );
+        expected[owning_shard(&c, &3)] += 1;
+        assert_eq!(shard_eviction_counters(&c), expected, "cache_remove_entry");
+
+        // 4) cache_set displacing an expired entry.
+        SyncConcurrentCached::cache_set(&c, 4, 40).expect("insert must succeed");
+        std::thread::sleep(std::time::Duration::from_millis(60));
+        assert_eq!(SyncConcurrentCached::cache_set(&c, 4, 41).unwrap(), None);
+        expected[owning_shard(&c, &4)] += 1;
+        assert_eq!(
+            shard_eviction_counters(&c),
+            expected,
+            "cache_set over expired"
+        );
+
+        // 5) evict() sweeps key 4 (re-set above) and key 5, both expired by now.
+        SyncConcurrentCached::cache_set(&c, 5, 50).expect("insert must succeed");
+        std::thread::sleep(std::time::Duration::from_millis(60));
+        assert_eq!(c.evict(), 2, "both stored entries are expired");
+        expected[owning_shard(&c, &4)] += 1;
+        expected[owning_shard(&c, &5)] += 1;
+        assert_eq!(shard_eviction_counters(&c), expected, "evict");
+
+        // 6) retain().
+        SyncConcurrentCached::cache_set(&c, 6, 60).expect("insert must succeed");
+        c.retain(|_k, _v| false);
+        expected[owning_shard(&c, &6)] += 1;
+        assert_eq!(shard_eviction_counters(&c), expected, "retain");
+
+        // 7) cache_clear_with_on_evict().
+        SyncConcurrentCached::cache_set(&c, 7, 70).expect("insert must succeed");
+        c.cache_clear_with_on_evict();
+        expected[owning_shard(&c, &7)] += 1;
+        assert_eq!(
+            shard_eviction_counters(&c),
+            expected,
+            "cache_clear_with_on_evict"
+        );
+
+        // The aggregate matches the sum of the per-shard counters exactly: no capacity
+        // eviction has happened yet, so nothing else contributes.
+        let total: u64 = expected.iter().sum();
+        assert_eq!(c.metrics().evictions, Some(total));
+        assert_eq!(ConcurrentCacheBase::cache_evictions(&c), Some(total));
+
+        // 8) Capacity evictions stay in the inner per-shard LruCache counter (the other half
+        //    of the split) and are added on top by metrics().
+        let victims: Vec<u32> = (0..1000u32)
+            .filter(|i| owning_shard(&c, i) == 0)
+            .take(20)
+            .collect();
+        assert_eq!(victims.len(), 20, "need 20 keys landing on shard 0");
+        for k in &victims {
+            SyncConcurrentCached::cache_set(&c, *k, *k).expect("insert must succeed");
+        }
+        let capacity_evictions = victims.len() as u64 - 8;
+        assert!(
+            capacity_evictions > 0,
+            "the test must actually overflow one shard's capacity"
+        );
+        assert_eq!(
+            shard_eviction_counters(&c),
+            expected,
+            "capacity evictions must NOT touch the non-capacity counters"
+        );
+        assert_eq!(
+            c.metrics().evictions,
+            Some(total + capacity_evictions),
+            "metrics() must sum capacity and non-capacity evictions without double counting"
+        );
+
+        // cache_reset_metrics zeroes both families.
+        ConcurrentCached::cache_reset_metrics(&c).unwrap();
+        assert_eq!(shard_eviction_counters(&c), vec![0u64; 8]);
+        assert_eq!(c.metrics().evictions, Some(0));
+    }
+
+    /// `deep_clone` used to copy one process-wide eviction counter; with the counters
+    /// per-shard it must copy each shard's, so the clone reports the same totals.
+    #[test]
+    fn deep_clone_preserves_per_shard_eviction_counts() {
+        let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
+            .shards(4)
+            .per_shard_max_size(4)
+            .ttl(Duration::from_secs(3600))
+            .build()
+            .unwrap();
+        for i in 0..8u32 {
+            SyncConcurrentCached::cache_set(&c, i, i).expect("insert must succeed");
+        }
+        // Non-capacity evictions (explicit removes) plus capacity evictions from overfilling.
+        for i in 0..4u32 {
+            let _ = SyncConcurrentCached::cache_remove(&c, &i).unwrap();
+        }
+        for i in 100..140u32 {
+            SyncConcurrentCached::cache_set(&c, i, i).expect("insert must succeed");
+        }
+        let before = c.metrics().evictions.expect("evictions tracked");
+        assert!(before >= 4, "the fixture must produce evictions");
+        let per_shard_before = shard_eviction_counters(&c);
+        assert_eq!(per_shard_before.iter().sum::<u64>(), 4);
+
+        let cloned = c.deep_clone();
+        assert_eq!(
+            shard_eviction_counters(&cloned),
+            per_shard_before,
+            "each shard's non-capacity counter must carry across a deep_clone"
+        );
+        assert_eq!(
+            cloned.metrics().evictions,
+            Some(before),
+            "the clone must report the same eviction total"
+        );
+
+        // The clone is independent: further evictions on it do not touch the source.
+        SyncConcurrentCached::cache_set(&cloned, 999, 999).expect("insert must succeed");
+        assert_eq!(
+            SyncConcurrentCached::cache_remove(&cloned, &999).unwrap(),
+            Some(999)
+        );
+        assert_eq!(
+            shard_eviction_counters(&cloned).iter().sum::<u64>(),
+            5,
+            "the explicit remove must count on the clone's own shard counter"
+        );
+        assert_eq!(
+            shard_eviction_counters(&c),
+            per_shard_before,
+            "the source's per-shard counters must be untouched by the clone"
+        );
+        assert_eq!(
+            c.metrics().evictions,
+            Some(before),
+            "the source's totals must be untouched by the clone"
+        );
+    }
+
+    /// `cache_clear_with_on_evict` drains each shard with `LruCache::drain_all` (no key clones,
+    /// no re-hashing); the callbacks must still arrive most-recently-used first, per shard.
+    #[test]
+    fn cache_clear_with_on_evict_fires_mru_to_lru_per_shard() {
+        use std::sync::Mutex;
+        let seen: Arc<Mutex<Vec<u32>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen2 = Arc::clone(&seen);
+        let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
+            .shards(1)
+            .max_size(64)
+            .ttl(Duration::from_secs(3600))
+            .on_evict(move |k: &u32, _v: &u32| seen2.lock().unwrap().push(*k))
+            .build()
+            .unwrap();
+        for i in 0..6u32 {
+            SyncConcurrentCached::cache_set(&c, i, i).expect("insert must succeed");
+        }
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &0).unwrap(), Some(0));
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &2).unwrap(), Some(2));
+        let expected = shard_key_order(&c, 0);
+        assert_eq!(
+            expected,
+            vec![2, 0, 5, 4, 3, 1],
+            "precondition: MRU -> LRU chain after the two re-reads"
+        );
+
+        c.cache_clear_with_on_evict();
+
+        assert_eq!(
+            *seen.lock().unwrap(),
+            expected,
+            "on_evict must fire in MRU -> LRU order"
+        );
+        assert!(c.is_empty());
+        // The drained shard stays usable.
+        SyncConcurrentCached::cache_set(&c, 42, 42).expect("insert must succeed");
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &42).unwrap(), Some(42));
     }
 }

--- a/src/stores/sharded/mod.rs
+++ b/src/stores/sharded/mod.rs
@@ -1,4 +1,5 @@
 use std::sync::atomic::AtomicU64;
+use std::sync::OnceLock;
 
 use crate::stores::BuildError;
 
@@ -41,6 +42,13 @@ pub(crate) struct Shard<S> {
     pub lock: parking_lot::RwLock<S>,
     pub hits: AtomicU64,
     pub misses: AtomicU64,
+    /// Per-shard eviction count. Co-located with `hits`/`misses` for the same reason:
+    /// a thread bumping this has just taken `lock`, so it already owns this cache line
+    /// exclusively. Consuming stores that currently keep a single process-wide
+    /// `evictions: AtomicU64` in `Arc<Inner>` (contended from every core, and sharing a
+    /// cache line with fields read on every op) should migrate to summing this field
+    /// across shards instead.
+    pub evictions: AtomicU64,
 }
 
 impl<S> Shard<S> {
@@ -49,19 +57,46 @@ impl<S> Shard<S> {
             lock: parking_lot::RwLock::new(store),
             hits: AtomicU64::new(0),
             misses: AtomicU64::new(0),
+            evictions: AtomicU64::new(0),
         }
     }
 }
 
 pub(crate) fn default_shard_count() -> usize {
-    let count = std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(4)
-        .saturating_mul(4);
-    // `clamp(8, 1024)` bounds the input to [8, 1024]; 1024 is itself a power of two, so
-    // `next_power_of_two()` returns at most 1024 and can never overflow. (The user-supplied
-    // path in `checked_shard_count` has no upper bound, so it uses `checked_next_power_of_two`.)
-    count.clamp(8, 1024).next_power_of_two()
+    static DEFAULT_SHARD_COUNT: OnceLock<usize> = OnceLock::new();
+    *DEFAULT_SHARD_COUNT.get_or_init(|| {
+        let count = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(4)
+            .saturating_mul(4);
+        // `clamp(8, 1024)` bounds the input to [8, 1024]; 1024 is itself a power of two, so
+        // `next_power_of_two()` returns at most 1024 and can never overflow. (The user-supplied
+        // path in `checked_shard_count` has no upper bound, so it uses `checked_next_power_of_two`.)
+        count.clamp(8, 1024).next_power_of_two()
+    })
+}
+
+/// Default shard count for the *default* (unconfigured) shard-count path, scaled down for
+/// small `max_size` values.
+///
+/// Without this, the default shard count is `available_parallelism() * 4` clamped to
+/// `[8, 1024]`, with no reference to `max_size` at all. Combined with the 16-entries-per-shard
+/// floor in [`per_shard_cap_from_total`] and eager per-shard allocation, `ShardedLruCache::new(100)`
+/// on a 64-core box would build 256 shards x 16 = 4096 effective capacity, preallocating 256
+/// hash tables plus 256 `Vec`s for a cache asked to hold only 100 entries.
+///
+/// This helper caps the shard count so that, for a bounded cache, each shard gets roughly
+/// `max_size / 16` capacity (rounded up to a power of two), never exceeding
+/// [`default_shard_count`] and never going below 1.
+///
+/// An explicit `.shards(n)` on a builder remains authoritative; this helper is only consulted
+/// on the *default* (no explicit shard count given) path.
+#[allow(dead_code)] // consumed by sibling shards migrating their builders' default path
+pub(crate) fn default_shard_count_for_capacity(max_size: Option<usize>) -> usize {
+    match max_size {
+        Some(n) => (n / 16).next_power_of_two().clamp(1, default_shard_count()),
+        None => default_shard_count(),
+    }
 }
 
 /// Compute the per-shard capacity for a given total and shard count, applying the
@@ -293,5 +328,69 @@ mod tests {
     fn check_shard_hasher_supertrait() {
         // DefaultShardHasher derives Clone, so it satisfies the bound.
         assert_shard_hasher_requires_clone(DefaultShardHasher::new());
+    }
+
+    #[test]
+    fn shard_has_evictions_counter_initialized_to_zero() {
+        let shard = Shard::new(0u32);
+        assert_eq!(shard.evictions.load(std::sync::atomic::Ordering::Relaxed), 0);
+        shard.evictions.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(shard.evictions.load(std::sync::atomic::Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn default_shard_count_is_stable_across_calls() {
+        // `default_shard_count` caches its result in a `OnceLock`; repeated calls
+        // must return the exact same value (process-stable), and it must always
+        // land in the documented [8, 1024] power-of-two range.
+        let first = default_shard_count();
+        let second = default_shard_count();
+        assert_eq!(first, second);
+        assert!((8..=1024).contains(&first));
+        assert!(first.is_power_of_two());
+    }
+
+    #[test]
+    fn default_shard_count_for_capacity_none_matches_default() {
+        assert_eq!(default_shard_count_for_capacity(None), default_shard_count());
+    }
+
+    #[test]
+    fn default_shard_count_for_capacity_small_sizes_floor_to_one() {
+        // n/16 == 0 for n in [0, 15], and next_power_of_two(0) == 1 (not 0), so the
+        // clamp lower bound of 1 is what actually saves us here -- confirm it does.
+        assert_eq!(default_shard_count_for_capacity(Some(1)), 1);
+        assert_eq!(default_shard_count_for_capacity(Some(15)), 1);
+        // 16/16 == 1, next_power_of_two(1) == 1.
+        assert_eq!(default_shard_count_for_capacity(Some(16)), 1);
+        // 17/16 == 1 (integer division truncates), next_power_of_two(1) == 1.
+        assert_eq!(default_shard_count_for_capacity(Some(17)), 1);
+    }
+
+    #[test]
+    fn default_shard_count_for_capacity_scales_with_size() {
+        // 100/16 == 6, next_power_of_two(6) == 8, and 8 <= default_shard_count()
+        // (whose minimum is 8), so the clamp never kicks in here.
+        assert_eq!(default_shard_count_for_capacity(Some(100)), 8);
+    }
+
+    #[test]
+    fn default_shard_count_for_capacity_clamps_at_max() {
+        // usize::MAX / 16 is huge; next_power_of_two() of that is still hugely larger
+        // than default_shard_count()'s max of 1024, so the upper clamp bound applies
+        // and the result equals default_shard_count() exactly.
+        assert_eq!(
+            default_shard_count_for_capacity(Some(usize::MAX)),
+            default_shard_count()
+        );
+    }
+
+    #[test]
+    fn default_shard_count_for_capacity_never_overflows_or_returns_zero() {
+        for n in [0usize, 1, 15, 16, 17, 100, usize::MAX] {
+            let result = default_shard_count_for_capacity(Some(n));
+            assert!(result >= 1, "result for {n} was 0");
+            assert!(result <= default_shard_count());
+        }
     }
 }

--- a/src/stores/sharded/mod.rs
+++ b/src/stores/sharded/mod.rs
@@ -85,9 +85,10 @@ pub(crate) fn default_shard_count() -> usize {
 /// on a 64-core box would build 256 shards x 16 = 4096 effective capacity, preallocating 256
 /// hash tables plus 256 `Vec`s for a cache asked to hold only 100 entries.
 ///
-/// This helper caps the shard count so that, for a bounded cache, each shard gets roughly
-/// `max_size / 16` capacity (rounded up to a power of two), never exceeding
-/// [`default_shard_count`] and never going below 1.
+/// This helper caps the shard count itself to roughly `max_size / 16` (rounded up to a power
+/// of two), never exceeding [`default_shard_count`] and never going below 1, so that a bounded
+/// cache ends up with each shard holding roughly 16 entries rather than 16 entries times an
+/// oversized shard count.
 ///
 /// An explicit `.shards(n)` on a builder remains authoritative; this helper is only consulted
 /// on the *default* (no explicit shard count given) path.

--- a/src/stores/sharded/mod.rs
+++ b/src/stores/sharded/mod.rs
@@ -1,5 +1,5 @@
-use std::sync::atomic::AtomicU64;
 use std::sync::OnceLock;
+use std::sync::atomic::AtomicU64;
 
 use crate::stores::BuildError;
 
@@ -333,9 +333,17 @@ mod tests {
     #[test]
     fn shard_has_evictions_counter_initialized_to_zero() {
         let shard = Shard::new(0u32);
-        assert_eq!(shard.evictions.load(std::sync::atomic::Ordering::Relaxed), 0);
-        shard.evictions.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        assert_eq!(shard.evictions.load(std::sync::atomic::Ordering::Relaxed), 1);
+        assert_eq!(
+            shard.evictions.load(std::sync::atomic::Ordering::Relaxed),
+            0
+        );
+        shard
+            .evictions
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            shard.evictions.load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
     }
 
     #[test]
@@ -352,7 +360,10 @@ mod tests {
 
     #[test]
     fn default_shard_count_for_capacity_none_matches_default() {
-        assert_eq!(default_shard_count_for_capacity(None), default_shard_count());
+        assert_eq!(
+            default_shard_count_for_capacity(None),
+            default_shard_count()
+        );
     }
 
     #[test]

--- a/src/stores/sharded/ttl.rs
+++ b/src/stores/sharded/ttl.rs
@@ -199,6 +199,7 @@ impl<K: Clone + Hash + Eq, V: Clone, H: ShardHasher<K>> ShardedTtlCacheBase<K, V
                     lock: parking_lot::RwLock::new(store_copy),
                     hits: AtomicU64::new(hits),
                     misses: AtomicU64::new(misses),
+                    evictions: AtomicU64::new(0),
                 };
                 CachePadded(shard)
             })

--- a/src/stores/sharded/ttl.rs
+++ b/src/stores/sharded/ttl.rs
@@ -38,7 +38,17 @@ struct TtlInner<K, V, H> {
     /// `ttl_set` flag. `unset_ttl`/`set_ttl(0)` store `0`; `set_ttl(nonzero)` stores the ttl.
     ttl_nanos: AtomicU64,
     refresh: AtomicBool,
-    evictions: AtomicU64,
+}
+
+/// Judge a stored entry's expiry against an already-sampled instant.
+///
+/// `expires_at = None` means never-expires (TTL was disabled at insert time); otherwise the
+/// entry is expired when `now >= expires_at`. Callers sample the clock **once** per operation
+/// and thread that instant through, so every entry a single call inspects is judged against
+/// the same instant (the discipline `evict`/`retain` already followed).
+#[inline]
+fn expired_at<V>(entry: &TimedEntry<V>, now: Instant) -> bool {
+    entry.expires_at.is_some_and(|t| now >= t)
 }
 
 /// A fully-concurrent, partitioned, TTL-bounded in-memory cache.
@@ -157,11 +167,7 @@ where
 
     #[inline]
     fn is_expired(&self, entry: &TimedEntry<V>) -> bool {
-        // `expires_at = None` means never-expires (TTL was disabled at insert time).
-        match entry.expires_at {
-            None => false,
-            Some(t) => Instant::now() >= t,
-        }
+        expired_at(entry, Instant::now())
     }
 
     /// Compute the expiry instant for a new or refreshed entry given the current TTL.
@@ -194,12 +200,13 @@ impl<K: Clone + Hash + Eq, V: Clone, H: ShardHasher<K>> ShardedTtlCacheBase<K, V
                 let store_copy = guard.clone();
                 let hits = self.inner.shards[i].hits.load(Ordering::Relaxed);
                 let misses = self.inner.shards[i].misses.load(Ordering::Relaxed);
+                let evictions = self.inner.shards[i].evictions.load(Ordering::Relaxed);
                 drop(guard);
                 let shard = Shard {
                     lock: parking_lot::RwLock::new(store_copy),
                     hits: AtomicU64::new(hits),
                     misses: AtomicU64::new(misses),
-                    evictions: AtomicU64::new(0),
+                    evictions: AtomicU64::new(evictions),
                 };
                 CachePadded(shard)
             })
@@ -213,7 +220,6 @@ impl<K: Clone + Hash + Eq, V: Clone, H: ShardHasher<K>> ShardedTtlCacheBase<K, V
                 on_evict: self.inner.on_evict.clone(),
                 ttl_nanos: AtomicU64::new(self.inner.ttl_nanos.load(Ordering::Relaxed)),
                 refresh: AtomicBool::new(self.inner.refresh.load(Ordering::Relaxed)),
-                evictions: AtomicU64::new(self.inner.evictions.load(Ordering::Relaxed)),
             }),
         }
     }
@@ -318,16 +324,20 @@ where
     pub fn metrics(&self) -> CacheMetrics {
         let mut hits = 0u64;
         let mut misses = 0u64;
+        let mut evictions = 0u64;
         let mut size = 0usize;
         for shard in self.inner.shards.iter() {
             hits += shard.hits.load(Ordering::Relaxed);
             misses += shard.misses.load(Ordering::Relaxed);
+            // Evictions are counted per shard (the counter lives on the same cache line the
+            // evicting thread already owns) and summed here, exactly like hits/misses.
+            evictions += shard.evictions.load(Ordering::Relaxed);
             size += shard.lock.read().len();
         }
         CacheMetrics {
             hits: Some(hits),
             misses: Some(misses),
-            evictions: Some(self.inner.evictions.load(Ordering::Relaxed)),
+            evictions: Some(evictions),
             entry_count: Some(size),
             capacity: None,
         }
@@ -376,16 +386,30 @@ where
     /// (`metrics().evictions`) whether or not an `on_evict` callback is configured; the callback
     /// fires only when one is set.
     pub fn cache_clear_with_on_evict(&self) {
+        let Some(on_evict) = &self.inner.on_evict else {
+            // No callback: only the removed *count* is observable, so clear each shard in
+            // place instead of draining every entry into a `Vec` just to drop it.
+            for shard in self.inner.shards.iter() {
+                let removed = {
+                    let mut guard = shard.lock.write();
+                    let n = guard.len();
+                    guard.clear();
+                    n
+                };
+                if removed > 0 {
+                    shard.evictions.fetch_add(removed as u64, Ordering::Relaxed);
+                }
+            }
+            return;
+        };
         for shard in self.inner.shards.iter() {
             let removed: Vec<(K, TimedEntry<V>)> = shard.lock.write().drain().collect();
             if !removed.is_empty() {
-                self.inner
+                shard
                     .evictions
                     .fetch_add(removed.len() as u64, Ordering::Relaxed);
-                if let Some(on_evict) = &self.inner.on_evict {
-                    for (k, entry) in &removed {
-                        on_evict(k, &entry.value);
-                    }
+                for (k, entry) in &removed {
+                    on_evict(k, &entry.value);
                 }
             }
         }
@@ -399,35 +423,42 @@ where
         K: Clone,
     {
         let mut total = 0;
+        // Expiry is judged against a single instant sampled once per call, so every entry in
+        // every shard is compared against the same instant (matching `retain`).
         let now = Instant::now();
-        for shard in self.inner.shards.iter() {
-            let removed = {
-                let mut guard = shard.lock.write();
-                let expired_keys: Vec<K> = guard
-                    .iter()
-                    // An entry is expired when expires_at is Some(t) and now >= t.
-                    // None means never-expires.
-                    .filter(|(_, e)| e.expires_at.is_some_and(|t| now >= t))
-                    .map(|(k, _)| k.clone())
-                    .collect();
-                let mut removed = Vec::new();
-                for k in expired_keys {
-                    if let Some((key, entry)) = guard.remove_entry(&k) {
-                        removed.push((key, entry));
-                    }
+        let Some(cb) = &self.inner.on_evict else {
+            // No callback: only the removed *count* is observable, so drop the expired entries
+            // in place via `retain` and take the length delta -- no key clones, no `Vec`.
+            for shard in self.inner.shards.iter() {
+                let removed = {
+                    let mut guard = shard.lock.write();
+                    let before = guard.len();
+                    guard.retain(|_, e| !expired_at(e, now));
+                    before - guard.len()
+                };
+                total += removed;
+                if removed > 0 {
+                    shard.evictions.fetch_add(removed as u64, Ordering::Relaxed);
                 }
-                removed
+            }
+            return total;
+        };
+        for shard in self.inner.shards.iter() {
+            // Single pass: `extract_if` removes and yields the expired entries as it walks the
+            // table, so no key is cloned and no key is re-hashed for a second lookup.
+            // Collect under the write lock, fire callbacks after releasing it.
+            let removed: Vec<(K, TimedEntry<V>)> = {
+                let mut guard = shard.lock.write();
+                guard.extract_if(|_, e| expired_at(e, now)).collect()
             };
 
             total += removed.len();
             if !removed.is_empty() {
-                self.inner
+                shard
                     .evictions
                     .fetch_add(removed.len() as u64, Ordering::Relaxed);
-                if let Some(cb) = &self.inner.on_evict {
-                    for (k, entry) in &removed {
-                        cb(k, &entry.value);
-                    }
+                for (k, entry) in &removed {
+                    cb(k, &entry.value);
                 }
             }
         }
@@ -464,16 +495,11 @@ where
             let removed: Vec<(K, TimedEntry<V>)> = {
                 let mut guard = shard.lock.write();
                 guard
-                    .extract_if(|k, entry| {
-                        // An entry is expired when expires_at is Some(t) and now >= t.
-                        // None means never-expires.
-                        let expired = entry.expires_at.is_some_and(|t| now >= t);
-                        expired || !keep(k, &entry.value)
-                    })
+                    .extract_if(|k, entry| expired_at(entry, now) || !keep(k, &entry.value))
                     .collect()
             };
             if !removed.is_empty() {
-                self.inner
+                shard
                     .evictions
                     .fetch_add(removed.len() as u64, Ordering::Relaxed);
                 if let Some(cb) = &self.inner.on_evict {
@@ -529,7 +555,13 @@ where
     }
 
     fn cache_evictions(&self) -> Option<u64> {
-        Some(self.inner.evictions.load(Ordering::Relaxed))
+        Some(
+            self.inner
+                .shards
+                .iter()
+                .map(|s| s.evictions.load(Ordering::Relaxed))
+                .sum(),
+        )
     }
 }
 
@@ -575,20 +607,34 @@ where
         let shard = self.shard_of(k);
         if self.inner.refresh.load(Ordering::Relaxed) {
             let mut guard = shard.lock.write();
-            match guard.get_mut(k) {
-                Some(entry) if !self.is_expired(entry) => {
+            // The clock is read once, and only when the key is actually present: a lookup for
+            // an absent key never touches it. The same instant decides expiry and stamps the
+            // renewed `expires_at` (the previous code read the clock twice on this path).
+            // `None` = key absent, `Some(None)` = present but expired, `Some(Some(v))` = live
+            // hit, already refreshed.
+            let outcome: Option<Option<V>> = match guard.get_mut(k) {
+                None => None,
+                Some(entry) => {
                     let now = Instant::now();
-                    entry.expires_at = self.compute_expires_at(now).or(entry.expires_at);
-                    let value = Some(entry.value.clone());
+                    if expired_at(entry, now) {
+                        Some(None)
+                    } else {
+                        entry.expires_at = self.compute_expires_at(now).or(entry.expires_at);
+                        Some(Some(entry.value.clone()))
+                    }
+                }
+            };
+            match outcome {
+                Some(Some(value)) => {
                     drop(guard);
                     shard.hits.fetch_add(1, Ordering::Relaxed);
-                    return Ok(value);
+                    return Ok(Some(value));
                 }
-                Some(_) => {
+                Some(None) => {
                     let removed = guard.remove_entry(k);
                     drop(guard);
                     if let Some((stored_k, entry)) = removed {
-                        self.inner.evictions.fetch_add(1, Ordering::Relaxed);
+                        shard.evictions.fetch_add(1, Ordering::Relaxed);
                         if let Some(cb) = &self.inner.on_evict {
                             cb(&stored_k, &entry.value);
                         }
@@ -605,21 +651,27 @@ where
         }
 
         // Check for expiry — try with a read lock.
-        let (expired, value) = {
+        let (expired, value, now) = {
             let guard = shard.lock.read();
             match guard.get(k) {
                 None => {
+                    // Release the shard lock before touching the counter, like every other
+                    // path in this file. A miss on an absent key never reads the clock.
+                    drop(guard);
                     shard.misses.fetch_add(1, Ordering::Relaxed);
                     return Ok(None);
                 }
                 Some(entry) => {
-                    let expired = self.is_expired(entry);
+                    // One clock read per call: this instant is reused by the write-lock
+                    // re-check below, which previously sampled the clock a second time.
+                    let now = Instant::now();
+                    let expired = expired_at(entry, now);
                     let value = if !expired {
                         Some(entry.value.clone())
                     } else {
                         None
                     };
-                    (expired, value)
+                    (expired, value, now)
                 }
             }
         };
@@ -629,7 +681,7 @@ where
             // Re-check under write lock — another thread may have replaced the entry
             // with a fresh value in the meantime; clone it out in the same lookup.
             let fresh_value = match guard.get(k) {
-                Some(entry) if !self.is_expired(entry) => Some(entry.value.clone()),
+                Some(entry) if !expired_at(entry, now) => Some(entry.value.clone()),
                 _ => None,
             };
             if let Some(fresh_value) = fresh_value {
@@ -641,7 +693,7 @@ where
             let removed = guard.remove_entry(k);
             drop(guard);
             if let Some((stored_k, entry)) = removed {
-                self.inner.evictions.fetch_add(1, Ordering::Relaxed);
+                shard.evictions.fetch_add(1, Ordering::Relaxed);
                 if let Some(cb) = &self.inner.on_evict {
                     cb(&stored_k, &entry.value);
                 }
@@ -663,19 +715,22 @@ where
         };
         // Capture the displaced entry and evaluate expiry while the write lock is still held
         // (B2: avoids a TOCTOU where the entry crosses the expiry threshold between unlock and
-        // the check). When an `on_evict` callback is configured, remove-then-insert so the
-        // owned old key can fire the callback after the lock is released (on_evict-after-unlock).
+        // the check). Expiry is judged against the same `now` that stamps the replacement
+        // entry — one clock read per call, and the displaced entry is judged against exactly
+        // the instant the new entry claims to start at. When an `on_evict` callback is
+        // configured, remove-then-insert so the owned old key can fire the callback after the
+        // lock is released (on_evict-after-unlock).
         let old: Option<(Option<K>, TimedEntry<V>, bool)> = if self.inner.on_evict.is_some() {
             let mut guard = shard.lock.write();
             let removed = guard.remove_entry(&k);
             guard.insert(k, new_entry);
             removed.map(|(ok, e)| {
-                let expired = e.expires_at.is_some_and(|t| Instant::now() >= t);
+                let expired = expired_at(&e, now);
                 (Some(ok), e, expired)
             })
         } else {
             shard.lock.write().insert(k, new_entry).map(|e| {
-                let expired = e.expires_at.is_some_and(|t| Instant::now() >= t);
+                let expired = expired_at(&e, now);
                 (None, e, expired)
             })
         };
@@ -686,7 +741,7 @@ where
                 if let (Some(cb), Some(key)) = (&self.inner.on_evict, &key) {
                     cb(key, &entry.value);
                 }
-                self.inner.evictions.fetch_add(1, Ordering::Relaxed);
+                shard.evictions.fetch_add(1, Ordering::Relaxed);
                 Ok(None)
             }
             Some((_, entry, false)) => Ok(Some(entry.value)),
@@ -698,7 +753,7 @@ where
         let shard = self.shard_of(k);
         let removed = shard.lock.write().remove_entry(k);
         if let Some((stored_k, entry)) = removed {
-            self.inner.evictions.fetch_add(1, Ordering::Relaxed);
+            shard.evictions.fetch_add(1, Ordering::Relaxed);
             if let Some(cb) = &self.inner.on_evict {
                 cb(&stored_k, &entry.value);
             }
@@ -717,7 +772,7 @@ where
         let shard = self.shard_of(k);
         let removed = shard.lock.write().remove_entry(k);
         if let Some((ref stored_k, ref entry)) = removed {
-            self.inner.evictions.fetch_add(1, Ordering::Relaxed);
+            shard.evictions.fetch_add(1, Ordering::Relaxed);
             if let Some(cb) = &self.inner.on_evict {
                 cb(stored_k, &entry.value);
             }
@@ -739,8 +794,8 @@ where
         for shard in self.inner.shards.iter() {
             shard.hits.store(0, Ordering::Relaxed);
             shard.misses.store(0, Ordering::Relaxed);
+            shard.evictions.store(0, Ordering::Relaxed);
         }
-        self.inner.evictions.store(0, Ordering::Relaxed);
         Ok(())
     }
 
@@ -989,7 +1044,6 @@ impl<K, V, H> ShardedTtlCacheBuilder<K, V, H> {
                 on_evict: self.on_evict,
                 ttl_nanos: AtomicU64::new(encode_ttl(ttl)),
                 refresh: AtomicBool::new(self.refresh),
-                evictions: AtomicU64::new(0),
             }),
         })
     }
@@ -1069,10 +1123,12 @@ where
                     (None, false)
                 }
                 Some(entry) => {
-                    let expired = self.is_expired(entry);
+                    // One clock read, taken only when the key is present: the same instant
+                    // decides expiry and stamps the renewed `expires_at`.
+                    let now = Instant::now();
+                    let expired = expired_at(entry, now);
                     let value = entry.value.clone();
                     if !expired {
-                        let now = Instant::now();
                         entry.expires_at = self.compute_expires_at(now).or(entry.expires_at);
                     }
                     drop(guard);
@@ -1095,7 +1151,7 @@ where
                     (None, false)
                 }
                 Some(entry) => {
-                    let expired = self.is_expired(entry);
+                    let expired = expired_at(entry, Instant::now());
                     let value = entry.value.clone();
                     drop(guard);
                     if expired {
@@ -2053,5 +2109,1441 @@ mod tests {
             1,
             "on_evict must not fire again for a displaced live entry"
         );
+    }
+
+    // --- Per-shard eviction counter -----------------------------------------
+    //
+    // Evictions are counted on the shard that owns the key (`Shard::evictions`) and summed
+    // on read by `metrics()` / `cache_evictions()`, rather than on one process-wide counter
+    // in `Arc<TtlInner>`. These tests pin both halves: the placement (which shard's counter
+    // moved) and the aggregation (the sum the public API reports).
+
+    /// Raw per-shard eviction counters, in shard order.
+    fn shard_eviction_counters<K, V, H>(c: &ShardedTtlCacheBase<K, V, H>) -> Vec<u64> {
+        c.inner
+            .shards
+            .iter()
+            .map(|s| s.evictions.load(Ordering::Relaxed))
+            .collect()
+    }
+
+    /// Index of the shard that owns `k`.
+    fn owning_shard<K, V, H: ShardHasher<K>>(c: &ShardedTtlCacheBase<K, V, H>, k: &K) -> usize {
+        shard_index(c.inner.hasher.shard_hash(k), c.inner.shard_mask)
+    }
+
+    #[test]
+    fn evict_counts_land_on_owning_shards_and_aggregate_exactly() {
+        let c = ShardedTtlCacheBase::<u32, u32>::builder()
+            .ttl(Duration::from_millis(1))
+            .shards(8)
+            .build()
+            .unwrap();
+        for i in 0..64u32 {
+            SyncConcurrentCached::cache_set(&c, i, i).expect("insert must succeed");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(30));
+        assert_eq!(c.evict(), 64, "every entry is expired");
+
+        let per_shard = shard_eviction_counters(&c);
+        assert_eq!(per_shard.len(), 8, "one counter per shard");
+        assert_eq!(
+            per_shard.iter().sum::<u64>(),
+            64,
+            "per-shard counters must account for every eviction: {per_shard:?}"
+        );
+        assert!(
+            per_shard.iter().filter(|&&n| n > 0).count() >= 2,
+            "64 keys over 8 shards must move more than one shard's counter: {per_shard:?}"
+        );
+        assert_eq!(
+            c.metrics().evictions,
+            Some(64),
+            "metrics() must sum the per-shard counters"
+        );
+        assert_eq!(
+            ConcurrentCacheBase::cache_evictions(&c),
+            Some(64),
+            "cache_evictions() must sum the per-shard counters"
+        );
+    }
+
+    #[test]
+    fn every_eviction_path_counts_on_the_owning_shard() {
+        let c = ShardedTtlCacheBase::<u32, u32>::builder()
+            .ttl(Duration::from_millis(20))
+            .shards(8)
+            .build()
+            .unwrap();
+        let mut expected = vec![0u64; 8];
+
+        // 1) Lazy expiry through cache_get.
+        SyncConcurrentCached::cache_set(&c, 1, 10).expect("insert must succeed");
+        std::thread::sleep(std::time::Duration::from_millis(60));
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &1).unwrap(), None);
+        expected[owning_shard(&c, &1)] += 1;
+        assert_eq!(
+            shard_eviction_counters(&c),
+            expected,
+            "cache_get lazy expiry must count on the key's own shard"
+        );
+
+        // 2) cache_remove.
+        SyncConcurrentCached::cache_set(&c, 2, 20).expect("insert must succeed");
+        assert_eq!(
+            SyncConcurrentCached::cache_remove(&c, &2).unwrap(),
+            Some(20)
+        );
+        expected[owning_shard(&c, &2)] += 1;
+        assert_eq!(
+            shard_eviction_counters(&c),
+            expected,
+            "cache_remove must count on the key's own shard"
+        );
+
+        // 3) cache_remove_entry.
+        SyncConcurrentCached::cache_set(&c, 3, 30).expect("insert must succeed");
+        assert_eq!(
+            SyncConcurrentCached::cache_remove_entry(&c, &3).unwrap(),
+            Some((3, 30))
+        );
+        expected[owning_shard(&c, &3)] += 1;
+        assert_eq!(
+            shard_eviction_counters(&c),
+            expected,
+            "cache_remove_entry must count on the key's own shard"
+        );
+
+        // 4) cache_set displacing an expired entry.
+        SyncConcurrentCached::cache_set(&c, 4, 40).expect("insert must succeed");
+        std::thread::sleep(std::time::Duration::from_millis(60));
+        assert_eq!(SyncConcurrentCached::cache_set(&c, 4, 41).unwrap(), None);
+        expected[owning_shard(&c, &4)] += 1;
+        assert_eq!(
+            shard_eviction_counters(&c),
+            expected,
+            "cache_set over an expired entry must count on the key's own shard"
+        );
+
+        // 5) evict() sweeps key 4 (re-set above) and key 5, both expired by now.
+        SyncConcurrentCached::cache_set(&c, 5, 50).expect("insert must succeed");
+        std::thread::sleep(std::time::Duration::from_millis(60));
+        assert_eq!(c.evict(), 2, "both stored entries are expired");
+        expected[owning_shard(&c, &4)] += 1;
+        expected[owning_shard(&c, &5)] += 1;
+        assert_eq!(
+            shard_eviction_counters(&c),
+            expected,
+            "evict must count each removal on the shard it came from"
+        );
+
+        // 6) retain().
+        SyncConcurrentCached::cache_set(&c, 6, 60).expect("insert must succeed");
+        c.retain(|_k, _v| false);
+        expected[owning_shard(&c, &6)] += 1;
+        assert_eq!(
+            shard_eviction_counters(&c),
+            expected,
+            "retain must count each removal on the shard it came from"
+        );
+
+        // 7) cache_clear_with_on_evict (no callback configured: the early-return path).
+        SyncConcurrentCached::cache_set(&c, 7, 70).expect("insert must succeed");
+        SyncConcurrentCached::cache_set(&c, 8, 80).expect("insert must succeed");
+        c.cache_clear_with_on_evict();
+        expected[owning_shard(&c, &7)] += 1;
+        expected[owning_shard(&c, &8)] += 1;
+        assert_eq!(
+            shard_eviction_counters(&c),
+            expected,
+            "cache_clear_with_on_evict must count each removal on its own shard"
+        );
+
+        let total: u64 = expected.iter().sum();
+        assert_eq!(
+            c.metrics().evictions,
+            Some(total),
+            "metrics() must report the sum of the per-shard counters"
+        );
+        assert_eq!(ConcurrentCacheBase::cache_evictions(&c), Some(total));
+    }
+
+    #[test]
+    fn cache_reset_metrics_zeroes_the_per_shard_eviction_counters() {
+        let c = ShardedTtlCacheBase::<u32, u32>::builder()
+            .ttl(Duration::from_millis(1))
+            .shards(4)
+            .build()
+            .unwrap();
+        for i in 0..16u32 {
+            SyncConcurrentCached::cache_set(&c, i, i).expect("insert must succeed");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(30));
+        assert_eq!(c.evict(), 16);
+        assert_eq!(c.metrics().evictions, Some(16));
+        assert_eq!(
+            shard_eviction_counters(&c).iter().sum::<u64>(),
+            16,
+            "the counts must live on the shards before the reset can zero them"
+        );
+        ConcurrentCached::cache_reset_metrics(&c).unwrap();
+        assert_eq!(
+            shard_eviction_counters(&c),
+            vec![0u64; 4],
+            "every per-shard counter must be zeroed"
+        );
+        assert_eq!(c.metrics().evictions, Some(0));
+        assert_eq!(ConcurrentCacheBase::cache_evictions(&c), Some(0));
+    }
+
+    #[test]
+    fn deep_clone_carries_per_shard_eviction_counts_and_then_diverges() {
+        let c = ShardedTtlCacheBase::<u32, u32>::builder()
+            .ttl(Duration::from_millis(1))
+            .shards(4)
+            .build()
+            .unwrap();
+        for i in 0..32u32 {
+            SyncConcurrentCached::cache_set(&c, i, i).expect("insert must succeed");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(30));
+        assert_eq!(c.evict(), 32);
+        let source_counters = shard_eviction_counters(&c);
+        assert_eq!(
+            source_counters.iter().sum::<u64>(),
+            32,
+            "the source must hold its counts on its own shards: {source_counters:?}"
+        );
+
+        let d = c.deep_clone();
+        assert_eq!(
+            shard_eviction_counters(&d),
+            source_counters,
+            "deep_clone must copy the counters shard-for-shard, not just the total"
+        );
+        assert_eq!(
+            d.metrics().evictions,
+            Some(32),
+            "the aggregate must survive deep_clone"
+        );
+        assert_eq!(ConcurrentCacheBase::cache_evictions(&d), Some(32));
+
+        // The copy is independent: further evictions on the source do not move the clone.
+        SyncConcurrentCached::cache_set(&c, 100, 1).expect("insert must succeed");
+        assert!(SyncConcurrentCached::cache_delete(&c, &100).unwrap());
+        assert_eq!(c.metrics().evictions, Some(33));
+        assert_eq!(d.metrics().evictions, Some(32));
+        assert_eq!(shard_eviction_counters(&d), source_counters);
+    }
+
+    // --- evict(): one-pass sweep, both branches ------------------------------
+
+    #[test]
+    fn evict_with_callback_fires_once_per_removed_entry_with_key_and_value() {
+        use std::sync::Mutex;
+        let seen: Arc<Mutex<Vec<(u32, u32)>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen2 = seen.clone();
+        let c = ShardedTtlCacheBase::<u32, u32>::builder()
+            .ttl(Duration::from_millis(30))
+            .shards(4)
+            .on_evict(move |k: &u32, v: &u32| {
+                seen2.lock().expect("callback lock").push((*k, *v));
+            })
+            .build()
+            .unwrap();
+        for i in 0..16u32 {
+            SyncConcurrentCached::cache_set(&c, i, i * 10).expect("insert must succeed");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(80));
+        // Fresh entries inserted after the sleep must survive the sweep.
+        for i in 100..104u32 {
+            SyncConcurrentCached::cache_set(&c, i, i).expect("insert must succeed");
+        }
+
+        let removed = c.evict();
+        assert_eq!(
+            removed, 16,
+            "evict must return the number of removed entries"
+        );
+
+        let mut fired = seen.lock().expect("callback lock").clone();
+        fired.sort_unstable();
+        let expected: Vec<(u32, u32)> = (0..16u32).map(|i| (i, i * 10)).collect();
+        assert_eq!(
+            fired, expected,
+            "on_evict must fire exactly once per removed entry, with its own key and value"
+        );
+        assert_eq!(c.len(), 4, "live entries must survive the sweep");
+        for i in 100..104u32 {
+            assert_eq!(SyncConcurrentCached::cache_get(&c, &i).unwrap(), Some(i));
+        }
+        assert_eq!(c.metrics().evictions, Some(16));
+        assert_eq!(
+            shard_eviction_counters(&c).iter().sum::<u64>(),
+            16,
+            "the callback branch must count on the per-shard counters"
+        );
+    }
+
+    #[test]
+    fn evict_without_callback_returns_count_and_counts_evictions() {
+        // The no-callback branch removes in place (`retain` + length delta) and never builds
+        // a Vec, so the returned count comes from the length delta -- pin it here.
+        let c = ShardedTtlCacheBase::<u32, u32>::builder()
+            .ttl(Duration::from_millis(30))
+            .shards(4)
+            .build()
+            .unwrap();
+        for i in 0..16u32 {
+            SyncConcurrentCached::cache_set(&c, i, i * 10).expect("insert must succeed");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(80));
+        for i in 100..104u32 {
+            SyncConcurrentCached::cache_set(&c, i, i).expect("insert must succeed");
+        }
+
+        let removed = c.evict();
+        assert_eq!(
+            removed, 16,
+            "the length-delta count must match the removed entries"
+        );
+        assert_eq!(c.len(), 4, "live entries must survive the sweep");
+        for i in 100..104u32 {
+            assert_eq!(SyncConcurrentCached::cache_get(&c, &i).unwrap(), Some(i));
+        }
+        for i in 0..16u32 {
+            assert_eq!(c.peek(&i), None, "expired entries must be physically gone");
+        }
+        assert_eq!(c.metrics().evictions, Some(16));
+        assert_eq!(
+            shard_eviction_counters(&c).iter().sum::<u64>(),
+            16,
+            "the no-callback branch must count on the per-shard counters"
+        );
+    }
+
+    #[test]
+    fn evict_with_nothing_expired_removes_nothing_in_either_branch() {
+        for with_callback in [false, true] {
+            let fired = Arc::new(std::sync::atomic::AtomicU64::new(0));
+            let fired2 = fired.clone();
+            let mut builder = ShardedTtlCacheBase::<u32, u32>::builder()
+                .ttl(Duration::from_secs(3600))
+                .shards(4);
+            if with_callback {
+                builder = builder.on_evict(move |_k: &u32, _v: &u32| {
+                    fired2.fetch_add(1, Ordering::Relaxed);
+                });
+            }
+            let c = builder.build().unwrap();
+            for i in 0..16u32 {
+                SyncConcurrentCached::cache_set(&c, i, i).expect("insert must succeed");
+            }
+            assert_eq!(
+                c.evict(),
+                0,
+                "nothing is expired (with_callback={with_callback})"
+            );
+            assert_eq!(c.len(), 16, "no entry may be dropped by a no-op sweep");
+            assert_eq!(c.metrics().evictions, Some(0));
+            assert_eq!(shard_eviction_counters(&c), vec![0u64; 4]);
+            assert_eq!(fired.load(Ordering::Relaxed), 0, "on_evict must not fire");
+        }
+    }
+
+    #[test]
+    fn evict_removes_only_expired_entries_in_either_branch() {
+        for with_callback in [false, true] {
+            let fired = Arc::new(std::sync::atomic::AtomicU64::new(0));
+            let fired2 = fired.clone();
+            let mut builder = ShardedTtlCacheBase::<u32, u32>::builder()
+                .ttl(Duration::from_secs(3600))
+                .shards(2);
+            if with_callback {
+                builder = builder.on_evict(move |_k: &u32, _v: &u32| {
+                    fired2.fetch_add(1, Ordering::Relaxed);
+                });
+            }
+            let c = builder.build().unwrap();
+            for i in 0..8u32 {
+                SyncConcurrentCached::cache_set(&c, i, i).expect("insert must succeed");
+            }
+            // Backdate the even keys so exactly half the entries are expired, without sleeping.
+            let past = Instant::now();
+            for i in (0..8u32).step_by(2) {
+                let shard = c.shard_of(&i);
+                let mut guard = shard.lock.write();
+                guard.get_mut(&i).expect("key stored").expires_at = Some(past);
+            }
+            assert_eq!(c.evict(), 4, "(with_callback={with_callback})");
+            assert_eq!(c.len(), 4);
+            for i in 0..8u32 {
+                let expected = if i % 2 == 0 { None } else { Some(i) };
+                assert_eq!(c.peek(&i), expected);
+            }
+            assert_eq!(c.metrics().evictions, Some(4));
+            let expected_fires = if with_callback { 4 } else { 0 };
+            assert_eq!(fired.load(Ordering::Relaxed), expected_fires);
+        }
+    }
+
+    // --- cache_clear_with_on_evict: no-callback early return -----------------
+
+    #[test]
+    fn cache_clear_with_on_evict_without_callback_counts_across_shards() {
+        let c = ShardedTtlCacheBase::<u32, u32>::builder()
+            .ttl(Duration::from_secs(3600))
+            .shards(8)
+            .build()
+            .unwrap();
+        for i in 0..40u32 {
+            SyncConcurrentCached::cache_set(&c, i, i).expect("insert must succeed");
+        }
+        c.cache_clear_with_on_evict();
+        assert_eq!(c.len(), 0, "every shard must be emptied");
+        assert!(c.is_empty());
+        let per_shard = shard_eviction_counters(&c);
+        assert_eq!(
+            per_shard.iter().sum::<u64>(),
+            40,
+            "the no-callback path must still count every removed entry: {per_shard:?}"
+        );
+        assert!(
+            per_shard.iter().filter(|&&n| n > 0).count() >= 2,
+            "40 keys over 8 shards must move more than one counter: {per_shard:?}"
+        );
+        assert_eq!(c.metrics().evictions, Some(40));
+
+        // Clearing an already-empty cache counts nothing.
+        c.cache_clear_with_on_evict();
+        assert_eq!(
+            c.metrics().evictions,
+            Some(40),
+            "clearing an empty cache must not count evictions"
+        );
+    }
+
+    // --- Expiry boundary under the single-sample clock -----------------------
+
+    #[test]
+    fn cache_get_evicts_at_the_expires_at_equals_now_boundary() {
+        // `cache_get` samples the clock once, before taking the shard lock. `Instant` is
+        // monotonic, so that sample is always >= the `expires_at` pinned here and the entry
+        // must be judged expired (`now >= expires_at`), removed, and counted exactly once
+        // on its own shard -- the same boundary `evict`/`retain` use.
+        let c = ShardedTtlCacheBase::<u32, u32>::builder()
+            .ttl(Duration::from_secs(3600))
+            .shards(4)
+            .build()
+            .unwrap();
+        SyncConcurrentCached::cache_set(&c, 1, 10).expect("insert must succeed");
+        SyncConcurrentCached::cache_set(&c, 2, 20).expect("insert must succeed");
+        {
+            let shard = c.shard_of(&1);
+            let mut guard = shard.lock.write();
+            guard.get_mut(&1).expect("key 1 stored").expires_at = Some(Instant::now());
+        }
+        assert_eq!(
+            SyncConcurrentCached::cache_get(&c, &1).unwrap(),
+            None,
+            "an entry whose expires_at equals the sampled now must read as expired"
+        );
+        assert_eq!(
+            SyncConcurrentCached::cache_get(&c, &2).unwrap(),
+            Some(20),
+            "an unexpired entry must be unaffected"
+        );
+        let mut expected = vec![0u64; 4];
+        expected[owning_shard(&c, &1)] += 1;
+        assert_eq!(shard_eviction_counters(&c), expected);
+        assert_eq!(c.metrics().evictions, Some(1));
+    }
+
+    #[test]
+    fn refresh_on_hit_get_evicts_at_the_boundary_and_renews_live_entries() {
+        // Same boundary on the refresh_on_hit (write-lock) path, which now shares one clock
+        // sample between the expiry check and the renewed expires_at stamp.
+        let c = ShardedTtlCacheBase::<u32, u32>::builder()
+            .ttl(Duration::from_secs(3600))
+            .refresh_on_hit(true)
+            .shards(4)
+            .build()
+            .unwrap();
+        SyncConcurrentCached::cache_set(&c, 1, 10).expect("insert must succeed");
+        SyncConcurrentCached::cache_set(&c, 2, 20).expect("insert must succeed");
+        {
+            let shard = c.shard_of(&1);
+            let mut guard = shard.lock.write();
+            guard.get_mut(&1).expect("key 1 stored").expires_at = Some(Instant::now());
+        }
+        assert_eq!(
+            SyncConcurrentCached::cache_get(&c, &1).unwrap(),
+            None,
+            "refresh_on_hit must apply the same now >= expires_at boundary"
+        );
+        assert_eq!(c.metrics().evictions, Some(1));
+
+        // The live entry is renewed: its expires_at moves forward on the hit.
+        let before = {
+            let shard = c.shard_of(&2);
+            let guard = shard.lock.read();
+            guard.get(&2).expect("key 2 stored").expires_at
+        };
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &2).unwrap(), Some(20));
+        let after = {
+            let shard = c.shard_of(&2);
+            let guard = shard.lock.read();
+            guard.get(&2).expect("key 2 stored").expires_at
+        };
+        assert!(
+            after > before,
+            "a refresh_on_hit hit must push expires_at forward (before={before:?}, after={after:?})"
+        );
+        assert_eq!(
+            c.metrics().evictions,
+            Some(1),
+            "a renewed hit must not count an eviction"
+        );
+    }
+
+    #[test]
+    fn cache_get_with_expiry_status_uses_the_same_now_boundary() {
+        for refresh in [false, true] {
+            let c = ShardedTtlCacheBase::<u32, u32>::builder()
+                .ttl(Duration::from_secs(3600))
+                .refresh_on_hit(refresh)
+                .shards(1)
+                .build()
+                .unwrap();
+            SyncConcurrentCached::cache_set(&c, 1, 10).expect("insert must succeed");
+            {
+                let shard = c.shard_of(&1);
+                let mut guard = shard.lock.write();
+                guard.get_mut(&1).expect("key 1 stored").expires_at = Some(Instant::now());
+            }
+            assert_eq!(
+                ConcurrentCloneCached::cache_get_with_expiry_status(&c, &1),
+                (Some(10), true),
+                "expires_at == the sampled now must report expired (refresh={refresh})"
+            );
+            assert_eq!(
+                c.metrics().evictions,
+                Some(0),
+                "the expiry-status read never evicts"
+            );
+            assert_eq!(c.len(), 1, "the expiry-status read never removes");
+        }
+    }
+
+    // --- Certification: adversarial coverage of the once-per-call clock rewrite ------
+    //
+    // The rewrite has to be behavior-preserving on three axes: the two `evict` branches
+    // (`extract_if` with a callback vs `retain` + length delta without one) must agree
+    // exactly; a single clock sample per call must not shift any expiry decision; and the
+    // per-shard eviction counters must behave under `deep_clone` / `cache_reset_metrics` /
+    // `copy_from`. These tests approach those from the outside.
+
+    /// Deterministic shard placement. `DefaultShardHasher` is randomly seeded per instance,
+    /// so two independently built caches would scatter the same keys onto different shards
+    /// and a shard-for-shard comparison between them would be meaningless.
+    #[derive(Clone)]
+    struct FixedShardHasher;
+
+    impl ShardHasher<u32> for FixedShardHasher {
+        fn shard_hash(&self, key: &u32) -> u64 {
+            u64::from(*key).wrapping_mul(0x9e37_79b9_7f4a_7c15)
+        }
+    }
+
+    /// Every stored entry as `(key, value, has_expiry)`, sorted. The `expires_at` instants
+    /// of two independently built caches differ, so only the `Some`/`None` shape of the
+    /// expiry is comparable across caches.
+    fn entry_snapshot<H: ShardHasher<u32>>(
+        c: &ShardedTtlCacheBase<u32, u32, H>,
+    ) -> Vec<(u32, u32, bool)> {
+        let mut out: Vec<(u32, u32, bool)> = Vec::new();
+        for shard in c.inner.shards.iter() {
+            let guard = shard.lock.read();
+            for (k, e) in guard.iter() {
+                out.push((*k, e.value, e.expires_at.is_some()));
+            }
+        }
+        out.sort_unstable();
+        out
+    }
+
+    /// Force a stored entry's `expires_at`, bypassing the TTL stamping.
+    fn set_expiry<H: ShardHasher<u32>>(
+        c: &ShardedTtlCacheBase<u32, u32, H>,
+        k: u32,
+        expires_at: Option<Instant>,
+    ) {
+        let shard = c.shard_of(&k);
+        let mut guard = shard.lock.write();
+        guard.get_mut(&k).expect("key stored").expires_at = expires_at;
+    }
+
+    /// `None` when the key is absent, `Some(expires_at)` (itself optional) when stored.
+    fn stored_expiry<H: ShardHasher<u32>>(
+        c: &ShardedTtlCacheBase<u32, u32, H>,
+        k: u32,
+    ) -> Option<Option<Instant>> {
+        let shard = c.shard_of(&k);
+        let guard = shard.lock.read();
+        guard.get(&k).map(|e| e.expires_at)
+    }
+
+    /// Keys `0..8` expired, `8..16` live, `16..24` never-expires (`expires_at == None`,
+    /// what `unset_ttl` stamps) -- all three kinds mixed into the same shards.
+    fn populate_mixed<H: ShardHasher<u32>>(c: &ShardedTtlCacheBase<u32, u32, H>) {
+        for i in 0..24u32 {
+            SyncConcurrentCached::cache_set(c, i, i * 10).expect("insert must succeed");
+        }
+        let now = Instant::now();
+        for i in 0..8u32 {
+            set_expiry(c, i, Some(now));
+        }
+        for i in 16..24u32 {
+            set_expiry(c, i, None);
+        }
+    }
+
+    #[test]
+    fn evict_callback_and_no_callback_branches_agree_exactly() {
+        // Same input, both branches: identical return count, identical surviving state,
+        // identical per-shard counters. The no-callback branch derives its count from
+        // `before - guard.len()` rather than from the removed entries, so the two are
+        // independent implementations of the same contract.
+        let fired: Arc<std::sync::Mutex<Vec<(u32, u32)>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let fired2 = fired.clone();
+        let with_cb = ShardedTtlCacheBase::<u32, u32>::builder()
+            .ttl(Duration::from_secs(3600))
+            .shards(4)
+            .hasher(FixedShardHasher)
+            .on_evict(move |k: &u32, v: &u32| {
+                fired2.lock().expect("callback lock").push((*k, *v));
+            })
+            .build()
+            .unwrap();
+        let no_cb = ShardedTtlCacheBase::<u32, u32>::builder()
+            .ttl(Duration::from_secs(3600))
+            .shards(4)
+            .hasher(FixedShardHasher)
+            .build()
+            .unwrap();
+        populate_mixed(&with_cb);
+        populate_mixed(&no_cb);
+        assert_eq!(
+            entry_snapshot(&with_cb),
+            entry_snapshot(&no_cb),
+            "the two caches must start from identical state"
+        );
+
+        let removed_cb = with_cb.evict();
+        let removed_plain = no_cb.evict();
+        assert_eq!(
+            removed_cb, 8,
+            "only the eight backdated entries are expired"
+        );
+        assert_eq!(
+            removed_plain, removed_cb,
+            "the retain + length-delta branch must return the same count as the extract_if branch"
+        );
+        assert_eq!(
+            entry_snapshot(&with_cb),
+            entry_snapshot(&no_cb),
+            "both branches must leave identical state"
+        );
+        assert_eq!(
+            shard_eviction_counters(&with_cb),
+            shard_eviction_counters(&no_cb),
+            "both branches must move the same per-shard counters"
+        );
+        let survivors: Vec<u32> = entry_snapshot(&no_cb)
+            .into_iter()
+            .map(|(k, ..)| k)
+            .collect();
+        assert_eq!(
+            survivors,
+            (8..24u32).collect::<Vec<u32>>(),
+            "live and never-expires entries must survive both branches"
+        );
+        assert_eq!(
+            entry_snapshot(&no_cb)
+                .iter()
+                .filter(|(.., has_expiry)| !has_expiry)
+                .count(),
+            8,
+            "the never-expires entries must keep expires_at = None"
+        );
+        let mut fired_keys = fired.lock().expect("callback lock").clone();
+        fired_keys.sort_unstable();
+        assert_eq!(
+            fired_keys,
+            (0..8u32).map(|i| (i, i * 10)).collect::<Vec<_>>(),
+            "on_evict must fire once per expired entry, and never for a never-expires one"
+        );
+
+        // A second sweep removes nothing: the zero-removal case of both branches.
+        let counters = shard_eviction_counters(&with_cb);
+        assert_eq!(with_cb.evict(), 0, "nothing is left to expire");
+        assert_eq!(no_cb.evict(), 0, "nothing is left to expire");
+        assert_eq!(
+            shard_eviction_counters(&with_cb),
+            counters,
+            "a sweep that removes nothing must not touch any counter"
+        );
+        assert_eq!(shard_eviction_counters(&no_cb), counters);
+        assert_eq!(
+            fired.lock().expect("callback lock").len(),
+            8,
+            "a no-op sweep must not fire on_evict"
+        );
+    }
+
+    #[test]
+    fn evict_no_callback_length_delta_is_exact_for_all_and_none_expired_shards() {
+        // The `before - guard.len()` arithmetic at its two extremes within one call: one
+        // shard loses every entry, the other loses none.
+        let c = ShardedTtlCacheBase::<u32, u32>::builder()
+            .ttl(Duration::from_secs(3600))
+            .shards(2)
+            .hasher(FixedShardHasher)
+            .build()
+            .unwrap();
+        let mut buckets: Vec<Vec<u32>> = vec![Vec::new(); 2];
+        for k in 0..256u32 {
+            let idx = owning_shard(&c, &k);
+            if buckets[idx].len() < 4 {
+                buckets[idx].push(k);
+            }
+        }
+        assert!(
+            buckets.iter().all(|b| b.len() == 4),
+            "both shards must receive keys: {buckets:?}"
+        );
+        for k in buckets.iter().flatten() {
+            SyncConcurrentCached::cache_set(&c, *k, *k * 10).expect("insert must succeed");
+        }
+        let now = Instant::now();
+        for k in &buckets[0] {
+            set_expiry(&c, *k, Some(now));
+        }
+
+        assert_eq!(c.evict(), 4, "only shard 0's entries are expired");
+        assert_eq!(
+            shard_eviction_counters(&c),
+            vec![4, 0],
+            "the emptied shard counts four, the untouched shard counts nothing"
+        );
+        assert_eq!(
+            c.shard_sizes(),
+            vec![0, 4],
+            "the all-expired shard must be emptied and the none-expired shard untouched"
+        );
+        for k in &buckets[0] {
+            assert_eq!(c.peek(k), None, "expired entries must be physically gone");
+        }
+        for k in &buckets[1] {
+            assert_eq!(c.peek(k), Some(*k * 10), "live entries must be untouched");
+        }
+    }
+
+    #[test]
+    fn evict_never_expires_entries_survive_both_branches_in_one_shard() {
+        // All three entry kinds in a *single* shard, so one `retain`/`extract_if` pass has
+        // to discriminate them: `expires_at == None` is never swept, even with the TTL
+        // subsequently disabled.
+        for with_callback in [false, true] {
+            let fired = Arc::new(AtomicU64::new(0));
+            let fired2 = fired.clone();
+            let mut builder = ShardedTtlCacheBase::<u32, u32>::builder()
+                .ttl(Duration::from_secs(3600))
+                .shards(1);
+            if with_callback {
+                builder = builder.on_evict(move |_k: &u32, _v: &u32| {
+                    fired2.fetch_add(1, Ordering::Relaxed);
+                });
+            }
+            let c = builder.build().unwrap();
+            for i in 0..8u32 {
+                SyncConcurrentCached::cache_set(&c, i, i * 10).expect("insert must succeed");
+            }
+            let now = Instant::now();
+            for i in 0..3u32 {
+                set_expiry(&c, i, Some(now));
+            }
+            for i in 5..8u32 {
+                set_expiry(&c, i, None);
+            }
+
+            assert_eq!(c.evict(), 3, "(with_callback={with_callback})");
+            assert_eq!(c.len(), 5, "(with_callback={with_callback})");
+            for i in 0..3u32 {
+                assert_eq!(c.peek(&i), None);
+            }
+            for i in 3..8u32 {
+                assert_eq!(c.peek(&i), Some(i * 10));
+            }
+            assert_eq!(c.metrics().evictions, Some(3));
+            assert_eq!(
+                fired.load(Ordering::Relaxed),
+                if with_callback { 3 } else { 0 }
+            );
+
+            // Disabling the TTL must not make the never-expires entries sweepable, and must
+            // not resurrect anything either.
+            c.unset_ttl();
+            assert_eq!(c.evict(), 0, "(with_callback={with_callback})");
+            assert_eq!(c.len(), 5);
+            assert_eq!(c.metrics().evictions, Some(3));
+        }
+    }
+
+    #[test]
+    fn refresh_on_hit_cache_get_trichotomy_absent_expired_live() {
+        // The refresh path funnels through an `Option<Option<V>>` outcome: `None` (absent),
+        // `Some(None)` (present but expired), `Some(Some(v))` (live, already refreshed).
+        // Each arm has its own counter/callback/removal contract.
+        let seen: Arc<std::sync::Mutex<Vec<(u32, u32)>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let seen2 = seen.clone();
+        let c = ShardedTtlCacheBase::<u32, u32>::builder()
+            .ttl(Duration::from_secs(3600))
+            .refresh_on_hit(true)
+            .shards(1)
+            .on_evict(move |k: &u32, v: &u32| {
+                seen2.lock().expect("callback lock").push((*k, *v));
+            })
+            .build()
+            .unwrap();
+
+        // 1) Absent: a miss, nothing else.
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &1).unwrap(), None);
+        let m = c.metrics();
+        assert_eq!((m.hits, m.misses, m.evictions), (Some(0), Some(1), Some(0)));
+        assert!(seen.lock().expect("callback lock").is_empty());
+
+        // 2) Live: a hit, the entry stays, and its expiry is pushed forward.
+        SyncConcurrentCached::cache_set(&c, 2, 20).expect("insert must succeed");
+        let before = stored_expiry(&c, 2).expect("key 2 stored");
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &2).unwrap(), Some(20));
+        let after = stored_expiry(&c, 2).expect("key 2 stored");
+        assert!(
+            after > before,
+            "a live refresh hit must renew expires_at (before={before:?}, after={after:?})"
+        );
+        let m = c.metrics();
+        assert_eq!((m.hits, m.misses, m.evictions), (Some(1), Some(1), Some(0)));
+        assert!(
+            seen.lock().expect("callback lock").is_empty(),
+            "a live hit must not fire on_evict"
+        );
+
+        // 3) Present but expired: a miss AND an eviction, entry physically removed.
+        SyncConcurrentCached::cache_set(&c, 3, 30).expect("insert must succeed");
+        set_expiry(&c, 3, Some(Instant::now()));
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &3).unwrap(), None);
+        let m = c.metrics();
+        assert_eq!(
+            (m.hits, m.misses, m.evictions),
+            (Some(1), Some(2), Some(1)),
+            "an expired refresh read counts one miss and one eviction, no hit"
+        );
+        assert_eq!(
+            *seen.lock().expect("callback lock"),
+            vec![(3, 30)],
+            "on_evict must fire once with the stored key and value"
+        );
+        assert_eq!(stored_expiry(&c, 3), None, "the entry must be removed");
+        assert_eq!(c.len(), 1, "only the live entry remains");
+
+        // 4) The now-absent key falls into the first arm: a plain miss, no second eviction.
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &3).unwrap(), None);
+        let m = c.metrics();
+        assert_eq!((m.hits, m.misses, m.evictions), (Some(1), Some(3), Some(1)));
+        assert_eq!(seen.lock().expect("callback lock").len(), 1);
+    }
+
+    #[test]
+    fn refresh_on_hit_with_ttl_disabled_keeps_each_entry_expiry_unchanged() {
+        // `entry.expires_at = compute_expires_at(now).or(entry.expires_at)`: with the TTL
+        // disabled, `compute_expires_at` is `None`, so a refresh hit must leave the stored
+        // expiry exactly as it was -- it must neither clear it (making the entry immortal)
+        // nor extend it.
+        let c = ShardedTtlCacheBase::<u32, u32>::builder()
+            .ttl(Duration::from_secs(3600))
+            .refresh_on_hit(true)
+            .shards(1)
+            .build()
+            .unwrap();
+        SyncConcurrentCached::cache_set(&c, 1, 10).expect("insert must succeed");
+        let stamped = stored_expiry(&c, 1).expect("key 1 stored");
+        assert!(stamped.is_some(), "the entry was stamped with the live TTL");
+
+        assert_eq!(c.unset_ttl(), Some(Duration::from_secs(3600)));
+        SyncConcurrentCached::cache_set(&c, 2, 20).expect("insert must succeed");
+        assert_eq!(
+            stored_expiry(&c, 2),
+            Some(None),
+            "an entry inserted with the TTL disabled never expires"
+        );
+
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &1).unwrap(), Some(10));
+        assert_eq!(
+            stored_expiry(&c, 1),
+            Some(stamped),
+            "with the TTL disabled a refresh hit must leave the stored expiry untouched"
+        );
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &2).unwrap(), Some(20));
+        assert_eq!(
+            stored_expiry(&c, 2),
+            Some(None),
+            "a never-expires entry must stay never-expires across a refresh hit"
+        );
+
+        // The retained stamp still governs: the entry expires on its own schedule even
+        // though the TTL is disabled cache-wide.
+        set_expiry(&c, 1, Some(Instant::now()));
+        assert_eq!(
+            SyncConcurrentCached::cache_get(&c, &1).unwrap(),
+            None,
+            "disabling the TTL must not resurrect an already-stamped entry"
+        );
+        assert_eq!(c.metrics().evictions, Some(1));
+    }
+
+    #[test]
+    fn cache_set_judges_the_displaced_entry_against_the_stamping_now() {
+        // `cache_set` samples the clock once and uses that instant both to stamp the new
+        // entry and to judge the displaced one.
+        let fired = Arc::new(AtomicU64::new(0));
+        let fired2 = fired.clone();
+        let c = ShardedTtlCacheBase::<u32, u32>::builder()
+            .ttl(Duration::from_secs(3600))
+            .shards(1)
+            .on_evict(move |_k: &u32, _v: &u32| {
+                fired2.fetch_add(1, Ordering::Relaxed);
+            })
+            .build()
+            .unwrap();
+        SyncConcurrentCached::cache_set(&c, 1, 10).expect("insert must succeed");
+
+        // A live displaced entry is returned, uncounted.
+        assert_eq!(
+            SyncConcurrentCached::cache_set(&c, 1, 11).unwrap(),
+            Some(10)
+        );
+        assert_eq!(c.metrics().evictions, Some(0));
+        assert_eq!(fired.load(Ordering::Relaxed), 0);
+
+        // At the `now >= expires_at` boundary the displaced entry is expired: filtered from
+        // the return, counted, and passed to on_evict.
+        set_expiry(&c, 1, Some(Instant::now()));
+        assert_eq!(
+            SyncConcurrentCached::cache_set(&c, 1, 12).unwrap(),
+            None,
+            "an entry whose expires_at equals the sampled now must count as displaced-expired"
+        );
+        assert_eq!(c.metrics().evictions, Some(1));
+        assert_eq!(fired.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            SyncConcurrentCached::cache_get(&c, &1).unwrap(),
+            Some(12),
+            "the replacement is stamped live against the same instant"
+        );
+
+        // A displaced never-expires entry is never treated as expired.
+        set_expiry(&c, 1, None);
+        assert_eq!(
+            SyncConcurrentCached::cache_set(&c, 1, 13).unwrap(),
+            Some(12)
+        );
+        assert_eq!(c.metrics().evictions, Some(1));
+        assert_eq!(fired.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn cache_set_with_ttl_disabled_still_evicts_the_displaced_expired_entry() {
+        // `unset_ttl` between the insert and the overwrite: the replacement is stamped
+        // never-expires, but the displaced entry keeps its own stamp and is still judged
+        // against the same `now`.
+        let fired = Arc::new(AtomicU64::new(0));
+        let fired2 = fired.clone();
+        let c = ShardedTtlCacheBase::<u32, u32>::builder()
+            .ttl(Duration::from_secs(3600))
+            .shards(1)
+            .on_evict(move |_k: &u32, _v: &u32| {
+                fired2.fetch_add(1, Ordering::Relaxed);
+            })
+            .build()
+            .unwrap();
+        SyncConcurrentCached::cache_set(&c, 1, 10).expect("insert must succeed");
+        set_expiry(&c, 1, Some(Instant::now()));
+        c.unset_ttl();
+
+        assert_eq!(
+            SyncConcurrentCached::cache_set(&c, 1, 20).unwrap(),
+            None,
+            "the displaced entry was expired when the replacement was stamped"
+        );
+        assert_eq!(c.metrics().evictions, Some(1));
+        assert_eq!(fired.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            stored_expiry(&c, 1),
+            Some(None),
+            "the replacement must be stamped never-expires"
+        );
+        assert_eq!(c.evict(), 0, "a never-expires entry is never swept");
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &1).unwrap(), Some(20));
+    }
+
+    #[test]
+    fn cache_set_judges_the_displaced_entry_against_its_pre_lock_sample() {
+        // `cache_set` samples the clock *before* it acquires the shard write lock, so an
+        // entry that crosses its expiry while the caller is queued on that lock is still
+        // judged live: it is handed back to the caller and no eviction is counted. This is
+        // the direct consequence of sampling once per call -- a version that re-read the
+        // clock after taking the lock would report the same displacement as expired
+        // (`None` + one eviction + an `on_evict` fire). The window is opened here with a
+        // `retain` predicate, which runs while the shard write guard is held.
+        const HOLD_MS: u64 = 500;
+        const EXPIRE_IN_MS: u64 = 200;
+        const START_DELAY_MS: u64 = 50;
+
+        let c = ShardedTtlCacheBase::<u32, u32>::builder()
+            .ttl(Duration::from_secs(3600))
+            .shards(1)
+            .build()
+            .unwrap();
+        SyncConcurrentCached::cache_set(&c, 1, 10).expect("insert must succeed");
+        let expires_at = Instant::now() + Duration::from_millis(EXPIRE_IN_MS);
+        set_expiry(&c, 1, Some(expires_at));
+
+        let gate = Arc::new(std::sync::Barrier::new(2));
+        let holder = {
+            let c = c.clone();
+            let gate = gate.clone();
+            std::thread::spawn(move || {
+                gate.wait();
+                // The entry is live when `retain` samples its own instant, so it is kept --
+                // the predicate only holds the shard's write lock.
+                c.retain(|_k, _v| {
+                    std::thread::sleep(std::time::Duration::from_millis(HOLD_MS));
+                    true
+                });
+            })
+        };
+        let setter = {
+            let c = c.clone();
+            let gate = gate.clone();
+            std::thread::spawn(move || {
+                gate.wait();
+                std::thread::sleep(std::time::Duration::from_millis(START_DELAY_MS));
+                let sampled = Instant::now();
+                let displaced = SyncConcurrentCached::cache_set(&c, 1, 20).unwrap();
+                (sampled, Instant::now(), displaced)
+            })
+        };
+        holder.join().expect("holder thread must not panic");
+        let (sampled, finished, displaced) = setter.join().expect("setter thread must not panic");
+
+        assert!(
+            sampled < expires_at,
+            "test timing: the setter must sample the clock while the entry is still live"
+        );
+        assert!(
+            finished > expires_at,
+            "test timing: the setter must stay blocked on the shard lock past the expiry"
+        );
+        assert_eq!(
+            displaced,
+            Some(10),
+            "the displaced entry is judged against the caller's own pre-lock sample, at \
+             which it was still live"
+        );
+        assert_eq!(
+            c.metrics().evictions,
+            Some(0),
+            "a displacement judged live must not count an eviction"
+        );
+        assert_eq!(
+            SyncConcurrentCached::cache_get(&c, &1).unwrap(),
+            Some(20),
+            "the replacement is stamped with the current TTL and is live"
+        );
+    }
+
+    #[test]
+    fn changing_the_ttl_never_restamps_stored_entries() {
+        // Runtime TTL changes apply to future stamps only. Entries carry their own
+        // `expires_at`, so shrinking the TTL must not retroactively expire live entries and
+        // growing it must not revive expired ones.
+        let c = ShardedTtlCacheBase::<u32, u32>::builder()
+            .ttl(Duration::from_secs(3600))
+            .shards(1)
+            .build()
+            .unwrap();
+        SyncConcurrentCached::cache_set(&c, 1, 10).expect("insert must succeed");
+        let stamped = stored_expiry(&c, 1).expect("key 1 stored");
+
+        assert_eq!(
+            c.set_ttl(Duration::from_millis(1)),
+            Some(Duration::from_secs(3600))
+        );
+        SyncConcurrentCached::cache_set(&c, 2, 20).expect("insert must succeed");
+        std::thread::sleep(std::time::Duration::from_millis(30));
+
+        assert_eq!(
+            stored_expiry(&c, 1),
+            Some(stamped),
+            "shrinking the TTL must not restamp a stored entry"
+        );
+        assert_eq!(
+            SyncConcurrentCached::cache_get(&c, &1).unwrap(),
+            Some(10),
+            "the long-stamped entry is still live"
+        );
+        assert_eq!(
+            SyncConcurrentCached::cache_get(&c, &2).unwrap(),
+            None,
+            "the short-stamped entry expired on its own stamp"
+        );
+        assert_eq!(c.metrics().evictions, Some(1));
+
+        // Growing the TTL back does not revive anything already removed, nor un-expire an
+        // entry whose stamp has passed.
+        SyncConcurrentCached::cache_set(&c, 3, 30).expect("insert must succeed");
+        std::thread::sleep(std::time::Duration::from_millis(30));
+        c.set_ttl(Duration::from_secs(3600));
+        assert_eq!(
+            SyncConcurrentCached::cache_get(&c, &3).unwrap(),
+            None,
+            "growing the TTL must not un-expire an already-stamped entry"
+        );
+        assert_eq!(c.metrics().evictions, Some(2));
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &1).unwrap(), Some(10));
+    }
+
+    #[test]
+    fn deep_clone_counters_are_independent_of_reset_metrics_on_either_handle() {
+        let c = ShardedTtlCacheBase::<u32, u32>::builder()
+            .ttl(Duration::from_secs(3600))
+            .shards(4)
+            .hasher(FixedShardHasher)
+            .build()
+            .unwrap();
+        for i in 0..16u32 {
+            SyncConcurrentCached::cache_set(&c, i, i * 10).expect("insert must succeed");
+        }
+        // Earn one of each counter kind.
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &0).unwrap(), Some(0));
+        assert_eq!(SyncConcurrentCached::cache_get(&c, &999).unwrap(), None);
+        assert_eq!(
+            SyncConcurrentCached::cache_remove(&c, &1).unwrap(),
+            Some(10)
+        );
+        let source_counters = shard_eviction_counters(&c);
+        let source_metrics = c.metrics();
+        assert_eq!(
+            (
+                source_metrics.hits,
+                source_metrics.misses,
+                source_metrics.evictions
+            ),
+            (Some(1), Some(1), Some(1))
+        );
+
+        let d = c.deep_clone();
+        assert_eq!(shard_eviction_counters(&d), source_counters);
+        let clone_metrics = d.metrics();
+        assert_eq!(
+            (
+                clone_metrics.hits,
+                clone_metrics.misses,
+                clone_metrics.evictions,
+                clone_metrics.entry_count
+            ),
+            (
+                source_metrics.hits,
+                source_metrics.misses,
+                source_metrics.evictions,
+                source_metrics.entry_count
+            ),
+            "deep_clone must carry every counter over"
+        );
+
+        // Reset on the source: the clone's counters are untouched.
+        ConcurrentCached::cache_reset_metrics(&c).unwrap();
+        assert_eq!(c.metrics().evictions, Some(0));
+        assert_eq!(shard_eviction_counters(&c), vec![0u64; 4]);
+        assert_eq!(
+            shard_eviction_counters(&d),
+            source_counters,
+            "resetting the source must not touch the clone"
+        );
+        assert_eq!(d.metrics().evictions, Some(1));
+        assert_eq!(c.len(), 15, "cache_reset_metrics must not remove any entry");
+
+        // Reset on the clone: the source (which has since earned counts again) is untouched.
+        assert!(SyncConcurrentCached::cache_delete(&c, &2).unwrap());
+        assert_eq!(c.metrics().evictions, Some(1));
+        ConcurrentCached::cache_reset_metrics(&d).unwrap();
+        assert_eq!(shard_eviction_counters(&d), vec![0u64; 4]);
+        assert_eq!(d.metrics().evictions, Some(0));
+        assert_eq!(
+            c.metrics().evictions,
+            Some(1),
+            "resetting the clone must not touch the source"
+        );
+
+        // The entry maps are independent too.
+        d.clear();
+        assert_eq!(d.len(), 0);
+        assert_eq!(c.len(), 14, "clearing the clone must not empty the source");
+    }
+
+    #[test]
+    fn copy_from_carries_entries_but_no_counters_and_fires_no_callback() {
+        // `copy_from` builds a fresh cache: it starts with zeroed counters even though the
+        // source has counts, and it reads (never removes) from the source, so the source's
+        // on_evict must stay silent.
+        let fired = Arc::new(AtomicU64::new(0));
+        let fired2 = fired.clone();
+        let src = ShardedTtlCacheBase::<u32, u32>::builder()
+            .ttl(Duration::from_secs(3600))
+            .shards(4)
+            .on_evict(move |_k: &u32, _v: &u32| {
+                fired2.fetch_add(1, Ordering::Relaxed);
+            })
+            .build()
+            .unwrap();
+        for i in 0..16u32 {
+            SyncConcurrentCached::cache_set(&src, i, i * 10).expect("insert must succeed");
+        }
+        assert_eq!(SyncConcurrentCached::cache_get(&src, &0).unwrap(), Some(0));
+        assert_eq!(SyncConcurrentCached::cache_get(&src, &999).unwrap(), None);
+        assert_eq!(
+            SyncConcurrentCached::cache_remove(&src, &1).unwrap(),
+            Some(10)
+        );
+        // A never-expires entry (TTL disabled at insert time) must survive the copy.
+        src.unset_ttl();
+        SyncConcurrentCached::cache_set(&src, 100, 1000).expect("insert must succeed");
+        src.set_ttl(Duration::from_secs(3600));
+        // An expired entry must not.
+        SyncConcurrentCached::cache_set(&src, 200, 2000).expect("insert must succeed");
+        set_expiry(&src, 200, Some(Instant::now()));
+
+        let src_before = src.metrics();
+        let fired_before = fired.load(Ordering::Relaxed);
+        assert_eq!(
+            fired_before, 1,
+            "only the explicit remove fired the callback"
+        );
+
+        let dst = ShardedTtlCacheBase::<u32, u32>::builder()
+            .ttl(Duration::from_secs(3600))
+            .shards(4)
+            .copy_from(&src)
+            .unwrap();
+
+        let dst_metrics = dst.metrics();
+        assert_eq!(
+            (dst_metrics.hits, dst_metrics.misses, dst_metrics.evictions),
+            (Some(0), Some(0), Some(0)),
+            "copy_from carries no counters at all"
+        );
+        assert_eq!(shard_eviction_counters(&dst), vec![0u64; 4]);
+        assert_eq!(
+            dst.len(),
+            16,
+            "fifteen live originals plus the never-expires entry, minus the expired one"
+        );
+        for i in 2..16u32 {
+            assert_eq!(dst.peek(&i), Some(i * 10));
+        }
+        assert_eq!(
+            dst.peek(&1),
+            None,
+            "an entry removed before the copy is gone"
+        );
+        assert_eq!(dst.peek(&200), None, "an expired entry is skipped");
+        assert_eq!(
+            stored_expiry(&dst, 100),
+            Some(None),
+            "a never-expires entry keeps its None stamp through the copy"
+        );
+
+        assert_eq!(
+            fired.load(Ordering::Relaxed),
+            fired_before,
+            "copy_from must not fire the source's on_evict"
+        );
+        let src_after = src.metrics();
+        assert_eq!(
+            (
+                src_after.hits,
+                src_after.misses,
+                src_after.evictions,
+                src_after.entry_count
+            ),
+            (
+                src_before.hits,
+                src_before.misses,
+                src_before.evictions,
+                src_before.entry_count
+            ),
+            "copy_from must leave the source's counters and entries alone"
+        );
+    }
+
+    #[test]
+    fn metrics_and_cache_evictions_agree_after_concurrent_evictions() {
+        // Per-shard relaxed loads mean a *mid-flight* aggregate can be torn, so only two
+        // things are guaranteed and asserted here: (1) an observer's successive aggregates
+        // never go backwards and never exceed the true total, because every per-shard read
+        // of one snapshot happens after every read of the previous one; (2) once the writers
+        // are joined, `metrics()`, `cache_evictions()` and the raw per-shard sum agree
+        // exactly.
+        const THREADS: u32 = 8;
+        const OPS: u32 = 250;
+        let c = ShardedTtlCacheBase::<u32, u32>::builder()
+            .ttl(Duration::from_secs(3600))
+            .shards(8)
+            .build()
+            .unwrap();
+        let total = u64::from(THREADS * OPS);
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let observer = {
+            let c = c.clone();
+            let stop = stop.clone();
+            std::thread::spawn(move || {
+                let mut last = 0u64;
+                let mut samples = 0u64;
+                while !stop.load(Ordering::Relaxed) {
+                    let seen = c.metrics().evictions.expect("evictions tracked");
+                    assert!(
+                        seen >= last,
+                        "a later aggregate must not go backwards ({seen} < {last})"
+                    );
+                    assert!(
+                        seen <= total,
+                        "the aggregate must never exceed the true total"
+                    );
+                    last = seen;
+                    samples += 1;
+                }
+                samples
+            })
+        };
+
+        let mut handles = Vec::new();
+        for t in 0..THREADS {
+            let c = c.clone();
+            handles.push(std::thread::spawn(move || {
+                for i in 0..OPS {
+                    let k = t * OPS + i;
+                    SyncConcurrentCached::cache_set(&c, k, k).expect("insert must succeed");
+                    assert_eq!(
+                        SyncConcurrentCached::cache_remove(&c, &k).unwrap(),
+                        Some(k),
+                        "each thread owns a disjoint key range"
+                    );
+                }
+            }));
+        }
+        for h in handles {
+            h.join().expect("worker thread must not panic");
+        }
+        stop.store(true, Ordering::Relaxed);
+        let samples = observer.join().expect("observer thread must not panic");
+        assert!(
+            samples > 0,
+            "the observer must have taken at least one sample"
+        );
+
+        assert_eq!(c.len(), 0, "every key was removed again");
+        assert_eq!(
+            c.metrics().evictions,
+            Some(total),
+            "every removal must be counted exactly once"
+        );
+        assert_eq!(ConcurrentCacheBase::cache_evictions(&c), Some(total));
+        assert_eq!(
+            shard_eviction_counters(&c).iter().sum::<u64>(),
+            total,
+            "the raw per-shard counters must sum to the same total"
+        );
+    }
+
+    #[test]
+    fn peek_contains_and_remove_apply_the_same_now_boundary() {
+        // The remaining converted read paths keep `now >= expires_at`, and the
+        // non-removing ones stay non-removing.
+        let c = ShardedTtlCacheBase::<u32, u32>::builder()
+            .ttl(Duration::from_secs(3600))
+            .shards(1)
+            .build()
+            .unwrap();
+        SyncConcurrentCached::cache_set(&c, 1, 10).expect("insert must succeed");
+        SyncConcurrentCached::cache_set(&c, 2, 20).expect("insert must succeed");
+        set_expiry(&c, 1, Some(Instant::now()));
+
+        assert!(!c.contains(&1), "expires_at == now reads as expired");
+        assert!(c.contains(&2));
+        assert_eq!(c.peek(&1), None);
+        assert_eq!(c.peek(&2), Some(20));
+        assert_eq!(
+            ConcurrentCloneCached::cache_peek_with_expiry_status(&c, &1),
+            (Some(10), true)
+        );
+        assert_eq!(c.len(), 2, "peek and contains must not remove anything");
+        assert_eq!(
+            c.metrics().evictions,
+            Some(0),
+            "peek and contains must not count evictions"
+        );
+
+        assert_eq!(
+            SyncConcurrentCached::cache_remove(&c, &1).unwrap(),
+            None,
+            "an expired entry is filtered from cache_remove's return"
+        );
+        assert_eq!(
+            c.metrics().evictions,
+            Some(1),
+            "cache_remove still counts the removal of an expired entry"
+        );
+        assert_eq!(c.len(), 1);
+        assert_eq!(
+            SyncConcurrentCached::cache_remove_entry(&c, &2).unwrap(),
+            Some((2, 20))
+        );
+        assert_eq!(c.metrics().evictions, Some(2));
+        assert_eq!(c.len(), 0);
+    }
+
+    #[test]
+    fn evict_is_callable_through_both_entry_points_under_the_key_clone_bound() {
+        // The one-pass rewrite no longer clones keys, but the public `K: Clone` bound on
+        // the inherent `evict` and on the `ConcurrentCacheEvict` impl was deliberately kept.
+        // A passing test cannot prove a bound is still *required* (that needs a
+        // compile-fail harness), so this pins the callable surface: both entry points
+        // resolve for a `K: Clone` key and agree on the swept count.
+        fn evict_both_ways<K: Clone + Hash + Eq, V: Clone>(c: &ShardedTtlCache<K, V>) -> usize {
+            let via_inherent = ShardedTtlCacheBase::evict(c);
+            let via_trait = ConcurrentCacheEvict::evict(c);
+            via_inherent + via_trait
+        }
+        let c = ShardedTtlCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(3600))
+            .build()
+            .unwrap();
+        SyncConcurrentCached::cache_set(&c, 1, 10).expect("insert must succeed");
+        assert_eq!(evict_both_ways(&c), 0, "nothing is expired");
+        assert_eq!(c.len(), 1);
     }
 }

--- a/src/stores/sharded/unbound.rs
+++ b/src/stores/sharded/unbound.rs
@@ -160,6 +160,7 @@ impl<K: Clone + Hash + Eq, V: Clone, H: ShardHasher<K>> ShardedUnboundCacheBase<
                     lock: parking_lot::RwLock::new(store_copy),
                     hits: AtomicU64::new(hits),
                     misses: AtomicU64::new(misses),
+                    evictions: AtomicU64::new(0),
                 };
                 CachePadded(shard)
             })
@@ -428,10 +429,12 @@ where
     fn cache_get(&self, k: &K) -> Result<Option<V>, Self::Error> {
         let shard = self.shard_of(k);
         let guard = shard.lock.read();
-        match guard.get(k) {
+        let found = guard.get(k).cloned();
+        drop(guard);
+        match found {
             Some(v) => {
                 shard.hits.fetch_add(1, Ordering::Relaxed);
-                Ok(Some(v.clone()))
+                Ok(Some(v))
             }
             None => {
                 shard.misses.fetch_add(1, Ordering::Relaxed);

--- a/src/stores/ttl.rs
+++ b/src/stores/ttl.rs
@@ -265,18 +265,29 @@ impl<K: Hash + Eq, V, S: BuildHasher> TtlCache<K, V, S> {
         expires_at.is_none_or(|t| Instant::now() < t)
     }
 
+    /// Same as [`entry_live`](Self::entry_live) but takes an already-sampled `now`
+    /// instead of reading the clock. Lets hot paths that already have `now` in hand
+    /// (e.g. a caller that just computed a fresh expiry) avoid a redundant clock read.
+    #[inline]
+    pub(super) fn entry_live_at(expires_at: Option<Instant>, now: Instant) -> bool {
+        expires_at.is_none_or(|t| now < t)
+    }
+
     /// Insert `entry` for `key`, returning the previous value only if it was still live.
     ///
     /// When the displaced previous value had already expired it is filtered from the return
     /// (matching the get paths), so it is dropped silently from the caller's view; in that case
     /// fire `on_evict` and count an eviction so resource cleanup and metrics stay consistent
     /// with the other removal paths.
-    fn set_entry(&mut self, key: K, entry: TimedEntry<V>) -> Option<V> {
+    ///
+    /// `now` is the caller's already-sampled clock reading, used to decide whether the
+    /// displaced entry was still live -- avoids a second `Instant::now()` call here.
+    fn set_entry(&mut self, key: K, entry: TimedEntry<V>, now: Instant) -> Option<V> {
         use std::collections::hash_map::Entry;
         match self.store.entry(key) {
             Entry::Occupied(mut occupied) => {
                 let old = occupied.insert(entry);
-                if Self::entry_live(old.expires_at) {
+                if Self::entry_live_at(old.expires_at, now) {
                     Some(old.value)
                 } else {
                     if let Some(on_evict) = &self.on_evict {
@@ -365,8 +376,11 @@ impl<K: Hash + Eq, V, S: BuildHasher> TtlCache<K, V, S> {
     pub fn retain<F: FnMut(&K, &V) -> bool>(&mut self, mut keep: F) {
         let on_evict = &self.on_evict;
         let evictions = &self.evictions;
+        // Sample the clock once for the whole eager sweep, as `evict` does above --
+        // one `now` shared across every entry instead of a clock read per entry.
+        let now = Instant::now();
         self.store.retain(|key, entry| {
-            let expired = !Self::entry_live(entry.expires_at);
+            let expired = !Self::entry_live_at(entry.expires_at, now);
             if expired || !keep(key, &entry.value) {
                 if let Some(on_evict) = on_evict {
                     on_evict(key, &entry.value);
@@ -390,12 +404,12 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for TtlCache<K, V, S> {
     {
         // Resolve hit / expired / absent from a SINGLE lookup: an absent key
         // (the common miss) must not pay a second `remove_entry` probe (CORE-7).
+        let now = Instant::now();
         let expired_present = match self.store.get_mut(key) {
-            Some(entry) if Self::entry_live(entry.expires_at) => {
+            Some(entry) if Self::entry_live_at(entry.expires_at, now) => {
                 self.hits.fetch_add(1, Ordering::Relaxed);
                 if self.refresh {
-                    entry.expires_at =
-                        Self::compute_expires_at(self.ttl, Instant::now()).or(entry.expires_at);
+                    entry.expires_at = Self::compute_expires_at(self.ttl, now).or(entry.expires_at);
                 }
                 // SAFETY: `ptr` points into a HashMap entry obtained from
                 // `get_mut`. We return immediately without modifying the map, so
@@ -425,12 +439,12 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for TtlCache<K, V, S> {
         Q: std::hash::Hash + Eq + ?Sized,
     {
         // Single lookup on the miss path, as in `cache_get` (CORE-7).
+        let now = Instant::now();
         let expired_present = match self.store.get_mut(key) {
-            Some(entry) if Self::entry_live(entry.expires_at) => {
+            Some(entry) if Self::entry_live_at(entry.expires_at, now) => {
                 self.hits.fetch_add(1, Ordering::Relaxed);
                 if self.refresh {
-                    entry.expires_at =
-                        Self::compute_expires_at(self.ttl, Instant::now()).or(entry.expires_at);
+                    entry.expires_at = Self::compute_expires_at(self.ttl, now).or(entry.expires_at);
                 }
                 // SAFETY: same as `cache_get` -- entry is not moved between
                 // obtaining the pointer and returning, and `&mut self` prevents
@@ -454,9 +468,11 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for TtlCache<K, V, S> {
     fn cache_get_or_set_with_mut<F: FnOnce() -> V>(&mut self, key: K, f: F) -> &mut V {
         match self.store.entry(key) {
             Entry::Occupied(mut occupied) => {
-                if Self::entry_live(occupied.get().expires_at) {
+                // Sample once and reuse for both the liveness check and the refresh
+                // computation below -- avoids a second clock read on the hit path.
+                let now = Instant::now();
+                if Self::entry_live_at(occupied.get().expires_at, now) {
                     if self.refresh {
-                        let now = Instant::now();
                         let new_exp =
                             Self::compute_expires_at(self.ttl, now).or(occupied.get().expires_at);
                         occupied.get_mut().expires_at = new_exp;
@@ -504,9 +520,11 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for TtlCache<K, V, S> {
     ) -> Result<&mut V, E> {
         match self.store.entry(key) {
             Entry::Occupied(mut occupied) => {
-                if Self::entry_live(occupied.get().expires_at) {
+                // Sample once and reuse for both the liveness check and the refresh
+                // computation below -- avoids a second clock read on the hit path.
+                let now = Instant::now();
+                if Self::entry_live_at(occupied.get().expires_at, now) {
                     if self.refresh {
-                        let now = Instant::now();
                         let new_exp =
                             Self::compute_expires_at(self.ttl, now).or(occupied.get().expires_at);
                         occupied.get_mut().expires_at = new_exp;
@@ -561,6 +579,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for TtlCache<K, V, S> {
                 expires_at,
                 value: val,
             },
+            now,
         )
     }
 
@@ -648,6 +667,11 @@ impl<K: Hash + Eq, V, S: BuildHasher> CachedIter<K, V> for TtlCache<K, V, S> {
         K: 'a,
         V: 'a,
     {
+        // Deliberately NOT hoisted (unlike the eager `retain`/`evict` sweeps above):
+        // this iterator is lazy and may be held and advanced over an arbitrary span
+        // of wall-clock time, so each item's liveness must be judged against a clock
+        // read taken at the moment that item is produced, not a single snapshot from
+        // when `iter()` was called.
         self.store.iter().filter_map(move |(k, entry)| {
             if Self::entry_live(entry.expires_at) {
                 Some((k, &entry.value))
@@ -713,14 +737,14 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher + Clone> CloneCached<K, V>
         Q: std::hash::Hash + Eq + ?Sized,
     {
         if let Some(entry) = self.store.get_mut(k) {
-            let expired = !Self::entry_live(entry.expires_at);
+            let now = Instant::now();
+            let expired = !Self::entry_live_at(entry.expires_at, now);
             if expired {
                 self.misses.fetch_add(1, Ordering::Relaxed);
                 (Some(entry.value.clone()), true)
             } else {
                 self.hits.fetch_add(1, Ordering::Relaxed);
                 if self.refresh {
-                    let now = Instant::now();
                     let new_exp = Self::compute_expires_at(self.ttl, now).or(entry.expires_at);
                     entry.expires_at = new_exp;
                 }
@@ -771,11 +795,13 @@ where
         Fut: Future<Output = V> + Send + 'a,
     {
         async move {
+            // One clock sample serves both the liveness check and the refresh
+            // recompute; the miss branch re-samples after the factory (CORE-3).
+            let now = Instant::now();
             match self.store.entry(k) {
                 Entry::Occupied(mut occupied) => {
-                    if Self::entry_live(occupied.get().expires_at) {
+                    if Self::entry_live_at(occupied.get().expires_at, now) {
                         if self.refresh {
-                            let now = Instant::now();
                             let new_exp = Self::compute_expires_at(self.ttl, now)
                                 .or(occupied.get().expires_at);
                             occupied.get_mut().expires_at = new_exp;
@@ -833,11 +859,13 @@ where
         Fut: Future<Output = Result<V, E>> + Send + 'a,
     {
         async move {
+            // One clock sample serves both the liveness check and the refresh
+            // recompute; the miss branch re-samples after the factory (CORE-3).
+            let now = Instant::now();
             let v = match self.store.entry(k) {
                 Entry::Occupied(mut occupied) => {
-                    if Self::entry_live(occupied.get().expires_at) {
+                    if Self::entry_live_at(occupied.get().expires_at, now) {
                         if self.refresh {
-                            let now = Instant::now();
                             let new_exp = Self::compute_expires_at(self.ttl, now)
                                 .or(occupied.get().expires_at);
                             occupied.get_mut().expires_at = new_exp;
@@ -1695,6 +1723,784 @@ mod tests {
             c.cache_peek(&1),
             Some(&200),
             "the new value must be cached and live"
+        );
+    }
+
+    // PERF-1: `entry_live_at` must preserve the exact same `now >= expires_at`
+    // boundary convention as `entry_live` (which reads `Instant::now()` internally).
+    // At `now == expires_at` the entry must be considered expired, mirroring
+    // `entry_live`'s strict `now < t` liveness check.
+    #[test]
+    fn entry_live_at_matches_now_ge_expires_at_is_expired_convention() {
+        let now = Instant::now();
+        let future = now + crate::time::Duration::from_millis(10);
+        let past = now - crate::time::Duration::from_millis(10);
+
+        // `expires_at = None` never expires, regardless of `now`.
+        assert!(TtlCache::<u32, u32>::entry_live_at(None, now));
+        // `now < expires_at`: live.
+        assert!(TtlCache::<u32, u32>::entry_live_at(Some(future), now));
+        // `now == expires_at`: the boundary itself is NOT live.
+        assert!(!TtlCache::<u32, u32>::entry_live_at(Some(now), now));
+        // `now > expires_at`: not live.
+        assert!(!TtlCache::<u32, u32>::entry_live_at(Some(past), now));
+    }
+
+    // PERF-1: `retain`'s eager sweep now samples the clock once per call (mirroring
+    // `evict`) instead of once per entry. Expired entries must still be removed
+    // unconditionally, regardless of what the predicate returns.
+    #[test]
+    fn retain_removes_expired_entries_regardless_of_predicate() {
+        let mut c: TtlCache<u32, u32> = TtlCache::builder()
+            .ttl(crate::time::Duration::from_millis(30))
+            .build()
+            .unwrap();
+        c.cache_set(1, 10);
+        std::thread::sleep(std::time::Duration::from_millis(80));
+        // Inserted after the sleep: still live relative to the single `now` sampled
+        // at the top of `retain`.
+        c.cache_set(2, 20);
+
+        // Predicate always says "keep" -- the expired entry must be swept anyway.
+        c.retain(|_, _| true);
+
+        assert_eq!(
+            c.cache_size(),
+            1,
+            "expired entry must be removed even though the predicate kept it"
+        );
+        assert_eq!(
+            c.cache_peek(&2),
+            Some(&20),
+            "live entry kept by the predicate must survive"
+        );
+    }
+
+    // PERF-1: with `refresh_on_hit`, a hit must extend the entry's expiry by the
+    // FULL configured ttl measured from the moment of the hit -- not by
+    // ttl-minus-epsilon (e.g. from a stale/earlier clock read). Verified directly
+    // against the stored `expires_at`, bracketed by clock reads taken immediately
+    // before and after the hit.
+    #[test]
+    fn refresh_on_hit_extends_expiry_by_full_ttl_from_hit_time() {
+        let ttl = crate::time::Duration::from_millis(200);
+        let mut c: TtlCache<u32, u32> = TtlCache::builder()
+            .ttl(ttl)
+            .refresh_on_hit(true)
+            .build()
+            .unwrap();
+        c.cache_set(1, 100);
+        std::thread::sleep(std::time::Duration::from_millis(80));
+
+        let before = Instant::now();
+        assert_eq!(c.cache_get(&1), Some(&100));
+        let after = Instant::now();
+
+        let expires_at = c
+            .store
+            .get(&1)
+            .expect("entry must still be present after the hit")
+            .expires_at
+            .expect("ttl is configured, so the entry must carry an expiry");
+        assert!(
+            expires_at >= before + ttl,
+            "refresh must extend by the FULL ttl measured from the hit, not less"
+        );
+        assert!(
+            expires_at <= after + ttl,
+            "refresh must not anchor to a clock read taken before the hit"
+        );
+    }
+
+    // --- PERF-1 boundary coverage: every call site converted to `entry_live_at`
+    // must preserve the exact `now >= expires_at` boundary, not just the pure
+    // helper (already pinned above by
+    // `entry_live_at_matches_now_ge_expires_at_is_expired_convention`).
+    //
+    // Each test below crafts a `TimedEntry` directly (the store field is
+    // `pub(crate)`) with `expires_at` set to an `Instant` sampled just before the
+    // call under test. Because the process clock is monotonic, the call's own
+    // internal `Instant::now()` read is guaranteed to be `>= ` that sampled
+    // instant, so this deterministically exercises the "tie or later" edge of the
+    // boundary without needing a mock clock. A comfortably-future `expires_at`
+    // exercises the live side, and `expires_at = None` exercises "never expires".
+
+    #[test]
+    fn cache_get_boundary_matches_now_ge_expires_at_convention() {
+        let mut c: TtlCache<u32, u32> = TtlCache::builder()
+            .ttl(crate::time::Duration::from_secs(60))
+            .build()
+            .unwrap();
+
+        let tie = Instant::now();
+        c.store.insert(
+            1,
+            TimedEntry {
+                expires_at: Some(tie),
+                value: 100,
+            },
+        );
+        assert_eq!(
+            c.cache_get(&1),
+            None,
+            "tie (now >= expires_at) must be a miss"
+        );
+        assert_eq!(c.cache_size(), 0, "expired entry must be swept on access");
+
+        let future = Instant::now() + crate::time::Duration::from_millis(200);
+        c.store.insert(
+            2,
+            TimedEntry {
+                expires_at: Some(future),
+                value: 200,
+            },
+        );
+        assert_eq!(
+            c.cache_get(&2),
+            Some(&200),
+            "now < expires_at must be a hit"
+        );
+
+        c.store.insert(
+            3,
+            TimedEntry {
+                expires_at: None,
+                value: 300,
+            },
+        );
+        std::thread::sleep(std::time::Duration::from_millis(30));
+        assert_eq!(
+            c.cache_get(&3),
+            Some(&300),
+            "expires_at = None never expires"
+        );
+    }
+
+    #[test]
+    fn cache_get_mut_boundary_matches_now_ge_expires_at_convention() {
+        let mut c: TtlCache<u32, u32> = TtlCache::builder()
+            .ttl(crate::time::Duration::from_secs(60))
+            .build()
+            .unwrap();
+
+        let tie = Instant::now();
+        c.store.insert(
+            1,
+            TimedEntry {
+                expires_at: Some(tie),
+                value: 100,
+            },
+        );
+        assert_eq!(
+            c.cache_get_mut(&1),
+            None,
+            "tie (now >= expires_at) must be a miss"
+        );
+        assert_eq!(c.cache_size(), 0, "expired entry must be swept on access");
+
+        let future = Instant::now() + crate::time::Duration::from_millis(200);
+        c.store.insert(
+            2,
+            TimedEntry {
+                expires_at: Some(future),
+                value: 200,
+            },
+        );
+        assert_eq!(
+            c.cache_get_mut(&2).map(|v| *v),
+            Some(200),
+            "now < expires_at must be a hit"
+        );
+
+        c.store.insert(
+            3,
+            TimedEntry {
+                expires_at: None,
+                value: 300,
+            },
+        );
+        std::thread::sleep(std::time::Duration::from_millis(30));
+        assert_eq!(
+            c.cache_get_mut(&3).map(|v| *v),
+            Some(300),
+            "expires_at = None never expires"
+        );
+    }
+
+    #[test]
+    fn cache_set_previous_value_liveness_boundary_matches_convention() {
+        let fired = Arc::new(AtomicUsize::new(0));
+        let fired2 = fired.clone();
+        let mut c: TtlCache<u32, u32> = TtlCache::builder()
+            .ttl(crate::time::Duration::from_secs(60))
+            .on_evict(move |_k: &u32, _v: &u32| {
+                fired2.fetch_add(1, Ordering::Relaxed);
+            })
+            .build()
+            .unwrap();
+
+        // Tie: `set_entry`'s previous-value liveness check must treat this as
+        // expired -- filtered from the return, on_evict fires, eviction counted.
+        let tie = Instant::now();
+        c.store.insert(
+            1,
+            TimedEntry {
+                expires_at: Some(tie),
+                value: 100,
+            },
+        );
+        assert_eq!(
+            c.cache_set(1, 999),
+            None,
+            "tie (now >= expires_at) previous value must be filtered as expired"
+        );
+        assert_eq!(fired.load(Ordering::Relaxed), 1);
+        assert_eq!(c.cache_evictions(), Some(1));
+
+        // Comfortably future: previous value is still live and must be returned,
+        // with no on_evict / eviction bump.
+        let future = Instant::now() + crate::time::Duration::from_millis(200);
+        c.store.insert(
+            2,
+            TimedEntry {
+                expires_at: Some(future),
+                value: 200,
+            },
+        );
+        assert_eq!(
+            c.cache_set(2, 888),
+            Some(200),
+            "now < expires_at: previous value must be returned, not filtered"
+        );
+        assert_eq!(
+            fired.load(Ordering::Relaxed),
+            1,
+            "no new eviction for a live overwrite"
+        );
+        assert_eq!(c.cache_evictions(), Some(1));
+
+        // None: previous value never expires, must always be returned.
+        c.store.insert(
+            3,
+            TimedEntry {
+                expires_at: None,
+                value: 300,
+            },
+        );
+        std::thread::sleep(std::time::Duration::from_millis(30));
+        assert_eq!(
+            c.cache_set(3, 777),
+            Some(300),
+            "expires_at = None previous value never expires"
+        );
+        assert_eq!(fired.load(Ordering::Relaxed), 1);
+        assert_eq!(c.cache_evictions(), Some(1));
+    }
+
+    #[test]
+    fn cache_get_or_set_with_mut_hit_liveness_boundary_matches_convention() {
+        let mut c: TtlCache<u32, u32> = TtlCache::builder()
+            .ttl(crate::time::Duration::from_secs(60))
+            .build()
+            .unwrap();
+
+        // Tie: expired -> the factory MUST run (miss + expired-replace branch).
+        let tie = Instant::now();
+        c.store.insert(
+            1,
+            TimedEntry {
+                expires_at: Some(tie),
+                value: 100,
+            },
+        );
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls2 = calls.clone();
+        let val = c.cache_get_or_set_with_mut(1u32, move || {
+            calls2.fetch_add(1, Ordering::Relaxed);
+            999u32
+        });
+        assert_eq!(
+            *val, 999,
+            "tie must be treated as expired: factory value used"
+        );
+        assert_eq!(
+            calls.load(Ordering::Relaxed),
+            1,
+            "factory must run at the tie boundary"
+        );
+
+        // Comfortably future: live -> factory must NOT run.
+        let future = Instant::now() + crate::time::Duration::from_millis(200);
+        c.store.insert(
+            2,
+            TimedEntry {
+                expires_at: Some(future),
+                value: 200,
+            },
+        );
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls2 = calls.clone();
+        let val = c.cache_get_or_set_with_mut(2u32, move || {
+            calls2.fetch_add(1, Ordering::Relaxed);
+            999u32
+        });
+        assert_eq!(
+            *val, 200,
+            "now < expires_at must be a hit: existing value returned"
+        );
+        assert_eq!(
+            calls.load(Ordering::Relaxed),
+            0,
+            "factory must not run on a hit"
+        );
+
+        // None: never expires -> always a hit, even after elapsed time.
+        c.store.insert(
+            3,
+            TimedEntry {
+                expires_at: None,
+                value: 300,
+            },
+        );
+        std::thread::sleep(std::time::Duration::from_millis(30));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls2 = calls.clone();
+        let val = c.cache_get_or_set_with_mut(3u32, move || {
+            calls2.fetch_add(1, Ordering::Relaxed);
+            999u32
+        });
+        assert_eq!(*val, 300, "expires_at = None must always be a hit");
+        assert_eq!(calls.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn cache_try_get_or_set_with_mut_hit_liveness_boundary_matches_convention() {
+        let mut c: TtlCache<u32, u32> = TtlCache::builder()
+            .ttl(crate::time::Duration::from_secs(60))
+            .build()
+            .unwrap();
+
+        let tie = Instant::now();
+        c.store.insert(
+            1,
+            TimedEntry {
+                expires_at: Some(tie),
+                value: 100,
+            },
+        );
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls2 = calls.clone();
+        let val: Result<&mut u32, ()> = c.cache_try_get_or_set_with_mut(1u32, move || {
+            calls2.fetch_add(1, Ordering::Relaxed);
+            Ok(999u32)
+        });
+        assert_eq!(
+            *val.unwrap(),
+            999,
+            "tie must be treated as expired: factory value used"
+        );
+        assert_eq!(
+            calls.load(Ordering::Relaxed),
+            1,
+            "factory must run at the tie boundary"
+        );
+
+        let future = Instant::now() + crate::time::Duration::from_millis(200);
+        c.store.insert(
+            2,
+            TimedEntry {
+                expires_at: Some(future),
+                value: 200,
+            },
+        );
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls2 = calls.clone();
+        let val: Result<&mut u32, ()> = c.cache_try_get_or_set_with_mut(2u32, move || {
+            calls2.fetch_add(1, Ordering::Relaxed);
+            Ok(999u32)
+        });
+        assert_eq!(
+            *val.unwrap(),
+            200,
+            "now < expires_at must be a hit: existing value returned"
+        );
+        assert_eq!(
+            calls.load(Ordering::Relaxed),
+            0,
+            "factory must not run on a hit"
+        );
+
+        c.store.insert(
+            3,
+            TimedEntry {
+                expires_at: None,
+                value: 300,
+            },
+        );
+        std::thread::sleep(std::time::Duration::from_millis(30));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls2 = calls.clone();
+        let val: Result<&mut u32, ()> = c.cache_try_get_or_set_with_mut(3u32, move || {
+            calls2.fetch_add(1, Ordering::Relaxed);
+            Ok(999u32)
+        });
+        assert_eq!(*val.unwrap(), 300, "expires_at = None must always be a hit");
+        assert_eq!(calls.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn cache_get_with_expiry_status_boundary_matches_convention() {
+        let mut c: TtlCache<u32, u32> = TtlCache::builder()
+            .ttl(crate::time::Duration::from_secs(60))
+            .build()
+            .unwrap();
+
+        let tie = Instant::now();
+        c.store.insert(
+            1,
+            TimedEntry {
+                expires_at: Some(tie),
+                value: 100,
+            },
+        );
+        assert_eq!(
+            c.cache_get_with_expiry_status(&1u32),
+            (Some(100), true),
+            "tie (now >= expires_at) must report expired=true"
+        );
+
+        let future = Instant::now() + crate::time::Duration::from_millis(200);
+        c.store.insert(
+            2,
+            TimedEntry {
+                expires_at: Some(future),
+                value: 200,
+            },
+        );
+        assert_eq!(
+            c.cache_get_with_expiry_status(&2u32),
+            (Some(200), false),
+            "now < expires_at must report expired=false"
+        );
+
+        c.store.insert(
+            3,
+            TimedEntry {
+                expires_at: None,
+                value: 300,
+            },
+        );
+        std::thread::sleep(std::time::Duration::from_millis(30));
+        assert_eq!(
+            c.cache_get_with_expiry_status(&3u32),
+            (Some(300), false),
+            "expires_at = None must always report expired=false"
+        );
+    }
+
+    #[test]
+    fn retain_boundary_matches_now_ge_expires_at_convention() {
+        let mut c: TtlCache<u32, u32> = TtlCache::builder()
+            .ttl(crate::time::Duration::from_secs(60))
+            .build()
+            .unwrap();
+
+        // Tie: expires_at == an instant sampled just before retain() is invoked.
+        // retain's hoisted `now` is sampled strictly later, so this entry must be
+        // removed unconditionally, even though the predicate says "keep".
+        let tie = Instant::now();
+        c.store.insert(
+            1,
+            TimedEntry {
+                expires_at: Some(tie),
+                value: 100,
+            },
+        );
+
+        // None: never expires, so retain must only remove it if the predicate says so.
+        c.store.insert(
+            2,
+            TimedEntry {
+                expires_at: None,
+                value: 200,
+            },
+        );
+
+        c.retain(|_, _| true);
+
+        assert_eq!(
+            c.cache_size(),
+            1,
+            "tie entry must be swept regardless of predicate"
+        );
+        assert_eq!(
+            c.cache_peek(&2),
+            Some(&200),
+            "never-expiring entry kept by predicate must survive"
+        );
+    }
+
+    // PERF-1: `retain`'s hoisted `now` is a single snapshot taken BEFORE the sweep
+    // begins (mirroring `evict`). An entry that was live at that snapshot must
+    // stay judged live for the whole pass, even if real wall-clock time advances
+    // past its expiry while the predicate is busy on other entries. A regression
+    // back to a per-entry `Instant::now()` read would evict entries examined later
+    // in the pass despite every entry having been live when `retain()` began.
+    #[test]
+    fn retain_judges_every_entry_against_the_pass_start_snapshot() {
+        let margin = crate::time::Duration::from_millis(35);
+        let mut c: TtlCache<u32, u32> = TtlCache::builder()
+            .ttl(crate::time::Duration::from_secs(60))
+            .build()
+            .unwrap();
+
+        // 6 entries, all live at "now" (the snapshot retain() will take), all
+        // sharing the same expires_at margin above it.
+        let base = Instant::now();
+        let expires_at = base + margin;
+        for k in 0..6u32 {
+            c.store.insert(
+                k,
+                TimedEntry {
+                    expires_at: Some(expires_at),
+                    value: k,
+                },
+            );
+        }
+
+        // The predicate sleeps on every call. With 6 entries at 20ms each, the
+        // cumulative elapsed time crosses the 35ms margin partway through the
+        // pass -- enough that a per-entry `Instant::now()` read would see entries
+        // examined later in the pass as expired, even though every entry was live
+        // when `retain()` began.
+        c.retain(|_, _| {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            true
+        });
+
+        assert_eq!(
+            c.cache_size(),
+            6,
+            "every entry must be judged live against the pass-start snapshot, \
+             regardless of how long the predicate takes on other entries"
+        );
+    }
+
+    // Confirms `CachedIter::iter` was deliberately NOT changed to hoist `now`
+    // (unlike `retain`/`evict`): a lazy iterator advanced after a delay must judge
+    // each item against a clock read taken at production time, not at the time
+    // `iter()` was called.
+    #[test]
+    fn iter_judges_each_item_at_production_time_not_at_iter_call_time() {
+        let mut c: TtlCache<u32, u32> = TtlCache::builder()
+            .ttl(crate::time::Duration::from_secs(60))
+            .build()
+            .unwrap();
+        let expires_at = Instant::now() + crate::time::Duration::from_millis(30);
+        c.store.insert(
+            1,
+            TimedEntry {
+                expires_at: Some(expires_at),
+                value: 100,
+            },
+        );
+
+        // The entry is live at the moment `iter()` is called -- building the lazy
+        // iterator does not itself read the clock.
+        let mut it = c.iter();
+
+        // Advance real time past the entry's expiry BEFORE consuming the iterator.
+        std::thread::sleep(std::time::Duration::from_millis(60));
+
+        assert_eq!(
+            it.next(),
+            None,
+            "item must be judged expired at consumption time, proving `iter` samples \
+             the clock per item rather than hoisting a single snapshot from iter() call time"
+        );
+    }
+
+    // PERF-1 / CORE-3 (sync): the expiry for a freshly-replaced expired entry must
+    // be anchored to the clock read taken AFTER the factory resolves, not the
+    // sample taken before the liveness check. A factory slower than the ttl proves
+    // this: if the expiry were computed from the pre-factory sample, the
+    // freshly-inserted entry would already be expired the instant it lands.
+    #[test]
+    fn cache_get_or_set_with_mut_expiry_anchored_after_slow_factory() {
+        let mut c: TtlCache<u32, u32> = TtlCache::builder()
+            .ttl(crate::time::Duration::from_millis(40))
+            .build()
+            .unwrap();
+        c.cache_set(1, 100);
+        std::thread::sleep(std::time::Duration::from_millis(60)); // now expired
+
+        let val = c.cache_get_or_set_with_mut(1u32, || {
+            std::thread::sleep(std::time::Duration::from_millis(120)); // 3x the ttl
+            200u32
+        });
+        assert_eq!(*val, 200);
+        assert_eq!(
+            c.cache_peek(&1),
+            Some(&200),
+            "entry must be live immediately after a factory slower than the ttl \
+             resolves -- expiry must be anchored post-factory, not pre-factory"
+        );
+    }
+
+    #[test]
+    fn cache_try_get_or_set_with_mut_expiry_anchored_after_slow_factory() {
+        let mut c: TtlCache<u32, u32> = TtlCache::builder()
+            .ttl(crate::time::Duration::from_millis(40))
+            .build()
+            .unwrap();
+        c.cache_set(1, 100);
+        std::thread::sleep(std::time::Duration::from_millis(60)); // now expired
+
+        let val: Result<&mut u32, ()> = c.cache_try_get_or_set_with_mut(1u32, || {
+            std::thread::sleep(std::time::Duration::from_millis(120)); // 3x the ttl
+            Ok(200u32)
+        });
+        assert_eq!(*val.unwrap(), 200);
+        assert_eq!(
+            c.cache_peek(&1),
+            Some(&200),
+            "entry must be live immediately after a factory slower than the ttl \
+             resolves -- expiry must be anchored post-factory, not pre-factory"
+        );
+    }
+
+    // Tight bracketing refresh-on-hit tests, mirroring
+    // `refresh_on_hit_extends_expiry_by_full_ttl_from_hit_time` (for `cache_get`)
+    // on the other call sites the `now`-threading change touched. Threading made
+    // the liveness-check sample and the refresh-compute sample the SAME value at
+    // each site, so these can no longer distinguish "pre-check" from "post-check"
+    // anchoring (that distinction no longer exists structurally) -- they instead
+    // pin the property that actually matters: the persisted `expires_at` reflects
+    // a full ttl measured from within the call, not a partial/stale extension.
+
+    #[test]
+    fn cache_get_mut_refresh_extends_expiry_by_full_ttl_from_hit_time() {
+        let ttl = crate::time::Duration::from_millis(200);
+        let mut c: TtlCache<u32, u32> = TtlCache::builder()
+            .ttl(ttl)
+            .refresh_on_hit(true)
+            .build()
+            .unwrap();
+        c.cache_set(1, 100);
+        std::thread::sleep(std::time::Duration::from_millis(80));
+
+        let before = Instant::now();
+        assert_eq!(c.cache_get_mut(&1).map(|v| *v), Some(100));
+        let after = Instant::now();
+
+        let expires_at = c
+            .store
+            .get(&1)
+            .expect("entry must still be present after the hit")
+            .expires_at
+            .expect("ttl is configured, so the entry must carry an expiry");
+        assert!(
+            expires_at >= before + ttl,
+            "refresh must extend by the FULL ttl measured from the hit, not less"
+        );
+        assert!(
+            expires_at <= after + ttl,
+            "refresh must not anchor to a clock read taken before the hit"
+        );
+    }
+
+    #[test]
+    fn cache_get_or_set_with_mut_refresh_extends_expiry_by_full_ttl_from_hit_time() {
+        let ttl = crate::time::Duration::from_millis(200);
+        let mut c: TtlCache<u32, u32> = TtlCache::builder()
+            .ttl(ttl)
+            .refresh_on_hit(true)
+            .build()
+            .unwrap();
+        c.cache_set(1, 100);
+        std::thread::sleep(std::time::Duration::from_millis(80));
+
+        let before = Instant::now();
+        let val = c.cache_get_or_set_with_mut(1u32, || 999u32);
+        assert_eq!(*val, 100, "still a hit, factory ignored");
+        let after = Instant::now();
+
+        let expires_at = c
+            .store
+            .get(&1)
+            .expect("entry must still be present after the hit")
+            .expires_at
+            .expect("ttl is configured, so the entry must carry an expiry");
+        assert!(
+            expires_at >= before + ttl,
+            "refresh must extend by the FULL ttl measured from the hit, not less"
+        );
+        assert!(
+            expires_at <= after + ttl,
+            "refresh must not anchor to a clock read taken before the hit"
+        );
+    }
+
+    #[test]
+    fn cache_try_get_or_set_with_mut_refresh_extends_expiry_by_full_ttl_from_hit_time() {
+        let ttl = crate::time::Duration::from_millis(200);
+        let mut c: TtlCache<u32, u32> = TtlCache::builder()
+            .ttl(ttl)
+            .refresh_on_hit(true)
+            .build()
+            .unwrap();
+        c.cache_set(1, 100);
+        std::thread::sleep(std::time::Duration::from_millis(80));
+
+        let before = Instant::now();
+        let val: Result<&mut u32, ()> = c.cache_try_get_or_set_with_mut(1u32, || Ok(999u32));
+        assert_eq!(*val.unwrap(), 100, "still a hit, factory ignored");
+        let after = Instant::now();
+
+        let expires_at = c
+            .store
+            .get(&1)
+            .expect("entry must still be present after the hit")
+            .expires_at
+            .expect("ttl is configured, so the entry must carry an expiry");
+        assert!(
+            expires_at >= before + ttl,
+            "refresh must extend by the FULL ttl measured from the hit, not less"
+        );
+        assert!(
+            expires_at <= after + ttl,
+            "refresh must not anchor to a clock read taken before the hit"
+        );
+    }
+
+    #[test]
+    fn cache_get_with_expiry_status_refresh_extends_expiry_by_full_ttl_from_hit_time() {
+        let ttl = crate::time::Duration::from_millis(200);
+        let mut c: TtlCache<u32, u32> = TtlCache::builder()
+            .ttl(ttl)
+            .refresh_on_hit(true)
+            .build()
+            .unwrap();
+        c.cache_set(1, 100);
+        std::thread::sleep(std::time::Duration::from_millis(80));
+
+        let before = Instant::now();
+        assert_eq!(c.cache_get_with_expiry_status(&1u32), (Some(100), false));
+        let after = Instant::now();
+
+        let expires_at = c
+            .store
+            .get(&1)
+            .expect("entry must still be present after the hit")
+            .expires_at
+            .expect("ttl is configured, so the entry must carry an expiry");
+        assert!(
+            expires_at >= before + ttl,
+            "refresh must extend by the FULL ttl measured from the hit, not less"
+        );
+        assert!(
+            expires_at <= after + ttl,
+            "refresh must not anchor to a clock read taken before the hit"
         );
     }
 }

--- a/src/stores/ttl_sorted.rs
+++ b/src/stores/ttl_sorted.rs
@@ -2573,7 +2573,11 @@ mod test {
             "map and keys must stay in lockstep across a Drop panic (no orphaned rows)"
         );
         // Every entry had expired, so the sweep drained the whole prefix from both.
-        assert_eq!(cache.map.len(), 0, "all expired entries must have left the map");
+        assert_eq!(
+            cache.map.len(),
+            0,
+            "all expired entries must have left the map"
+        );
         assert_eq!(cache.cache_size(), 0);
         // The counter is incremented before the drain `Vec` drops, so it reflects exactly
         // the three rows pulled from the map. Pre-fix the batched `fetch_add` after the loop

--- a/src/stores/ttl_sorted.rs
+++ b/src/stores/ttl_sorted.rs
@@ -7,7 +7,6 @@ use std::borrow::Borrow;
 use std::cmp::Ordering as CmpOrdering;
 use std::collections::BTreeSet;
 use std::hash::{BuildHasher, Hash, Hasher};
-use std::ops::Bound::{Excluded, Included};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 #[cfg(feature = "async_core")]
@@ -108,6 +107,10 @@ impl<K> Stamped<K> {
     /// Build a sentinel `Stamped` for use as a BTreeSet range bound.
     /// Only `Some(expiry)` bounds are used for expiry-sweep ranges; never-expiring
     /// entries (`None`) sort beyond all `Some(_)` values and are excluded automatically.
+    ///
+    /// This is the canonical constructor for the `key: None` sentinel that the `Option` in
+    /// [`Stamped::key`] exists for: [`TtlSortedCache::evict_at`] uses it as the `split_off`
+    /// pivot, and the tests use it to re-derive the pre-refactor range-based expected counts.
     fn bound(expiry: Instant) -> Stamped<K> {
         Stamped {
             expiry: Some(expiry),
@@ -553,36 +556,79 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> TtlSortedCache<K, V, S> {
     /// Returns number of dropped items.
     #[must_use]
     pub fn evict(&mut self) -> usize {
-        let cutoff = Instant::now();
-        let min = Stamped::bound(self.min_instant);
-        let max = Stamped::bound(cutoff);
-        let min = Included(&min);
-        // `Stamped::bound(cutoff)` has `key: None`, which sorts below every real entry at the
-        // same expiry, so a real entry expiring exactly at `cutoff` is never in this range under
-        // either `Excluded` or `Included`. That matches `is_expired_at`'s at-or-after boundary in
-        // practice: `cutoff` is sampled here, so no stored expiry (computed at an earlier insert)
-        // ever equals it, and any entry that did tie is caught by the next `is_expired` get.
-        let max = Excluded(&max);
-        let remove = self.keys.range((min, max)).count();
+        self.evict_at(Instant::now())
+    }
 
-        let mut count = 0;
-        while count < remove {
-            match self.keys.pop_first() {
-                None => break,
-                Some(stamped) => {
-                    // Invariant: `None` keys are only used as artificial range sentinels
-                    // in `evict()`/`retain_latest()` and are never inserted into `self.keys`.
-                    let key = stamped
-                        .key
-                        .expect("evicting: only artificial bounds are none");
-                    if let Some(entry) = self.map.remove(key.0.as_ref()) {
-                        if let Some(on_evict) = &self.on_evict {
-                            on_evict(key.0.as_ref(), &entry.value);
-                        }
-                        self.evictions.fetch_add(1, AtomicOrdering::Relaxed);
-                    }
-                    count += 1;
+    /// [`evict`](Self::evict) against an explicit `cutoff`, so a caller that already sampled
+    /// the clock (e.g. [`set_inner`](Self::set_inner) on an evicting insert) does not pay for a
+    /// second `Instant::now()`.
+    ///
+    /// The expired entries are exactly the front prefix of `self.keys`: the index is ordered by
+    /// expiry and `None` (never-expires) sorts GREATEST (see [`Stamped`]'s `Ord`). Rather than
+    /// counting a range and then popping the same prefix one entry at a time (two traversals,
+    /// and an `O(log n)` rebalance per popped entry), the prefix is detached in one
+    /// `split_off` and drained by value: the split is a single `O(log n)` descent and the
+    /// drain is an in-order walk of a tree that is being consumed, so no rebalancing happens
+    /// at all.
+    ///
+    /// The boundary is `expiry < cutoff` (strictly-less), exactly what the previous
+    /// `range(Included(bound(min_instant))..Excluded(bound(cutoff)))` selected: the sentinel
+    /// `Stamped::bound(cutoff)` carries `key: None`, which sorts below every real key at the
+    /// same expiry, so a real entry expiring exactly at `cutoff` stays on the live side under
+    /// `split_off` just as it was excluded from the old range. That matches `is_expired_at`'s
+    /// at-or-after boundary in practice: `cutoff` is sampled by the caller, so no stored expiry
+    /// (computed at an earlier insert) ever equals it, and any entry that did tie is caught by
+    /// the next `is_expired` get. The old `min_instant` lower bound is likewise unnecessary —
+    /// every stored expiry is `>= min_instant` by construction (it is `insert_time + ttl` and
+    /// the cache was built before any insert) — so dropping it saves a tree descent.
+    ///
+    /// Returns the number of index entries dropped (matching the old `pop_first` count), while
+    /// `evictions` counts only the entries that were actually present in the map.
+    fn evict_at(&mut self, cutoff: Instant) -> usize {
+        // Detach `[.., cutoff)` in one operation: `split_off` leaves everything BELOW the
+        // sentinel in `self.keys` and returns the rest, so swap the two halves back.
+        let live = self.keys.split_off(&Stamped::bound(cutoff));
+        let expired = std::mem::replace(&mut self.keys, live);
+        let count = expired.len();
+        if count == 0 {
+            return 0;
+        }
+
+        if self.on_evict.is_none() {
+            let mut evicted = 0u64;
+            for stamped in expired {
+                // Invariant: `None` keys are only used as artificial range sentinels
+                // in `evict()`/`retain_latest()` and are never inserted into `self.keys`.
+                let key = stamped
+                    .key
+                    .expect("evicting: only artificial bounds are none");
+                if self.map.remove(key.0.as_ref()).is_some() {
+                    evicted += 1;
                 }
+            }
+            self.evictions.fetch_add(evicted, AtomicOrdering::Relaxed);
+            return count;
+        }
+
+        // With a callback configured, drain both structures FIRST and fire `on_evict` only
+        // once every removal is done — as `retain` does. Firing mid-drain would let a
+        // panicking callback unwind with the remaining stamps already detached from
+        // `self.keys` but their entries still in `self.map`, orphaning them: invisible to a
+        // later sweep yet still counted by `len`.
+        let mut removed = Vec::with_capacity(count);
+        for stamped in expired {
+            let key = stamped
+                .key
+                .expect("evicting: only artificial bounds are none");
+            if let Some(entry) = self.map.remove(key.0.as_ref()) {
+                removed.push((key, entry));
+            }
+        }
+        self.evictions
+            .fetch_add(removed.len() as u64, AtomicOrdering::Relaxed);
+        if let Some(on_evict) = &self.on_evict {
+            for (key, entry) in &removed {
+                on_evict(key.0.as_ref(), &entry.value);
             }
         }
         count
@@ -651,40 +697,55 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> TtlSortedCache<K, V, S> {
     /// entries by a `FnMut(&K, &V) -> bool` predicate (which also sweeps expired entries
     /// regardless of the predicate, but ignores `size_limit` and returns `()`).
     pub fn retain_latest(&mut self, count: usize, evict: bool) -> usize {
+        self.retain_latest_at(count, evict.then(Instant::now))
+    }
+
+    /// [`retain_latest`](Self::retain_latest) with the expiry sweep driven by an explicit
+    /// cutoff: `Some(cutoff)` is the `evict = true` sweep, `None` disables it. Lets a caller
+    /// that already sampled the clock reuse its own `now`.
+    ///
+    /// Like [`evict_at`](Self::evict_at) this walks the front of the expiry index instead of
+    /// pre-counting a range. The old code took `max(retain_drop_count, expired_count)` and
+    /// popped that many; since the expired entries are exactly a front prefix, popping while
+    /// `dropped < retain_drop_count || (evict && front_is_expired)` removes the same set.
+    fn retain_latest_at(&mut self, count: usize, cutoff: Option<Instant>) -> usize {
         let retain_drop_count = self.map.len().saturating_sub(count);
+        if retain_drop_count == 0 {
+            // No size trim to do: this is either a pure expiry sweep (where the old
+            // `max(0, expired_count)` is just the sweep count) or a complete no-op that must
+            // leave the index untouched.
+            return match cutoff {
+                Some(cutoff) => self.evict_at(cutoff),
+                None => 0,
+            };
+        }
 
-        let remove = if evict {
-            let cutoff = Instant::now();
-            let min = Stamped::bound(self.min_instant);
-            let max = Stamped::bound(cutoff);
-            let min = Included(&min);
-            let max = Excluded(&max);
-            let to_evict_count = self.keys.range((min, max)).count();
-            retain_drop_count.max(to_evict_count)
-        } else {
-            retain_drop_count
-        };
-
-        let mut count = 0;
-        while count < remove {
-            match self.keys.pop_first() {
-                None => break,
-                Some(stamped) => {
-                    // Invariant: same as evict() — None keys are sentinel-only.
-                    let key = stamped
-                        .key
-                        .expect("retaining: only artificial bounds are none");
-                    if let Some(entry) = self.map.remove(key.0.as_ref()) {
-                        if let Some(on_evict) = &self.on_evict {
-                            on_evict(key.0.as_ref(), &entry.value);
-                        }
-                        self.evictions.fetch_add(1, AtomicOrdering::Relaxed);
-                    }
-                    count += 1;
+        let mut dropped = 0;
+        while let Some(stamped) = self.keys.pop_first() {
+            if dropped >= retain_drop_count {
+                // Size trim satisfied; keep going only while the front is expired.
+                let expired = match cutoff {
+                    Some(cutoff) => matches!(stamped.expiry, Some(expiry) if expiry < cutoff),
+                    None => false,
+                };
+                if !expired {
+                    self.keys.insert(stamped);
+                    break;
                 }
             }
+            // Invariant: same as evict() — None keys are sentinel-only.
+            let key = stamped
+                .key
+                .expect("retaining: only artificial bounds are none");
+            if let Some(entry) = self.map.remove(key.0.as_ref()) {
+                self.evictions.fetch_add(1, AtomicOrdering::Relaxed);
+                if let Some(on_evict) = &self.on_evict {
+                    on_evict(key.0.as_ref(), &entry.value);
+                }
+            }
+            dropped += 1;
         }
-        count
+        dropped
     }
 
     /// Set k/v pair without running eviction logic, using the cache's default TTL.
@@ -698,7 +759,7 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> TtlSortedCache<K, V, S> {
     /// years), the entry is stored with no expiry (never expires), matching
     /// [`cache_set`](crate::Cached::cache_set) on the other TTL stores.
     pub fn set(&mut self, key: K, value: V) -> Option<V> {
-        self.set_inner(key, value, None, false, false)
+        self.set_inner(key, value, None, false, false).0
     }
 
     /// Start building a `set` call with an optional per-entry TTL override and/or
@@ -736,6 +797,11 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> TtlSortedCache<K, V, S> {
     ///
     /// `skip_size_eviction` defers size-limit enforcement to the caller
     /// (`set_and_get_mut` must protect the just-inserted entry before evicting).
+    ///
+    /// Returns the displaced (unexpired) value plus the `Stamped` that was written to the
+    /// expiry index. Handing the stamp back lets `set_and_get_mut` protect and re-find the
+    /// entry it just inserted without cloning the key again or re-hashing it; the stamp holds
+    /// the very same `CacheArc` handle the stored `Entry` does (an `Arc`, so no deep clone).
     fn set_inner(
         &mut self,
         key: K,
@@ -743,42 +809,65 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> TtlSortedCache<K, V, S> {
         ttl: Option<Duration>,
         evict: bool,
         skip_size_eviction: bool,
-    ) -> Option<V> {
-        let arc_key = CacheArc::new(key.clone());
+    ) -> (Option<V>, Stamped<K>) {
         let effective_ttl = ttl.unwrap_or(self.ttl);
+
+        // Sample the clock ONCE for the whole operation: the new expiry, the displaced
+        // entry's expiry check, and any eager sweep below are all judged against this
+        // instant instead of taking two or three separate `Instant::now()` readings.
+        let now = Instant::now();
 
         // A zero TTL means "never expires": store expiry = None. `checked_add`
         // returning `None` on overflow lands on the same never-expires representation.
         let expiry = if effective_ttl.is_zero() {
             None
         } else {
-            Instant::now().checked_add(effective_ttl)
+            now.checked_add(effective_ttl)
+        };
+
+        // `entry` rather than `insert`: on the occupied path the existing `Entry` already owns
+        // a `CacheArc` for this key, so reusing it is a refcount bump instead of an allocation
+        // plus a deep `K::clone`. Only the vacant path allocates, and it clones the key out of
+        // `VacantEntry::key` (the caller's `key` is moved into the map by `insert`).
+        let (arc_key, old) = match self.map.entry(key) {
+            std::collections::hash_map::Entry::Occupied(mut occupied) => {
+                let arc_key = occupied.get().key.clone();
+                let old = occupied.insert(Entry {
+                    expiry,
+                    key: arc_key.clone(),
+                    value,
+                });
+                (arc_key, Some(old))
+            }
+            std::collections::hash_map::Entry::Vacant(vacant) => {
+                let arc_key = CacheArc::new(vacant.key().clone());
+                vacant.insert(Entry {
+                    expiry,
+                    key: arc_key.clone(),
+                    value,
+                });
+                (arc_key, None)
+            }
         };
 
         let new_stamped = Stamped {
             expiry,
-            key: Some(arc_key.clone()),
+            key: Some(arc_key),
         };
         self.keys.insert(new_stamped.clone());
-        let old = self.map.insert(
-            key,
-            Entry {
-                expiry,
-                key: arc_key,
-                value,
-            },
-        );
-        if let Some(old) = &old {
-            let old_stamped = old.as_stamped();
-            if old_stamped != new_stamped {
-                self.keys.remove(&old_stamped);
-            }
+        // The displaced entry's stamp carries the same (equal) key, so it differs from the new
+        // one exactly when the expiry changed — comparing the two instants avoids rebuilding
+        // `old.as_stamped()` on the (common) unchanged-expiry path.
+        if let Some(old) = &old
+            && old.expiry != expiry
+        {
+            self.keys.remove(&old.as_stamped());
         }
         let old_value = match old {
             // A displaced expired value is filtered from the return (matching the get paths), so
             // it is dropped silently from the caller's view; fire `on_evict` and count an
             // eviction so cleanup and metrics stay consistent with the other removal paths.
-            Some(entry) if entry.is_expired() => {
+            Some(entry) if entry.is_expired_at(now) => {
                 if let Some(on_evict) = &self.on_evict {
                     on_evict(entry.key.0.as_ref(), &entry.value);
                 }
@@ -792,17 +881,18 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> TtlSortedCache<K, V, S> {
         // Size-limit eviction is skipped only when the caller explicitly requests it
         // (`skip_size_eviction`) — e.g. `set_and_get_mut` must guarantee the just-inserted
         // entry is still present to return `&mut V` safely, regardless of the entry's TTL.
+        // The sweeps reuse `now` rather than re-reading the clock.
         if !skip_size_eviction {
             if let Some(size_limit) = self.size_limit {
                 if self.map.len() > size_limit {
-                    self.retain_latest(size_limit, evict);
+                    self.retain_latest_at(size_limit, evict.then_some(now));
                 }
             } else if evict {
-                let _ = self.evict();
+                let _ = self.evict_at(now);
             }
         }
 
-        old_value
+        (old_value, new_stamped)
     }
 
     /// Insert `key`/`value` and return a mutable reference to the stored value.
@@ -812,8 +902,11 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> TtlSortedCache<K, V, S> {
     /// capacity. Used by the `cache_get_or_set_with_mut` family.
     fn set_and_get_mut(&mut self, key: K, value: V) -> &mut V {
         // `skip_size_eviction = true` defers size enforcement to the block below,
-        // where we can protect the just-inserted entry.
-        let _ = self.set_inner(key.clone(), value, None, false, true);
+        // where we can protect the just-inserted entry. `set_inner` hands back the exact
+        // `Stamped` it indexed, so the key is moved in (no extra `K::clone`) and the
+        // protect/re-find steps below reuse that stamp instead of re-deriving it from a
+        // second map lookup.
+        let (_, protected) = self.set_inner(key, value, None, false, true);
 
         if let Some(size_limit) = self.size_limit
             && self.map.len() > size_limit
@@ -822,15 +915,22 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> TtlSortedCache<K, V, S> {
             // `retain_latest` cannot select it for eviction. Other entries are
             // dropped in TTL order until the map is back within `size_limit`.
             // The stamp is restored afterward so the index stays consistent.
-            let protected = self.map[&key].as_stamped();
             self.keys.remove(&protected);
             self.retain_latest(size_limit, false);
-            self.keys.insert(protected);
+            self.keys.insert(protected.clone());
         }
 
+        // The stamp shares the stored entry's key `Arc`, so this borrows the key rather than
+        // cloning it. The `&mut V` is tied to `&mut self`, not to `protected`.
+        let key: &K = protected
+            .key
+            .as_ref()
+            .expect("set_and_get_mut: set_inner always stamps a real key")
+            .0
+            .as_ref();
         &mut self
             .map
-            .get_mut(&key)
+            .get_mut(key)
             .expect("set_and_get_mut: the protected eviction path guarantees the entry is present")
             .value
     }
@@ -917,6 +1017,7 @@ impl<'a, K: Hash + Eq + Ord + Clone, V, S: BuildHasher> TtlSortedSetBuilder<'a, 
     pub fn set(self) -> Option<V> {
         self.cache
             .set_inner(self.key, self.value, self.ttl, self.evict, false)
+            .0
     }
 }
 
@@ -930,9 +1031,11 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> Cached<K, V> for TtlSortedCa
     {
         // Two lookups on the hit path: the first checks expiry (releasing the borrow via
         // `.map`), the second returns the reference. A single-lookup approach is not possible
-        // in stable Rust because returning `&'1 V` from inside an `if let` block ties the
-        // borrow to lifetime `'1`, which prevents `remove_entry` (a mutable borrow) even on
-        // the non-returning path. Polonius (nightly) would fix this.
+        // SAFELY in stable Rust because returning `&'1 V` from inside an `if let` block ties
+        // the borrow to lifetime `'1`, which prevents `remove_entry` (a mutable borrow) even on
+        // the non-returning path. Polonius (nightly) would fix this. It IS possible with
+        // `unsafe`: `TtlCache::cache_get` (see `src/stores/ttl.rs`, the `&entry.value as
+        // *const V` reborrow) collapses this to one lookup behind a documented SAFETY comment.
         let is_expired = match self.map.get(key) {
             None => {
                 self.misses.increment();
@@ -975,7 +1078,7 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> Cached<K, V> for TtlSortedCa
     }
 
     fn cache_set(&mut self, key: K, value: V) -> Option<V> {
-        self.set_inner(key, value, None, false, false)
+        self.set_inner(key, value, None, false, false).0
     }
 
     fn cache_get_or_set_with_mut<F: FnOnce() -> V>(&mut self, key: K, f: F) -> &mut V {
@@ -1037,9 +1140,10 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> Cached<K, V> for TtlSortedCa
             Some(removed) => {
                 let expired = removed.is_expired();
                 self.keys.remove(&removed.as_stamped());
-                let stored_k = (*removed.key.0).clone();
+                // The stored key `Arc` derefs to `&K` directly: no clone is needed to hand the
+                // callback a reference (and the clone previously ran even without a callback).
                 if let Some(on_evict) = &self.on_evict {
-                    on_evict(&stored_k, &removed.value);
+                    on_evict(removed.key.0.as_ref(), &removed.value);
                 }
                 self.evictions.fetch_add(1, AtomicOrdering::Relaxed);
                 if expired { None } else { Some(removed.value) }
@@ -1135,6 +1239,9 @@ impl<K: Hash + Eq + Ord, V, S: BuildHasher> CachedIter<K, V> for TtlSortedCache<
         K: 'a,
         V: 'a,
     {
+        // The clock is read per item rather than hoisted into a construction-time snapshot:
+        // this iterator is lazy and may be held across a long consumer loop, where a stale
+        // snapshot would report entries that have since expired as live.
         self.map.iter().filter_map(|(k, entry)| {
             if entry.is_expired() {
                 None
@@ -1287,14 +1394,24 @@ where
         Fut: Future<Output = V> + Send + 'a,
     {
         async move {
-            if self.cache_get(&k).is_some() {
+            // Same shape as the sync `cache_get_or_set_with_mut`: check liveness in place
+            // (one lookup) instead of going through `cache_get`, which costs two lookups of
+            // its own before this method's `get_mut` — three on an async hit. As in the sync
+            // version, an expired entry is left in place for `set_and_get_mut` to displace
+            // (which fires `on_evict` and counts the eviction) rather than being swept before
+            // the future runs, so a dropped/panicking future leaves the stale entry alone.
+            let live = matches!(self.map.get(&k), Some(entry) if !entry.is_expired());
+            if live {
+                self.hits.increment();
                 return self
                     .map
                     .get_mut(&k)
                     .map(|entry| &mut entry.value)
-                    // Invariant: cache_get confirmed the entry is present and unexpired.
+                    // Invariant: the liveness check above confirmed the entry is present and
+                    // unexpired, and nothing removes it in between.
                     .expect("cache entry vanished");
             }
+            self.misses.increment();
             // `set_and_get_mut` never drops the value, so this path is panic-free.
             let value = f().await;
             self.set_and_get_mut(k, value)
@@ -1314,16 +1431,27 @@ where
         Fut: Future<Output = Result<V, E>> + Send + 'a,
     {
         async move {
-            if self.cache_get(&k).is_some() {
+            // Same shape as `async_cache_get_or_set_with_mut` / the sync fallible sibling:
+            // check liveness in place (one lookup) instead of going through `cache_get`, which
+            // would sweep an expired entry (and fire `on_evict`) before the factory is even
+            // polled. An expired entry is left in place for `set_and_get_mut` to displace on
+            // `Ok` (which fires `on_evict` and counts the eviction) rather than being swept
+            // up front, so a factory `Err` or a dropped/cancelled future leaves the stale entry
+            // alone.
+            let live = matches!(self.map.get(&k), Some(entry) if !entry.is_expired());
+            if live {
+                self.hits.increment();
                 return Ok(self
                     .map
                     .get_mut(&k)
                     .map(|entry| &mut entry.value)
-                    // Invariant: cache_get confirmed the entry is present and unexpired.
+                    // Invariant: the liveness check above confirmed the entry is present and
+                    // unexpired, and nothing removes it in between.
                     .expect("cache entry vanished"));
             }
-            // `set_and_get_mut` never drops the value, so this path is panic-free.
+            self.misses.increment();
             let value = f().await?;
+            // `set_and_get_mut` never drops the value, so this path is panic-free.
             Ok(self.set_and_get_mut(k, value))
         }
     }
@@ -3356,5 +3484,1891 @@ mod test {
         assert_eq!(cache.retain_latest(0, false), 32);
         assert!(cache.map.is_empty());
         assert!(cache.keys.is_empty());
+    }
+
+    // ---------------------------------------------------------------------------
+    // Front-driven `evict_at` / `retain_latest_at` equivalence with the old two-pass
+    // (`range(..).count()` then pop) logic. The real monotonic clock never produces a
+    // deterministic `now == expiry` tie, so these drive the private `*_at` entry points
+    // with hand-built entries and an explicit cutoff.
+    // ---------------------------------------------------------------------------
+
+    /// Insert an entry with an exact `expiry`, keeping map and index in lockstep the same
+    /// way `set_inner` does (same `CacheArc` in both structures).
+    fn insert_raw(
+        cache: &mut TtlSortedCache<u32, u32>,
+        key: u32,
+        value: u32,
+        expiry: Option<crate::time::Instant>,
+    ) {
+        use super::{CacheArc, Entry, Stamped};
+        let arc = CacheArc::new(key);
+        cache.keys.insert(Stamped {
+            expiry,
+            key: Some(arc.clone()),
+        });
+        cache.map.insert(
+            key,
+            Entry {
+                expiry,
+                key: arc,
+                value,
+            },
+        );
+    }
+
+    /// The number of entries the pre-refactor sweep would have removed: the count of the
+    /// `[bound(min_instant), bound(cutoff))` range over the expiry index.
+    fn old_range_expired_count(
+        cache: &TtlSortedCache<u32, u32>,
+        cutoff: crate::time::Instant,
+    ) -> usize {
+        use super::Stamped;
+        use std::ops::Bound::{Excluded, Included};
+        let min = Stamped::<u32>::bound(cache.min_instant);
+        let max = Stamped::<u32>::bound(cutoff);
+        cache.keys.range((Included(&min), Excluded(&max))).count()
+    }
+
+    /// Build a cache holding one entry strictly before the cutoff, one tied exactly at the
+    /// cutoff, one after it, and one that never expires. All expiries are in the future
+    /// relative to `min_instant`, so the old lower range bound would not have excluded any.
+    fn boundary_population() -> (TtlSortedCache<u32, u32>, crate::time::Instant) {
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        let cutoff = crate::time::Instant::now() + Duration::from_secs(1);
+        insert_raw(&mut cache, 1, 10, Some(cutoff - Duration::from_nanos(1)));
+        insert_raw(&mut cache, 2, 20, Some(cutoff));
+        insert_raw(&mut cache, 3, 30, Some(cutoff + Duration::from_nanos(1)));
+        insert_raw(&mut cache, 4, 40, None);
+        (cache, cutoff)
+    }
+
+    /// An entry expiring EXACTLY at the cutoff is not swept (the old
+    /// `Excluded(bound(cutoff))` bound excluded it too, because the sentinel's `key: None`
+    /// sorts below every real key at the same expiry), and a never-expiring entry survives.
+    #[test]
+    fn evict_at_boundary_tie_and_never_expiring_entries_match_the_old_range_bounds() {
+        let (mut cache, cutoff) = boundary_population();
+        assert_eq!(
+            old_range_expired_count(&cache, cutoff),
+            1,
+            "reference: the old range selected only the strictly-earlier entry"
+        );
+
+        assert_eq!(
+            cache.evict_at(cutoff),
+            1,
+            "only the entry expiring strictly before the cutoff is swept"
+        );
+        assert!(!cache.map.contains_key(&1u32), "strictly earlier is swept");
+        assert!(
+            cache.map.contains_key(&2u32),
+            "an exact now == expiry tie survives, matching the old Excluded upper bound"
+        );
+        assert!(cache.map.contains_key(&3u32), "later expiry survives");
+        assert!(cache.map.contains_key(&4u32), "never-expiring survives");
+        assert_index_lockstep(&cache, "after a boundary evict_at");
+
+        // A cutoff one tick past the tie now sweeps it, proving the boundary is where the
+        // old range put it and not one entry off.
+        assert_eq!(cache.evict_at(cutoff + Duration::from_nanos(1)), 1);
+        assert!(!cache.map.contains_key(&2u32));
+        assert!(cache.map.contains_key(&3u32));
+        assert!(cache.map.contains_key(&4u32));
+        assert_index_lockstep(&cache, "after sweeping the tie");
+    }
+
+    /// Over a mixed population (many expired, some live, some never-expiring, colliding
+    /// expiries) the front-driven sweep must drop exactly as many entries as the old
+    /// `range(..).count()` pass would have.
+    #[test]
+    fn evict_at_drop_count_matches_the_old_two_pass_range_count() {
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        let cutoff = crate::time::Instant::now() + Duration::from_secs(1);
+        for k in 0u32..30 {
+            let expiry = match k % 3 {
+                // Expired, with pairs of keys colliding on the same instant.
+                0 => Some(cutoff - Duration::from_micros(u64::from(k / 3) + 1)),
+                // Live: half of them tie EXACTLY on the cutoff, which must be kept.
+                1 => Some(cutoff + Duration::from_micros(u64::from(k % 2))),
+                // Never expires.
+                _ => None,
+            };
+            insert_raw(&mut cache, k, k * 10, expiry);
+        }
+        let expected = old_range_expired_count(&cache, cutoff);
+        assert_eq!(expected, 10, "reference count over the mixed population");
+
+        assert_eq!(
+            cache.evict_at(cutoff),
+            expected,
+            "front-driven evict must drop the same count as the old range pass"
+        );
+        assert_eq!(cache.map.len(), 20);
+        assert_index_lockstep(&cache, "after a mixed evict_at");
+        for k in 0u32..30 {
+            assert_eq!(
+                cache.map.contains_key(&k),
+                k % 3 != 0,
+                "exactly the expired third is swept"
+            );
+        }
+        assert_eq!(
+            cache.evict_at(cutoff),
+            0,
+            "a repeat sweep at the same cutoff drops nothing"
+        );
+    }
+
+    /// A panicking `on_evict` must not desynchronize the map from the expiry index during an
+    /// expiry sweep either. `evict` detaches the whole expired prefix from `keys` up front, so
+    /// it must finish every `map` removal before firing any callback — unwinding mid-drain
+    /// would strand the not-yet-removed entries in `map` with their stamps already gone.
+    #[test]
+    fn evict_on_evict_panic_leaves_the_index_in_lockstep() {
+        let fired = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let cb = std::sync::Arc::clone(&fired);
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .on_evict(move |_k, _v| {
+                // Panic on the FIRST callback: with an interleaved drain that would leave the
+                // remaining five entries in `map` without stamps.
+                if cb.fetch_add(1, std::sync::atomic::Ordering::Relaxed) == 0 {
+                    panic!("boom");
+                }
+            })
+            .build()
+            .unwrap();
+        let cutoff = crate::time::Instant::now() + Duration::from_secs(1);
+        for k in 0u32..6 {
+            insert_raw(
+                &mut cache,
+                k,
+                k,
+                Some(cutoff - Duration::from_micros(u64::from(k) + 1)),
+            );
+        }
+        // One live entry that must survive untouched.
+        insert_raw(&mut cache, 100u32, 100u32, Some(cutoff));
+
+        let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _ = cache.evict_at(cutoff);
+        }));
+        assert!(caught.is_err(), "the callback panic must propagate");
+
+        assert_index_lockstep(&cache, "after on_evict panicked mid-evict");
+        assert_eq!(
+            cache.map.len(),
+            1,
+            "every expired entry left the map before the callbacks ran"
+        );
+        assert!(cache.map.contains_key(&100u32), "the live entry survives");
+        assert_eq!(cache.cache_evictions(), Some(6));
+        // The survivor is still reachable through the index.
+        assert_eq!(cache.retain_latest(0, false), 1);
+        assert_index_lockstep(&cache, "after trimming the survivor");
+    }
+
+    /// `retain_latest_at` with the sweep enabled: the tie at the cutoff is kept and
+    /// never-expiring entries sort last, exactly as under the old range bounds.
+    #[test]
+    fn retain_latest_at_boundary_tie_and_never_expiring_entries_match_the_old_range_bounds() {
+        // count = 4 (no size pressure): only the expiry sweep can drop anything.
+        let (mut cache, cutoff) = boundary_population();
+        assert_eq!(
+            cache.retain_latest_at(4, Some(cutoff)),
+            1,
+            "only the strictly-earlier entry is swept; the tie is kept"
+        );
+        assert!(cache.map.contains_key(&2u32), "the exact tie survives");
+        assert!(cache.map.contains_key(&4u32), "never-expiring survives");
+        assert_index_lockstep(&cache, "after a boundary retain_latest_at");
+
+        // Size pressure beyond the expired prefix: the sweep count and the trim count are
+        // combined exactly as `max(retain_drop_count, expired_count)` did.
+        let (mut cache, cutoff) = boundary_population();
+        assert_eq!(
+            cache.retain_latest_at(2, Some(cutoff)),
+            2,
+            "trim of 2 dominates the single expired entry"
+        );
+        assert!(!cache.map.contains_key(&1u32), "expired dropped first");
+        assert!(!cache.map.contains_key(&2u32), "then the soonest-to-expire");
+        assert!(
+            cache.map.contains_key(&4u32),
+            "never-expiring entries are retained last"
+        );
+        assert_index_lockstep(&cache, "after a size-dominated retain_latest_at");
+
+        // Sweep disabled: a size trim alone never consults the cutoff.
+        let (mut cache, _cutoff) = boundary_population();
+        assert_eq!(cache.retain_latest_at(4, None), 0);
+        assert_eq!(cache.map.len(), 4, "no trim needed, no sweep requested");
+        assert_index_lockstep(&cache, "after a no-op retain_latest_at");
+    }
+
+    /// The combined trim/sweep drop count must equal the old
+    /// `max(retain_drop_count, range(..).count())` for every `count` and both sweep modes.
+    #[test]
+    fn retain_latest_at_drop_count_matches_the_old_two_pass_logic() {
+        fn fresh() -> (TtlSortedCache<u32, u32>, crate::time::Instant) {
+            let mut cache = TtlSortedCache::<u32, u32>::builder()
+                .ttl(Duration::from_secs(60))
+                .build()
+                .unwrap();
+            let cutoff = crate::time::Instant::now() + Duration::from_secs(1);
+            for k in 0u32..12 {
+                let expiry = match k % 3 {
+                    0 => Some(cutoff - Duration::from_micros(u64::from(k) + 1)),
+                    // Half of the live entries tie EXACTLY on the cutoff.
+                    1 => Some(cutoff + Duration::from_micros(u64::from(k % 2))),
+                    _ => None,
+                };
+                insert_raw(&mut cache, k, k * 10, expiry);
+            }
+            (cache, cutoff)
+        }
+
+        for keep in 0..=13usize {
+            for sweep in [false, true] {
+                let (mut cache, cutoff) = fresh();
+                let retain_drop_count = cache.map.len().saturating_sub(keep);
+                let expected = if sweep {
+                    retain_drop_count.max(old_range_expired_count(&cache, cutoff))
+                } else {
+                    retain_drop_count
+                };
+                let dropped = cache.retain_latest_at(keep, sweep.then_some(cutoff));
+                assert_eq!(
+                    dropped, expected,
+                    "keep={keep} sweep={sweep}: drop count must match the old two-pass logic"
+                );
+                assert_eq!(cache.map.len(), 12 - expected);
+                assert_index_lockstep(&cache, "after retain_latest_at");
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // `set_inner` / `set_and_get_mut` refactor
+    // ---------------------------------------------------------------------------
+
+    /// `set_and_get_mut` no longer re-looks-up the key after inserting; it reuses the stamp
+    /// `set_inner` returns. The map/index lockstep must hold on every branch it takes:
+    /// plain miss, expired displacement, and the protected size-limited eviction.
+    #[test]
+    fn set_and_get_mut_keeps_the_index_in_lockstep() {
+        // Plain miss, no size limit.
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        for k in 0u32..4 {
+            let v = cache.cache_get_or_set_with_mut(k, || k * 10);
+            assert_eq!(*v, k * 10);
+            assert_index_lockstep(&cache, "after a miss insert");
+        }
+        assert_eq!(cache.map.len(), 4);
+
+        // Expired displacement: the factory runs again and the stale stamp is replaced.
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_millis(20))
+            .build()
+            .unwrap();
+        cache.cache_set(1u32, 10u32);
+        std::thread::sleep(std::time::Duration::from_millis(60));
+        assert_eq!(*cache.cache_get_or_set_with_mut(1u32, || 99u32), 99u32);
+        assert_eq!(cache.map.len(), 1);
+        assert_index_lockstep(&cache, "after replacing an expired entry");
+
+        // Size-limited: the just-inserted entry is protected, its stamp is restored, and the
+        // returned reference points at that entry.
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .max_size(3)
+            .build()
+            .unwrap();
+        for k in 0u32..8 {
+            let v = cache.cache_get_or_set_with_mut(k, || k * 100);
+            assert_eq!(*v, k * 100, "the reference must be the entry just inserted");
+            *v += 1;
+            assert!(cache.map.len() <= 3, "the size limit is enforced");
+            assert_index_lockstep(&cache, "after a protected size-limited insert");
+            assert_eq!(
+                crate::CachedPeek::cache_peek(&cache, &k),
+                Some(&(k * 100 + 1)),
+                "the protected entry survives its own insert and is mutable through the ref"
+            );
+        }
+        // The index is still complete enough to trim everything.
+        let len = cache.map.len();
+        assert_eq!(cache.retain_latest(0, false), len);
+        assert!(cache.keys.is_empty());
+    }
+
+    /// Overwriting an existing key reuses the stored key `Arc` (a refcount bump) instead of
+    /// allocating a fresh `Arc` from a deep key clone, and the index keeps exactly one stamp.
+    #[test]
+    fn cache_set_overwrite_reuses_the_stored_key_arc() {
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        cache.cache_set(1u32, 10u32);
+        let before = cache.map.get(&1u32).expect("entry present").key.0.clone();
+
+        assert_eq!(cache.cache_set(1u32, 20u32), Some(10u32));
+        let after = &cache.map.get(&1u32).expect("entry present").key.0;
+        assert!(
+            Arc::ptr_eq(&before, after),
+            "an overwrite must reuse the stored key Arc, not allocate a new one"
+        );
+        assert_eq!(cache.map.len(), 1);
+        assert_eq!(cache.keys.len(), 1, "no orphan stamp is left behind");
+        assert_index_lockstep(&cache, "after an overwrite");
+    }
+
+    /// An overwrite that changes the expiry must remove the old stamp and index the new one;
+    /// an overwrite that leaves the expiry unchanged must leave a single stamp in place.
+    #[test]
+    fn overwrite_replaces_the_index_stamp_only_when_the_expiry_changes() {
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        // Two entries so a stale stamp would be visible as a length mismatch.
+        cache.set_with(1u32, 10u32).ttl(Duration::ZERO).set();
+        cache.set_with(2u32, 20u32).ttl(Duration::ZERO).set();
+        assert_index_lockstep(&cache, "never-expiring pair");
+
+        // Same (None) expiry: the stamp is identical, nothing to remove.
+        assert_eq!(
+            cache.set_with(1u32, 11u32).ttl(Duration::ZERO).set(),
+            Some(10u32)
+        );
+        assert_eq!(cache.keys.len(), 2);
+        assert_index_lockstep(&cache, "after a same-expiry overwrite");
+
+        // Changed expiry (None -> Some): the never-expires stamp must be dropped, leaving the
+        // entry sorted by its new finite expiry (so it now evicts before the never-expiring one).
+        assert_eq!(
+            cache
+                .set_with(1u32, 12u32)
+                .ttl(Duration::from_secs(30))
+                .set(),
+            Some(11u32)
+        );
+        assert_eq!(cache.keys.len(), 2, "the stale never-expires stamp is gone");
+        assert_index_lockstep(&cache, "after an expiry-changing overwrite");
+        assert_eq!(cache.retain_latest(1, false), 1);
+        assert!(
+            !cache.map.contains_key(&1u32),
+            "the re-stamped entry now expires first and is trimmed first"
+        );
+        assert!(cache.map.contains_key(&2u32));
+        assert_index_lockstep(&cache, "after trimming the re-stamped entry");
+    }
+
+    /// The async get-or-set now checks liveness in place instead of routing through
+    /// `cache_get` (which swept the expired entry before the factory even ran). A factory
+    /// future dropped before completion must therefore leave the expired entry alone and
+    /// must not fire `on_evict`, matching the sync path and `TtlCache`.
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn async_cache_get_or_set_with_mut_cancel_keeps_expired_entry() {
+        use crate::CachedGetOrSetAsync;
+        use std::task::Poll;
+
+        let fired = Arc::new(AtomicUsize::new(0));
+        let fired2 = fired.clone();
+        let mut c: TtlSortedCache<u32, u32> = TtlSortedCache::builder()
+            .ttl(Duration::from_millis(20))
+            .on_evict(move |_k: &u32, _v: &u32| {
+                fired2.fetch_add(1, Ordering::Relaxed);
+            })
+            .build()
+            .unwrap();
+        c.cache_set(1u32, 100u32);
+        tokio::time::sleep(std::time::Duration::from_millis(60)).await;
+
+        {
+            let mut fut = Box::pin(CachedGetOrSetAsync::async_cache_get_or_set_with_mut(
+                &mut c,
+                1u32,
+                std::future::pending::<u32>,
+            ));
+            let waker = std::task::Waker::noop();
+            let mut cx = std::task::Context::from_waker(waker);
+            assert!(
+                matches!(
+                    std::future::Future::poll(fut.as_mut(), &mut cx),
+                    Poll::Pending
+                ),
+                "future must be pending while the factory is unresolved"
+            );
+            // Dropped here: cancellation mid-factory.
+        }
+
+        assert_eq!(
+            fired.load(Ordering::Relaxed),
+            0,
+            "on_evict must not fire when the factory future is dropped"
+        );
+        assert_eq!(c.cache_evictions(), Some(0));
+        assert_eq!(c.cache_size(), 1, "the expired entry must still be present");
+        assert_index_lockstep(&c, "after async factory cancellation");
+
+        // A completed factory replaces it, firing on_evict exactly once for the displaced
+        // expired value.
+        let v =
+            CachedGetOrSetAsync::async_cache_get_or_set_with_mut(&mut c, 1u32, || async { 200u32 })
+                .await;
+        assert_eq!(*v, 200u32);
+        assert_eq!(fired.load(Ordering::Relaxed), 1);
+        assert_eq!(c.cache_evictions(), Some(1));
+        assert_index_lockstep(&c, "after async replacement");
+    }
+
+    /// An async hit counts exactly one hit (and no miss), the same as the sync path: the
+    /// in-place liveness check replaced a `cache_get` call that also touched the counters.
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn async_cache_get_or_set_with_mut_hit_counts_one_hit() {
+        use crate::CachedGetOrSetAsync;
+
+        let mut c: TtlSortedCache<u32, u32> = TtlSortedCache::builder()
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        c.cache_set(1u32, 100u32);
+        c.cache_reset_metrics();
+
+        let v = CachedGetOrSetAsync::async_cache_get_or_set_with_mut(&mut c, 1u32, || async {
+            unreachable!("the factory must not run on a live hit")
+        })
+        .await;
+        assert_eq!(*v, 100u32);
+        assert_eq!(c.cache_hits(), Some(1));
+        assert_eq!(c.cache_misses(), Some(0));
+
+        // And a miss counts exactly one miss.
+        let v =
+            CachedGetOrSetAsync::async_cache_get_or_set_with_mut(&mut c, 2u32, || async { 200u32 })
+                .await;
+        assert_eq!(*v, 200u32);
+        assert_eq!(c.cache_hits(), Some(1));
+        assert_eq!(c.cache_misses(), Some(1));
+        assert_index_lockstep(&c, "after an async miss insert");
+    }
+
+    /// The fallible async sibling (`async_cache_try_get_or_set_with_mut`) was never given a
+    /// dedicated absent-key test: the flagged risk is that its explicit `hits`/`misses`
+    /// increments (replacing the old implicit `cache_get`-driven ones) could be off by one or
+    /// double-counted on the paths the big cross-variant table test does not visit (a key that
+    /// was never inserted, as opposed to one that expired). Walks a live hit, an absent-key
+    /// `Err`, an absent-key `Ok`, an expired-key `Err`, and an expired-key `Ok` in sequence,
+    /// asserting the exact running `hits`/`misses` totals and `on_evict`/`evictions` at each
+    /// step -- a double count or a missed count on any single path desyncs the running total
+    /// for every step after it.
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn async_try_get_or_set_with_mut_hits_and_misses_match_across_absent_expired_and_live()
+     {
+        use crate::CachedGetOrSetAsync;
+
+        let fired = Arc::new(AtomicUsize::new(0));
+        let fired2 = fired.clone();
+        let mut c: TtlSortedCache<u32, u32> = TtlSortedCache::builder()
+            .ttl(Duration::from_millis(20))
+            .on_evict(move |_k: &u32, _v: &u32| {
+                fired2.fetch_add(1, Ordering::Relaxed);
+            })
+            .build()
+            .unwrap();
+
+        // A live entry (key 1, long TTL via the builder) to hit against.
+        c.set_with(1u32, 100u32).ttl(Duration::from_secs(60)).set();
+        c.cache_reset_metrics();
+
+        // Step 1: LIVE HIT. The factory must not run; exactly one hit, no miss, nothing
+        // evicted, the value is unchanged.
+        let v: Result<&mut u32, &'static str> =
+            CachedGetOrSetAsync::async_cache_try_get_or_set_with_mut(&mut c, 1u32, || async {
+                unreachable!("the factory must not run on a live hit")
+            })
+            .await;
+        assert_eq!(v.ok(), Some(&mut 100u32));
+        assert_eq!(c.cache_hits(), Some(1), "step 1: one hit");
+        assert_eq!(c.cache_misses(), Some(0), "step 1: no miss");
+        assert_eq!(fired.load(Ordering::Relaxed), 0);
+        assert_eq!(c.cache_evictions(), Some(0));
+
+        // Step 2: ABSENT KEY, factory Err. Nothing is stored, one miss is counted (before the
+        // factory runs), no eviction fires (there was nothing to displace).
+        let v: Result<&mut u32, &'static str> =
+            CachedGetOrSetAsync::async_cache_try_get_or_set_with_mut(&mut c, 2u32, || async {
+                Err("nope")
+            })
+            .await;
+        assert_eq!(v.err(), Some("nope"));
+        // `cache_peek` (not `cache_get`) to check absence without touching the very counters
+        // under test.
+        assert_eq!(
+            crate::CachedPeek::cache_peek(&c, &2u32),
+            None,
+            "a failed factory inserts nothing"
+        );
+        assert_eq!(c.cache_size(), 1);
+        assert_eq!(c.cache_hits(), Some(1), "step 2: still one hit");
+        assert_eq!(c.cache_misses(), Some(1), "step 2: one miss, not two");
+        assert_eq!(fired.load(Ordering::Relaxed), 0);
+        assert_eq!(c.cache_evictions(), Some(0));
+
+        // Step 3: the SAME absent key, factory Ok this time. One more miss (the key is still
+        // absent going in), a fresh insert with nothing displaced, so no eviction.
+        let v: Result<&mut u32, &'static str> =
+            CachedGetOrSetAsync::async_cache_try_get_or_set_with_mut(&mut c, 2u32, || async {
+                Ok(200u32)
+            })
+            .await;
+        assert_eq!(v.ok(), Some(&mut 200u32));
+        assert_eq!(c.cache_size(), 2);
+        assert_eq!(c.cache_hits(), Some(1), "step 3: still one hit");
+        assert_eq!(c.cache_misses(), Some(2), "step 3: two misses total");
+        assert_eq!(fired.load(Ordering::Relaxed), 0);
+        assert_eq!(c.cache_evictions(), Some(0));
+
+        // Step 4: an EXPIRED key (key 3), factory Err. Counts a miss even though the key is
+        // technically present-but-stale; the stale entry is left exactly alone (no eviction).
+        c.set_with(3u32, 300u32).ttl(Duration::from_millis(1)).set();
+        tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+        let v: Result<&mut u32, &'static str> =
+            CachedGetOrSetAsync::async_cache_try_get_or_set_with_mut(&mut c, 3u32, || async {
+                Err("still nope")
+            })
+            .await;
+        assert_eq!(v.err(), Some("still nope"));
+        assert_eq!(c.cache_hits(), Some(1), "step 4: still one hit");
+        assert_eq!(c.cache_misses(), Some(3), "step 4: three misses total");
+        assert_eq!(
+            fired.load(Ordering::Relaxed),
+            0,
+            "the stale entry is left alone on Err, not evicted"
+        );
+        assert_eq!(c.cache_evictions(), Some(0));
+
+        // Step 5: the SAME expired key, factory Ok. One more miss, and NOW the stale entry is
+        // displaced: exactly one eviction fires, counted once.
+        let v: Result<&mut u32, &'static str> =
+            CachedGetOrSetAsync::async_cache_try_get_or_set_with_mut(&mut c, 3u32, || async {
+                Ok(301u32)
+            })
+            .await;
+        assert_eq!(v.ok(), Some(&mut 301u32));
+        assert_eq!(c.cache_hits(), Some(1), "step 5: still one hit");
+        assert_eq!(c.cache_misses(), Some(4), "step 5: four misses total");
+        assert_eq!(
+            fired.load(Ordering::Relaxed),
+            1,
+            "the stale entry is evicted exactly once when finally displaced"
+        );
+        assert_eq!(c.cache_evictions(), Some(1));
+
+        // Step 6: a final live hit on the just-replaced key 3, to confirm hits still advance
+        // correctly after a run of misses.
+        let v: Result<&mut u32, &'static str> =
+            CachedGetOrSetAsync::async_cache_try_get_or_set_with_mut(&mut c, 3u32, || async {
+                unreachable!("the factory must not run on a live hit")
+            })
+            .await;
+        assert_eq!(v.ok(), Some(&mut 301u32));
+        assert_eq!(c.cache_hits(), Some(2), "step 6: two hits total");
+        assert_eq!(c.cache_misses(), Some(4), "step 6: no additional miss");
+        assert_eq!(c.cache_evictions(), Some(1));
+        assert_eq!(c.cache_size(), 3);
+        assert_index_lockstep(&c, "after the mixed hit/miss/absent/expired sequence");
+    }
+
+    // ===========================================================================
+    // Independent certification coverage (outside-in): the `split_off` pivot,
+    // the two `evict_at` drain branches, deferred-callback panic safety, the
+    // orphaned-stamp divergence, coarse-`Ord` keys, and the async liveness-check
+    // behavior change.
+    // ===========================================================================
+
+    /// Insert a stamp into the expiry index WITHOUT a matching map entry, i.e. deliberately
+    /// break the map/index lockstep invariant. Only reachable from inside this module; used
+    /// to pin what the sweeps do if the invariant were ever violated.
+    fn insert_orphan_stamp(
+        cache: &mut TtlSortedCache<u32, u32>,
+        key: u32,
+        expiry: Option<crate::time::Instant>,
+    ) {
+        use super::{CacheArc, Stamped};
+        cache.keys.insert(Stamped {
+            expiry,
+            key: Some(CacheArc::new(key)),
+        });
+    }
+
+    /// The `key: None` sentinel must sort strictly BELOW every real key carrying the same
+    /// expiry, and strictly below any never-expiring stamp. This is the single ordering fact
+    /// the whole `split_off` boundary rests on.
+    #[test]
+    fn bound_sentinel_sorts_below_every_real_key_at_the_same_expiry() {
+        use super::{CacheArc, Stamped};
+        use crate::time::Instant;
+
+        let t = Instant::now();
+        let sentinel = Stamped::<u32>::bound(t);
+        for k in [u32::MIN, 1u32, u32::MAX] {
+            let real = Stamped {
+                expiry: Some(t),
+                key: Some(CacheArc::new(k)),
+            };
+            assert!(
+                sentinel < real,
+                "bound({t:?}) must sort below the real key {k} at the same expiry"
+            );
+        }
+        // A never-expiring stamp sorts above every finite bound, no matter how far out.
+        let never = Stamped {
+            expiry: None,
+            key: Some(CacheArc::new(0u32)),
+        };
+        assert!(sentinel < never, "None expiry sorts greatest");
+        assert!(
+            Stamped::<u32>::bound(t + Duration::from_secs(60 * 60 * 24 * 365)) < never,
+            "no finite cutoff can ever reach a never-expiring stamp"
+        );
+        // And the sentinel is strictly ordered by expiry.
+        assert!(sentinel < Stamped::<u32>::bound(t + Duration::from_nanos(1)));
+    }
+
+    /// Non-vacuity guard for the boundary tests: the population they use genuinely
+    /// discriminates the pivot. Splitting the SAME index at `bound(cutoff - 1ns)`,
+    /// `bound(cutoff)` and `bound(cutoff + 1ns)` must yield three different prefix sizes
+    /// (0, 1, 2), so an off-by-one-tick pivot could not pass the shipped assertions.
+    #[test]
+    fn evict_at_pivot_choice_is_observable_at_the_tie() {
+        use super::Stamped;
+
+        for (shift_back, expected) in [(true, 0usize), (false, 1)] {
+            let (cache, cutoff) = boundary_population();
+            let pivot = if shift_back {
+                Stamped::<u32>::bound(cutoff - Duration::from_nanos(1))
+            } else {
+                Stamped::<u32>::bound(cutoff)
+            };
+            let mut keys = cache.keys.clone();
+            let prefix_len = keys.len() - keys.split_off(&pivot).len();
+            assert_eq!(
+                prefix_len, expected,
+                "shift_back={shift_back}: the split prefix must be sensitive to the pivot"
+            );
+        }
+        let (cache, cutoff) = boundary_population();
+        let mut keys = cache.keys.clone();
+        let past_tie = keys.len()
+            - keys
+                .split_off(&Stamped::<u32>::bound(cutoff + Duration::from_nanos(1)))
+                .len();
+        assert_eq!(
+            past_tie, 2,
+            "a pivot one tick past the tie would sweep the tied entry too"
+        );
+        // The shipped pivot is the middle one, so both off-by-one-tick mutants are caught.
+        let (mut cache, cutoff) = boundary_population();
+        assert_eq!(cache.evict_at(cutoff), 1);
+    }
+
+    /// `split_off` on an empty index must be a clean no-op, not a panic or a leaked
+    /// half-swapped tree.
+    #[test]
+    fn evict_at_on_an_empty_index_is_a_noop() {
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        let now = crate::time::Instant::now();
+        assert_eq!(cache.evict_at(now), 0);
+        assert_eq!(cache.evict_at(now + Duration::from_secs(1000)), 0);
+        assert!(cache.keys.is_empty());
+        assert!(cache.map.is_empty());
+        assert_eq!(cache.cache_evictions(), Some(0));
+        assert_index_lockstep(&cache, "empty evict_at");
+
+        // Still usable afterwards.
+        cache.set(1u32, 1u32);
+        assert_index_lockstep(&cache, "after reuse");
+        assert_eq!(cache.cache_get(&1u32), Some(&1u32));
+    }
+
+    /// An index that is ENTIRELY expired: `split_off` returns an empty live half, so the
+    /// whole tree is drained and `self.keys` must end up empty (not the detached prefix).
+    #[test]
+    fn evict_at_with_an_entirely_expired_index_drains_everything() {
+        for with_callback in [false, true] {
+            let fired = Arc::new(AtomicUsize::new(0));
+            let fired2 = fired.clone();
+            let mut builder = TtlSortedCache::<u32, u32>::builder().ttl(Duration::from_secs(60));
+            if with_callback {
+                builder = builder.on_evict(move |_k: &u32, _v: &u32| {
+                    fired2.fetch_add(1, Ordering::Relaxed);
+                });
+            }
+            let mut cache = builder.build().unwrap();
+            let cutoff = crate::time::Instant::now() + Duration::from_secs(1);
+            for k in 0u32..8 {
+                insert_raw(
+                    &mut cache,
+                    k,
+                    k,
+                    Some(cutoff - Duration::from_micros(u64::from(k) + 1)),
+                );
+            }
+            assert_eq!(cache.evict_at(cutoff), 8, "with_callback={with_callback}");
+            assert!(cache.keys.is_empty(), "the index must be fully drained");
+            assert!(cache.map.is_empty());
+            assert_eq!(cache.cache_evictions(), Some(8));
+            assert_eq!(
+                fired.load(Ordering::Relaxed),
+                usize::from(with_callback) * 8
+            );
+            assert_index_lockstep(&cache, "after draining every entry");
+            assert_eq!(cache.evict_at(cutoff), 0, "a repeat sweep drops nothing");
+        }
+    }
+
+    /// An index that is ENTIRELY live: the detached prefix must be empty and the live half
+    /// must be swapped back intact, in order.
+    #[test]
+    fn evict_at_with_an_entirely_live_index_drops_nothing() {
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        let cutoff = crate::time::Instant::now() + Duration::from_secs(1);
+        for k in 0u32..8 {
+            let expiry = if k % 2 == 0 {
+                Some(cutoff + Duration::from_micros(u64::from(k) + 1))
+            } else {
+                None
+            };
+            insert_raw(&mut cache, k, k * 10, expiry);
+        }
+        let before: Vec<Option<u32>> = cache
+            .keys
+            .iter()
+            .map(|s| s.key.as_ref().map(|k| *k.0))
+            .collect();
+
+        assert_eq!(cache.evict_at(cutoff), 0);
+        assert_eq!(cache.map.len(), 8);
+        assert_eq!(cache.cache_evictions(), Some(0));
+        let after: Vec<Option<u32>> = cache
+            .keys
+            .iter()
+            .map(|s| s.key.as_ref().map(|k| *k.0))
+            .collect();
+        assert_eq!(before, after, "the live half is swapped back in order");
+        assert_index_lockstep(&cache, "after an all-live evict_at");
+    }
+
+    /// The degenerate single-element cases at the tie: one entry exactly at the cutoff is
+    /// kept, one entry a tick earlier is swept, and one never-expiring entry is kept.
+    #[test]
+    fn evict_at_single_element_exactly_at_the_tie_is_kept() {
+        let cutoff = crate::time::Instant::now() + Duration::from_secs(1);
+        let cases: [(Option<Duration>, usize); 3] = [
+            (Some(Duration::ZERO), 0),          // expiry == cutoff -> live
+            (Some(Duration::from_nanos(1)), 1), // expiry == cutoff - 1ns -> swept
+            (None, 0),                          // never expires -> live
+        ];
+        for (back_off, expected) in cases {
+            let mut cache = TtlSortedCache::<u32, u32>::builder()
+                .ttl(Duration::from_secs(60))
+                .build()
+                .unwrap();
+            let expiry = back_off.map(|d| cutoff - d);
+            insert_raw(&mut cache, 1u32, 10u32, expiry);
+            assert_eq!(
+                old_range_expired_count(&cache, cutoff),
+                expected,
+                "reference: the old range agrees for back_off={back_off:?}"
+            );
+            assert_eq!(
+                cache.evict_at(cutoff),
+                expected,
+                "single-element boundary for back_off={back_off:?}"
+            );
+            assert_eq!(cache.map.len(), 1 - expected);
+            assert_index_lockstep(&cache, "single-element boundary");
+        }
+    }
+
+    /// DIVERGENCE FROM THE OLD CODE (intentional): the old sweep range started at
+    /// `Included(bound(min_instant))`, so an entry expiring BEFORE the cache was built would
+    /// never have been swept. `split_off` has no lower bound, so such an entry is now swept.
+    /// It is unreachable through the public API (every stored expiry is `insert_time + ttl`
+    /// and every insert happens after `min_instant`), so this is a strict improvement, but it
+    /// is a real behavioral difference and is pinned here.
+    #[test]
+    fn evict_at_sweeps_entries_older_than_min_instant_unlike_the_old_lower_bound() {
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        let min_instant = cache.min_instant;
+        let cutoff = min_instant + Duration::from_secs(1);
+        // Below `min_instant`: outside the old `Included(bound(min_instant))..` range.
+        insert_raw(
+            &mut cache,
+            1u32,
+            10u32,
+            Some(min_instant - Duration::from_nanos(1)),
+        );
+        insert_raw(&mut cache, 2u32, 20u32, Some(min_instant));
+
+        assert_eq!(
+            old_range_expired_count(&cache, cutoff),
+            1,
+            "the old lower bound excluded the pre-min_instant entry"
+        );
+        assert_eq!(
+            cache.evict_at(cutoff),
+            2,
+            "the front-driven sweep has no lower bound and reaps both"
+        );
+        assert!(cache.map.is_empty());
+        assert_index_lockstep(&cache, "after sweeping below min_instant");
+    }
+
+    /// Deferred callbacks must still fire in expiry order, exactly once per entry actually
+    /// removed from the map, with the return value and the eviction counter agreeing.
+    #[test]
+    fn evict_at_fires_on_evict_in_expiry_order_after_every_map_removal() {
+        let log = Arc::new(std::sync::Mutex::new(Vec::<(u32, u32)>::new()));
+        let log2 = log.clone();
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .on_evict(move |k: &u32, v: &u32| log2.lock().unwrap().push((*k, *v)))
+            .build()
+            .unwrap();
+        let cutoff = crate::time::Instant::now() + Duration::from_secs(1);
+        // Inserted in a scrambled order; the index sorts them by expiry regardless.
+        for k in [3u32, 0, 4, 1, 2] {
+            insert_raw(
+                &mut cache,
+                k,
+                k * 10,
+                Some(cutoff - Duration::from_micros(10 - u64::from(k))),
+            );
+        }
+        insert_raw(&mut cache, 100u32, 1000u32, Some(cutoff));
+
+        let dropped = cache.evict_at(cutoff);
+        assert_eq!(dropped, 5, "the returned count is the number of drops");
+        assert_eq!(
+            cache.cache_evictions(),
+            Some(5),
+            "the counter agrees with the return value"
+        );
+        assert_eq!(
+            *log.lock().unwrap(),
+            vec![(0, 0), (1, 10), (2, 20), (3, 30), (4, 40)],
+            "callbacks fire in ascending expiry order, once per removed entry"
+        );
+        assert_eq!(cache.map.len(), 1);
+        assert_index_lockstep(&cache, "after an ordered deferred sweep");
+    }
+
+    /// A callback that panics on a MIDDLE entry: every map removal has already happened, so
+    /// the index and the map stay in lockstep and the counter reflects all of them.
+    #[test]
+    fn evict_at_on_evict_panic_on_a_middle_callback_leaves_the_index_in_lockstep() {
+        for panic_on in [0usize, 2, 5] {
+            let seen = Arc::new(AtomicUsize::new(0));
+            let seen2 = seen.clone();
+            let mut cache = TtlSortedCache::<u32, u32>::builder()
+                .ttl(Duration::from_secs(60))
+                .on_evict(move |_k: &u32, _v: &u32| {
+                    if seen2.fetch_add(1, Ordering::Relaxed) == panic_on {
+                        panic!("boom");
+                    }
+                })
+                .build()
+                .unwrap();
+            let cutoff = crate::time::Instant::now() + Duration::from_secs(1);
+            for k in 0u32..6 {
+                insert_raw(
+                    &mut cache,
+                    k,
+                    k,
+                    Some(cutoff - Duration::from_micros(u64::from(k) + 1)),
+                );
+            }
+            insert_raw(&mut cache, 100u32, 100u32, Some(cutoff));
+
+            let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let _ = cache.evict_at(cutoff);
+            }));
+            assert!(caught.is_err(), "panic_on={panic_on}: must propagate");
+            assert_index_lockstep(&cache, "after a mid-drain callback panic");
+            assert_eq!(
+                cache.map.len(),
+                1,
+                "panic_on={panic_on}: every expired entry left the map before any callback"
+            );
+            assert!(cache.map.contains_key(&100u32));
+            assert_eq!(
+                cache.cache_evictions(),
+                Some(6),
+                "panic_on={panic_on}: the counter is bumped before the callbacks"
+            );
+            assert_eq!(
+                seen.load(Ordering::Relaxed),
+                panic_on + 1,
+                "panic_on={panic_on}: unwinding stops the remaining callbacks"
+            );
+            // The survivor is still reachable through the index.
+            assert_eq!(cache.retain_latest(0, false), 1);
+            assert_index_lockstep(&cache, "after trimming the survivor");
+        }
+    }
+
+    /// The no-callback branch and the callback branch of `evict_at` must produce identical
+    /// return values, identical eviction counts and identical resulting state for the same
+    /// input. Only the callback branch is directly asserted elsewhere.
+    #[test]
+    fn evict_at_drain_branches_agree_on_count_state_and_evictions() {
+        fn populate(cache: &mut TtlSortedCache<u32, u32>, cutoff: crate::time::Instant) {
+            for k in 0u32..24 {
+                let expiry = match k % 4 {
+                    // Expired, with colliding instants in pairs.
+                    0 | 1 => Some(cutoff - Duration::from_micros(u64::from(k / 2) + 1)),
+                    // Live, half of them exactly on the tie.
+                    2 => Some(cutoff + Duration::from_micros(u64::from(k % 3))),
+                    _ => None,
+                };
+                insert_raw(cache, k, k * 7, expiry);
+            }
+        }
+
+        let cutoff = crate::time::Instant::now() + Duration::from_secs(1);
+
+        let mut plain = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        populate(&mut plain, cutoff);
+
+        let fired = Arc::new(AtomicUsize::new(0));
+        let fired2 = fired.clone();
+        let mut with_cb = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .on_evict(move |_k: &u32, _v: &u32| {
+                fired2.fetch_add(1, Ordering::Relaxed);
+            })
+            .build()
+            .unwrap();
+        populate(&mut with_cb, cutoff);
+
+        let plain_dropped = plain.evict_at(cutoff);
+        let cb_dropped = with_cb.evict_at(cutoff);
+
+        assert_eq!(
+            plain_dropped, cb_dropped,
+            "both drain branches drop the same count"
+        );
+        assert_eq!(plain_dropped, 12, "half the population is expired");
+        assert_eq!(plain.cache_evictions(), with_cb.cache_evictions());
+        assert_eq!(plain.cache_evictions(), Some(12));
+        assert_eq!(fired.load(Ordering::Relaxed), 12);
+
+        let plain_keys: Vec<u32> = {
+            let mut v: Vec<u32> = plain.map.keys().copied().collect();
+            v.sort_unstable();
+            v
+        };
+        let cb_keys: Vec<u32> = {
+            let mut v: Vec<u32> = with_cb.map.keys().copied().collect();
+            v.sort_unstable();
+            v
+        };
+        assert_eq!(plain_keys, cb_keys, "identical surviving map contents");
+
+        let plain_index: Vec<(Option<crate::time::Instant>, Option<u32>)> = plain
+            .keys
+            .iter()
+            .map(|s| (s.expiry, s.key.as_ref().map(|k| *k.0)))
+            .collect();
+        let cb_index: Vec<(Option<crate::time::Instant>, Option<u32>)> = with_cb
+            .keys
+            .iter()
+            .map(|s| (s.expiry, s.key.as_ref().map(|k| *k.0)))
+            .collect();
+        assert_eq!(plain_index, cb_index, "identical surviving index contents");
+        assert_index_lockstep(&plain, "no-callback branch");
+        assert_index_lockstep(&with_cb, "callback branch");
+    }
+
+    /// PINS THE ORPHAN DIVERGENCE. An index stamp with no map entry is unreachable through
+    /// the public API (see the module certification notes: every insert stamps exactly one
+    /// entry and every removal drops the rebuilt stamp), but if it ever occurred, `evict_at`
+    /// would COUNT it as a drop in its return value while NOT counting it as an eviction.
+    /// This test documents that asymmetry so a future change to either counter is deliberate.
+    #[test]
+    fn evict_at_orphaned_stamp_is_counted_as_a_drop_but_not_as_an_eviction() {
+        for with_callback in [false, true] {
+            let fired = Arc::new(AtomicUsize::new(0));
+            let fired2 = fired.clone();
+            let mut builder = TtlSortedCache::<u32, u32>::builder().ttl(Duration::from_secs(60));
+            if with_callback {
+                builder = builder.on_evict(move |_k: &u32, _v: &u32| {
+                    fired2.fetch_add(1, Ordering::Relaxed);
+                });
+            }
+            let mut cache = builder.build().unwrap();
+            let cutoff = crate::time::Instant::now() + Duration::from_secs(1);
+            insert_raw(
+                &mut cache,
+                1u32,
+                10u32,
+                Some(cutoff - Duration::from_micros(2)),
+            );
+            // No map entry for key 9.
+            insert_orphan_stamp(&mut cache, 9u32, Some(cutoff - Duration::from_micros(1)));
+            assert_eq!(cache.keys.len(), 2);
+            assert_eq!(cache.map.len(), 1);
+
+            assert_eq!(
+                cache.evict_at(cutoff),
+                2,
+                "with_callback={with_callback}: the return value counts index drops"
+            );
+            assert_eq!(
+                cache.cache_evictions(),
+                Some(1),
+                "with_callback={with_callback}: only real map removals are evictions"
+            );
+            assert_eq!(fired.load(Ordering::Relaxed), usize::from(with_callback));
+            // The orphan is gone, so the cache is back in lockstep afterwards.
+            assert_index_lockstep(&cache, "after sweeping an orphaned stamp");
+        }
+    }
+
+    /// The same divergence through `retain_latest_at`: `retain_drop_count` is derived from
+    /// `map.len()` while the pop loop walks `keys`, so an orphan makes the trim consume one
+    /// index slot without freeing a map entry, leaving the cache above the requested count.
+    #[test]
+    fn retain_latest_at_orphaned_stamp_diverges_from_the_map_length() {
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        let base = crate::time::Instant::now() + Duration::from_secs(60);
+        // The orphan sorts FIRST, so the trim pops it before any real entry.
+        insert_orphan_stamp(&mut cache, 9u32, Some(base));
+        for k in 0u32..3 {
+            insert_raw(
+                &mut cache,
+                k,
+                k,
+                Some(base + Duration::from_micros(u64::from(k) + 1)),
+            );
+        }
+        assert_eq!(cache.map.len(), 3);
+        assert_eq!(cache.keys.len(), 4);
+
+        // Ask to keep 2 of 3 map entries: one drop. The orphan absorbs it.
+        assert_eq!(cache.retain_latest_at(2, None), 1);
+        assert_eq!(
+            cache.map.len(),
+            3,
+            "the orphan absorbed the trim, so no map entry was freed"
+        );
+        assert_eq!(cache.cache_evictions(), Some(0));
+        assert_eq!(cache.keys.len(), 3, "the cache is back in lockstep");
+        assert_index_lockstep(&cache, "after the orphan absorbed a trim");
+        // A second trim now behaves normally.
+        assert_eq!(cache.retain_latest_at(2, None), 1);
+        assert_eq!(cache.map.len(), 2);
+        assert_eq!(cache.cache_evictions(), Some(1));
+    }
+
+    /// `retain_latest_at` pops one stamp at a time and removes its map entry, counts the
+    /// eviction, and only then fires the callback -- matching `evict_at` / `retain`. So a
+    /// panicking callback still leaves the two structures in lockstep AND the entry whose
+    /// callback panicked is still counted, since the counter is bumped BEFORE the callback runs.
+    #[test]
+    fn retain_latest_at_on_evict_panic_leaves_lockstep_and_counts_the_eviction() {
+        let seen = Arc::new(AtomicUsize::new(0));
+        let seen2 = seen.clone();
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .on_evict(move |_k: &u32, _v: &u32| {
+                if seen2.fetch_add(1, Ordering::Relaxed) == 1 {
+                    panic!("boom");
+                }
+            })
+            .build()
+            .unwrap();
+        for k in 0u32..5 {
+            cache
+                .set_with(k, k * 10)
+                .ttl(Duration::from_secs(10 * (u64::from(k) + 1)))
+                .set();
+        }
+
+        let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _ = cache.retain_latest(1, false);
+        }));
+        assert!(caught.is_err(), "the callback panic must propagate");
+
+        assert_index_lockstep(&cache, "after a retain_latest callback panic");
+        assert_eq!(
+            cache.map.len(),
+            3,
+            "two entries were removed before the panic"
+        );
+        assert_eq!(seen.load(Ordering::Relaxed), 2);
+        assert_eq!(
+            cache.cache_evictions(),
+            Some(2),
+            "both removals are counted: the counter is bumped before the callback runs"
+        );
+        // The cache remains usable and fully reachable through the index.
+        assert_eq!(cache.retain_latest(0, false), 3);
+        assert!(cache.map.is_empty());
+        assert!(cache.keys.is_empty());
+    }
+
+    /// The tie boundary reached through the SECOND phase of `retain_latest_at` (after the
+    /// size trim is satisfied), which uses a separate `expiry < cutoff` comparison rather
+    /// than the `split_off` pivot. An entry expiring exactly at the cutoff must stop the
+    /// sweep, matching `evict_at`.
+    #[test]
+    fn retain_latest_at_tie_stops_the_sweep_after_the_size_trim() {
+        // 4 entries, keep 3 -> retain_drop_count = 1: entry 1 (strictly before the cutoff) is
+        // dropped by the trim, then entry 2 sits exactly ON the cutoff and must stop the sweep.
+        let (mut cache, cutoff) = boundary_population();
+        assert_eq!(
+            cache.retain_latest_at(3, Some(cutoff)),
+            1,
+            "the tied entry must not be swept by the post-trim expiry loop"
+        );
+        assert!(!cache.map.contains_key(&1u32));
+        assert!(cache.map.contains_key(&2u32), "the exact tie survives");
+        assert!(cache.map.contains_key(&3u32));
+        assert!(cache.map.contains_key(&4u32));
+        assert_index_lockstep(&cache, "after a post-trim tie stop");
+
+        // One tick later the tie IS expired and the sweep continues past the trim.
+        let (mut cache, cutoff) = boundary_population();
+        assert_eq!(
+            cache.retain_latest_at(3, Some(cutoff + Duration::from_nanos(1))),
+            2
+        );
+        assert!(!cache.map.contains_key(&2u32));
+        assert!(cache.map.contains_key(&3u32));
+        assert_index_lockstep(&cache, "after sweeping past the tie");
+    }
+
+    // --- Coarse `Eq`/`Ord` keys: two distinct values that compare equal ------------------
+
+    /// A key whose `Eq`/`Ord`/`Hash` consider only `label`, so two values carrying different
+    /// `payload`s compare EQUAL. `set_inner`'s occupied branch reuses the stored `Arc`, and
+    /// `BTreeSet::insert` keeps the incumbent on an equal insert, so the index and the map
+    /// can hold different-but-equal `Stamped`s.
+    #[derive(Clone, Debug)]
+    struct CoarseKey {
+        label: &'static str,
+        payload: u32,
+    }
+
+    impl Hash for CoarseKey {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            self.label.hash(state);
+        }
+    }
+    impl PartialEq for CoarseKey {
+        fn eq(&self, other: &Self) -> bool {
+            self.label == other.label
+        }
+    }
+    impl Eq for CoarseKey {}
+    impl PartialOrd for CoarseKey {
+        fn partial_cmp(&self, other: &Self) -> Option<CmpOrdering> {
+            Some(self.cmp(other))
+        }
+    }
+    impl Ord for CoarseKey {
+        fn cmp(&self, other: &Self) -> CmpOrdering {
+            self.label.cmp(other.label)
+        }
+    }
+
+    /// Overwriting with an equal-but-distinct key must keep exactly one map entry and one
+    /// stamp, and the STORED key is the FIRST-inserted payload (the occupied branch reuses
+    /// the existing `Arc`, matching `HashMap`'s own "insert keeps the incumbent key" rule).
+    /// `on_evict` and `cache_remove_entry` therefore report the first payload, not the last.
+    #[test]
+    fn coarse_key_overwrite_keeps_lockstep_and_reports_the_first_stored_key() {
+        let seen = Arc::new(std::sync::Mutex::new(Vec::<u32>::new()));
+        let seen2 = seen.clone();
+        let mut cache = TtlSortedCache::<CoarseKey, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .on_evict(move |k: &CoarseKey, _v: &u32| seen2.lock().unwrap().push(k.payload))
+            .build()
+            .unwrap();
+
+        let first = CoarseKey {
+            label: "a",
+            payload: 1,
+        };
+        let second = CoarseKey {
+            label: "a",
+            payload: 2,
+        };
+        assert_eq!(first, second, "the two keys compare equal");
+        assert_eq!(first.cmp(&second), CmpOrdering::Equal);
+
+        cache.cache_set(first.clone(), 10u32);
+        assert_eq!(cache.cache_set(second.clone(), 20u32), Some(10u32));
+        assert_eq!(cache.map.len(), 1);
+        assert_eq!(cache.keys.len(), 1, "no duplicate stamp for an equal key");
+        assert_index_lockstep(&cache, "after a coarse-key overwrite");
+
+        // The stored key is the first payload, and the index stamp shares its `Arc`.
+        let entry = cache.map.values().next().expect("one entry");
+        assert_eq!(
+            entry.key.0.payload, 1,
+            "the occupied branch reuses the originally stored key"
+        );
+        let stamp = cache.keys.iter().next().expect("one stamp");
+        assert!(
+            Arc::ptr_eq(
+                &stamp.key.as_ref().expect("real key").0,
+                &cache.map.values().next().expect("one entry").key.0
+            ),
+            "the index stamp and the map entry share the same key Arc"
+        );
+
+        // Removal by the SECOND (equal) key still finds the entry, and hands the callback and
+        // the `cache_remove_entry` return the FIRST payload.
+        let removed = cache.cache_remove_entry(&second).expect("present");
+        assert_eq!(removed.0.payload, 1, "the stored key is returned");
+        assert_eq!(removed.1, 20u32);
+        assert_eq!(*seen.lock().unwrap(), vec![1u32]);
+        assert!(cache.map.is_empty());
+        assert!(cache.keys.is_empty());
+        assert_index_lockstep(&cache, "after a coarse-key removal");
+    }
+
+    /// The same coarse key across an expiry change: the stale stamp must be removed by the
+    /// rebuilt `old.as_stamped()`, which carries the shared `Arc`, so no duplicate survives
+    /// and the sweep order follows the NEW expiry.
+    #[test]
+    fn coarse_key_overwrite_with_a_new_expiry_replaces_exactly_one_stamp() {
+        let mut cache = TtlSortedCache::<CoarseKey, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        let a1 = CoarseKey {
+            label: "a",
+            payload: 1,
+        };
+        let a2 = CoarseKey {
+            label: "a",
+            payload: 2,
+        };
+        let b = CoarseKey {
+            label: "b",
+            payload: 9,
+        };
+        cache.set_with(a1, 10u32).ttl(Duration::ZERO).set();
+        cache.set_with(b, 90u32).ttl(Duration::from_secs(30)).set();
+        assert_index_lockstep(&cache, "coarse pair");
+
+        // UNCHANGED expiry (None -> None) with a different-but-equal key: the new stamp is
+        // Ord-equal to the incumbent, so `BTreeSet::insert` is a no-op and the stale-stamp
+        // removal MUST be skipped -- removing it here would delete the only stamp for a live
+        // map entry and orphan it.
+        assert_eq!(
+            cache.set_with(a2.clone(), 10u32).ttl(Duration::ZERO).set(),
+            Some(10u32)
+        );
+        assert_eq!(cache.map.len(), 2);
+        assert_eq!(
+            cache.keys.len(),
+            2,
+            "the single stamp survives the overwrite"
+        );
+        assert_index_lockstep(&cache, "after a same-expiry coarse-key overwrite");
+
+        // None -> Some: the never-expires stamp must go.
+        assert_eq!(
+            cache
+                .set_with(a2.clone(), 11u32)
+                .ttl(Duration::from_secs(5))
+                .set(),
+            Some(10u32)
+        );
+        assert_eq!(cache.cache_evictions(), Some(0), "no expired displacement");
+        assert_eq!(cache.map.len(), 2);
+        assert_eq!(cache.keys.len(), 2, "the stale stamp is gone");
+        assert_index_lockstep(&cache, "after a coarse-key re-stamp");
+
+        // "a" now expires first, so it is trimmed first.
+        assert_eq!(cache.retain_latest(1, false), 1);
+        assert!(!cache.map.contains_key(&a2));
+        assert_index_lockstep(&cache, "after trimming the re-stamped coarse key");
+    }
+
+    /// A long mixed sequence over the public surface: the lockstep invariant must hold after
+    /// every single operation. This is the empirical half of the "an orphaned stamp is
+    /// unreachable by construction" claim.
+    #[test]
+    fn lockstep_holds_across_a_mixed_public_operation_sequence() {
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_millis(30))
+            .max_size(5)
+            .on_evict(|_k: &u32, _v: &u32| {})
+            .build()
+            .unwrap();
+        for round in 0u32..40 {
+            let k = round % 7;
+            match round % 8 {
+                0 => {
+                    cache.set(k, round);
+                }
+                1 => {
+                    cache.set_with(k, round).ttl(Duration::ZERO).set();
+                }
+                2 => {
+                    cache
+                        .set_with(k, round)
+                        .ttl(Duration::from_millis(10))
+                        .evict()
+                        .set();
+                }
+                3 => {
+                    let _ = cache.cache_get(&k);
+                }
+                4 => {
+                    let _ = cache.cache_remove(&k);
+                }
+                5 => {
+                    let _ = cache.cache_get_or_set_with_mut(k, || round);
+                }
+                6 => {
+                    cache.retain(|kk, _v| *kk != round % 5);
+                }
+                _ => {
+                    let _ = cache.retain_latest(3, round % 16 == 7);
+                }
+            }
+            assert_index_lockstep(&cache, "mixed sequence");
+            assert!(cache.map.len() <= 5 || round % 8 == 5);
+        }
+        let _ = cache.evict();
+        assert_index_lockstep(&cache, "after the final sweep");
+        cache.cache_clear();
+        assert_index_lockstep(&cache, "after clear");
+    }
+
+    /// `set_inner` samples the clock ONCE and judges the displaced entry against that sample.
+    /// The classification itself is pinned here with exact expiries; the sub-microsecond
+    /// window between the sample and the map write is NOT observable from a test (see the
+    /// certification notes) because the store exposes no clock injection point.
+    #[test]
+    fn set_inner_classifies_the_displaced_entry_against_its_clock_sample() {
+        let fired = Arc::new(AtomicUsize::new(0));
+        let fired2 = fired.clone();
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .on_evict(move |_k: &u32, _v: &u32| {
+                fired2.fetch_add(1, Ordering::Relaxed);
+            })
+            .build()
+            .unwrap();
+
+        // Displaced entry already past its deadline -> filtered from the return, evicted.
+        insert_raw(
+            &mut cache,
+            1u32,
+            10u32,
+            Some(crate::time::Instant::now() - Duration::from_nanos(1)),
+        );
+        assert_eq!(cache.cache_set(1u32, 11u32), None);
+        assert_eq!(fired.load(Ordering::Relaxed), 1);
+        assert_eq!(cache.cache_evictions(), Some(1));
+        assert_index_lockstep(&cache, "after displacing an expired entry");
+
+        // Displaced entry comfortably in the future -> returned as live, no eviction.
+        insert_raw(
+            &mut cache,
+            2u32,
+            20u32,
+            Some(crate::time::Instant::now() + Duration::from_secs(3600)),
+        );
+        assert_eq!(cache.cache_set(2u32, 21u32), Some(20u32));
+        assert_eq!(fired.load(Ordering::Relaxed), 1);
+        assert_eq!(cache.cache_evictions(), Some(1));
+        assert_index_lockstep(&cache, "after displacing a live entry");
+    }
+
+    // --- Item 7: the async liveness-check behavior change -------------------------------
+
+    /// (c) A PANICKING factory future: the expired entry is left in place, `on_evict` never
+    /// fires and nothing is counted. Under the previous `cache_get`-based shape the entry was
+    /// already swept (and `on_evict` already fired) before the future was ever polled.
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn async_cache_get_or_set_with_mut_factory_panic_keeps_the_expired_entry() {
+        use crate::CachedGetOrSetAsync;
+
+        let fired = Arc::new(AtomicUsize::new(0));
+        let fired2 = fired.clone();
+        let mut c: TtlSortedCache<u32, u32> = TtlSortedCache::builder()
+            .ttl(Duration::from_millis(20))
+            .on_evict(move |_k: &u32, _v: &u32| {
+                fired2.fetch_add(1, Ordering::Relaxed);
+            })
+            .build()
+            .unwrap();
+        c.cache_set(1u32, 100u32);
+        tokio::time::sleep(std::time::Duration::from_millis(60)).await;
+        c.cache_reset_metrics();
+
+        {
+            let mut fut = Box::pin(CachedGetOrSetAsync::async_cache_get_or_set_with_mut(
+                &mut c,
+                1u32,
+                || async { panic!("factory boom") },
+            ));
+            let waker = std::task::Waker::noop();
+            let mut cx = std::task::Context::from_waker(waker);
+            let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let _ = std::future::Future::poll(fut.as_mut(), &mut cx);
+            }));
+            assert!(caught.is_err(), "the factory panic must propagate");
+        }
+
+        assert_eq!(
+            fired.load(Ordering::Relaxed),
+            0,
+            "on_evict must not fire when the factory panics"
+        );
+        assert_eq!(c.cache_evictions(), Some(0));
+        assert_eq!(c.cache_size(), 1, "the expired entry is still stored");
+        assert_eq!(
+            c.cache_misses(),
+            Some(1),
+            "the miss is counted before the factory runs"
+        );
+        // The stale value is still observable through the expiry-status peek.
+        assert_eq!(
+            crate::CloneCached::cache_peek_with_expiry_status(&c, &1u32),
+            (Some(100u32), true),
+            "the stale value survives the panic and is reported as expired"
+        );
+        assert_index_lockstep(&c, "after an async factory panic");
+    }
+
+    /// (a) NORMAL COMPLETION: the eviction of the displaced expired entry now happens AFTER
+    /// the factory resolves, not before it is polled. Observed through the callback ordering.
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn async_cache_get_or_set_with_mut_fires_on_evict_after_the_factory_completes() {
+        use crate::CachedGetOrSetAsync;
+
+        let log = Arc::new(std::sync::Mutex::new(Vec::<&'static str>::new()));
+        let log2 = log.clone();
+        let mut c: TtlSortedCache<u32, u32> = TtlSortedCache::builder()
+            .ttl(Duration::from_millis(20))
+            .on_evict(move |_k: &u32, _v: &u32| log2.lock().unwrap().push("evict"))
+            .build()
+            .unwrap();
+        c.cache_set(1u32, 100u32);
+        tokio::time::sleep(std::time::Duration::from_millis(60)).await;
+
+        let log3 = log.clone();
+        let v = CachedGetOrSetAsync::async_cache_get_or_set_with_mut(&mut c, 1u32, || async move {
+            log3.lock().unwrap().push("factory");
+            200u32
+        })
+        .await;
+        assert_eq!(*v, 200u32);
+        assert_eq!(
+            *log.lock().unwrap(),
+            vec!["factory", "evict"],
+            "the displaced expired entry is evicted after the factory resolves"
+        );
+        assert_eq!(c.cache_evictions(), Some(1));
+        assert_eq!(c.cache_size(), 1);
+        assert_index_lockstep(&c, "after an async replacement");
+    }
+
+    /// The fallible async sibling now uses the same in-place liveness check as the other
+    /// three `cache_*get_or_set_with_mut` variants instead of routing through `cache_get`
+    /// (which would sweep the expired entry, firing `on_evict`, before the factory is ever
+    /// polled). On `Err` the expired entry is left exactly in place, matching the sync
+    /// fallible sibling.
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn async_try_get_or_set_with_mut_leaves_the_expired_entry_alone_on_err() {
+        use crate::CachedGetOrSetAsync;
+
+        let fired = Arc::new(AtomicUsize::new(0));
+        let fired2 = fired.clone();
+        let mut c: TtlSortedCache<u32, u32> = TtlSortedCache::builder()
+            .ttl(Duration::from_millis(20))
+            .on_evict(move |_k: &u32, _v: &u32| {
+                fired2.fetch_add(1, Ordering::Relaxed);
+            })
+            .build()
+            .unwrap();
+        c.cache_set(1u32, 100u32);
+        tokio::time::sleep(std::time::Duration::from_millis(60)).await;
+        c.cache_reset_metrics();
+
+        let out: Result<&mut u32, &'static str> =
+            CachedGetOrSetAsync::async_cache_try_get_or_set_with_mut(&mut c, 1u32, || async {
+                Err("nope")
+            })
+            .await;
+        assert_eq!(out.err(), Some("nope"));
+        assert_eq!(
+            c.cache_size(),
+            1,
+            "the fallible async path leaves the expired entry alone on Err"
+        );
+        assert_eq!(fired.load(Ordering::Relaxed), 0, "on_evict must not fire");
+        assert_eq!(c.cache_evictions(), Some(0));
+        assert_eq!(
+            c.cache_misses(),
+            Some(1),
+            "the miss is counted before the factory runs"
+        );
+        assert_index_lockstep(&c, "after a failed async try factory");
+
+        // The SYNC fallible sibling agrees: the expired entry is left in place.
+        let mut c2: TtlSortedCache<u32, u32> = TtlSortedCache::builder()
+            .ttl(Duration::from_millis(20))
+            .build()
+            .unwrap();
+        c2.cache_set(1u32, 100u32);
+        std::thread::sleep(std::time::Duration::from_millis(60));
+        let out: Result<&mut u32, &'static str> =
+            c2.cache_try_get_or_set_with_mut(1u32, || Err("nope"));
+        assert_eq!(out.err(), Some("nope"));
+        assert_eq!(
+            c2.cache_size(),
+            1,
+            "the sync fallible path leaves the expired entry alone"
+        );
+        assert_eq!(c2.cache_evictions(), Some(0));
+    }
+
+    /// (b) CANCELLATION, contrasted directly between the two async methods on an identical
+    /// starting state. Both now agree: the expired entry survives an in-flight future being
+    /// dropped, and `on_evict` never fires for it.
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn async_get_or_set_variants_agree_on_cancellation_over_an_expired_entry() {
+        use crate::CachedGetOrSetAsync;
+
+        async fn expired_cache() -> (TtlSortedCache<u32, u32>, Arc<AtomicUsize>) {
+            let fired = Arc::new(AtomicUsize::new(0));
+            let fired2 = fired.clone();
+            let mut c: TtlSortedCache<u32, u32> = TtlSortedCache::builder()
+                .ttl(Duration::from_millis(20))
+                .on_evict(move |_k: &u32, _v: &u32| {
+                    fired2.fetch_add(1, Ordering::Relaxed);
+                })
+                .build()
+                .unwrap();
+            c.cache_set(1u32, 100u32);
+            tokio::time::sleep(std::time::Duration::from_millis(60)).await;
+            (c, fired)
+        }
+
+        // Infallible: nothing observable happens to the entry.
+        let (mut c, fired) = expired_cache().await;
+        {
+            let mut fut = Box::pin(CachedGetOrSetAsync::async_cache_get_or_set_with_mut(
+                &mut c,
+                1u32,
+                std::future::pending::<u32>,
+            ));
+            let waker = std::task::Waker::noop();
+            let mut cx = std::task::Context::from_waker(waker);
+            assert!(matches!(
+                std::future::Future::poll(fut.as_mut(), &mut cx),
+                std::task::Poll::Pending
+            ));
+        }
+        assert_eq!(c.cache_size(), 1);
+        assert_eq!(fired.load(Ordering::Relaxed), 0);
+        assert_eq!(c.cache_evictions(), Some(0));
+        assert_index_lockstep(&c, "after a cancelled infallible async factory");
+
+        // Fallible: now agrees -- the expired entry is likewise left alone by cancellation.
+        let (mut c, fired) = expired_cache().await;
+        {
+            let mut fut = Box::pin(CachedGetOrSetAsync::async_cache_try_get_or_set_with_mut::<
+                _,
+                _,
+                &'static str,
+            >(&mut c, 1u32, || {
+                std::future::pending::<Result<u32, &'static str>>()
+            }));
+            let waker = std::task::Waker::noop();
+            let mut cx = std::task::Context::from_waker(waker);
+            assert!(matches!(
+                std::future::Future::poll(fut.as_mut(), &mut cx),
+                std::task::Poll::Pending
+            ));
+        }
+        assert_eq!(
+            c.cache_size(),
+            1,
+            "the fallible async path also leaves the expired entry alone when cancelled"
+        );
+        assert_eq!(fired.load(Ordering::Relaxed), 0);
+        assert_eq!(c.cache_evictions(), Some(0));
+        assert_index_lockstep(&c, "after a cancelled fallible async factory");
+    }
+
+    /// (d) `Ok` completion for the fallible async variant: net end state/counters match the
+    /// pre-fix behavior, but `on_evict` now fires AFTER the factory resolves (observed via
+    /// callback ordering) and the insert takes the OCCUPIED `set_inner` branch (reusing the
+    /// stored key `Arc`) rather than a vacant one, because the expired entry was never swept.
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn async_try_get_or_set_with_mut_fires_on_evict_after_the_factory_completes() {
+        use crate::CachedGetOrSetAsync;
+
+        let log = Arc::new(std::sync::Mutex::new(Vec::<&'static str>::new()));
+        let log2 = log.clone();
+        let mut c: TtlSortedCache<u32, u32> = TtlSortedCache::builder()
+            .ttl(Duration::from_millis(20))
+            .on_evict(move |_k: &u32, _v: &u32| log2.lock().unwrap().push("evict"))
+            .build()
+            .unwrap();
+        c.cache_set(1u32, 100u32);
+        tokio::time::sleep(std::time::Duration::from_millis(60)).await;
+
+        let log3 = log.clone();
+        let out: Result<&mut u32, &'static str> =
+            CachedGetOrSetAsync::async_cache_try_get_or_set_with_mut(&mut c, 1u32, || async move {
+                log3.lock().unwrap().push("factory");
+                Ok(200u32)
+            })
+            .await;
+        assert_eq!(out.ok(), Some(&mut 200u32));
+        assert_eq!(
+            *log.lock().unwrap(),
+            vec!["factory", "evict"],
+            "the displaced expired entry is evicted after the factory resolves"
+        );
+        assert_eq!(c.cache_evictions(), Some(1));
+        assert_eq!(c.cache_size(), 1);
+        assert_index_lockstep(&c, "after an async fallible replacement");
+    }
+
+    /// Cross-variant agreement table: sync infallible, sync fallible, async infallible, and
+    /// async fallible must all behave identically on an expired-entry key for each terminal
+    /// outcome the family shares, so a future change to one cannot silently desync the group.
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn get_or_set_family_agrees_on_expired_entry_across_variants() {
+        use crate::CachedGetOrSetAsync;
+
+        fn expired_cache() -> TtlSortedCache<u32, u32> {
+            let mut c: TtlSortedCache<u32, u32> = TtlSortedCache::builder()
+                .ttl(Duration::from_millis(1))
+                .build()
+                .unwrap();
+            c.cache_set(1u32, 100u32);
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            c
+        }
+
+        /// Same as `expired_cache`, but wired with an `on_evict` that appends to a shared
+        /// log, so the Ok-outcome sub-block below can pin *when* the displaced expired entry
+        /// is evicted relative to the factory, not just the net counts. This is the
+        /// discriminator the plain count assertions below cannot see: reverting the fix-2
+        /// liveness check to an eager `cache_get`-based sweep still nets `cache_size() == 1`
+        /// and `cache_evictions() == Some(1)` for the Ok outcome (the eager sweep evicts, then
+        /// the factory's value is inserted fresh), so only the callback order and `cache_get`
+        /// on-hit accounting expose that regression on this outcome.
+        type Log = std::sync::Arc<std::sync::Mutex<Vec<&'static str>>>;
+        fn expired_cache_with_log() -> (TtlSortedCache<u32, u32>, Log) {
+            let log: Log = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+            let log2 = log.clone();
+            let mut c: TtlSortedCache<u32, u32> = TtlSortedCache::builder()
+                .ttl(Duration::from_millis(1))
+                .on_evict(move |_k: &u32, _v: &u32| log2.lock().unwrap().push("evict"))
+                .build()
+                .unwrap();
+            c.cache_set(1u32, 100u32);
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            (c, log)
+        }
+
+        // --- Ok / infallible-success outcome: all four end up with the factory's value,
+        // fire on_evict exactly once AFTER the factory runs, and count exactly one eviction. ---
+        {
+            let (mut sync_infallible, log) = expired_cache_with_log();
+            let log2 = log.clone();
+            let v = sync_infallible.cache_get_or_set_with_mut(1u32, || {
+                log2.lock().unwrap().push("factory");
+                200u32
+            });
+            assert_eq!(*v, 200u32);
+            assert_eq!(sync_infallible.cache_size(), 1);
+            assert_eq!(sync_infallible.cache_evictions(), Some(1));
+            assert_eq!(
+                *log.lock().unwrap(),
+                vec!["factory", "evict"],
+                "sync infallible: on_evict fires after the factory"
+            );
+            assert_index_lockstep(&sync_infallible, "sync infallible Ok outcome");
+
+            let (mut sync_try, log) = expired_cache_with_log();
+            let log2 = log.clone();
+            let v: Result<&mut u32, &'static str> = sync_try.cache_try_get_or_set_with_mut(1u32, || {
+                log2.lock().unwrap().push("factory");
+                Ok(200u32)
+            });
+            assert_eq!(v.ok(), Some(&mut 200u32));
+            assert_eq!(sync_try.cache_size(), 1);
+            assert_eq!(sync_try.cache_evictions(), Some(1));
+            assert_eq!(
+                *log.lock().unwrap(),
+                vec!["factory", "evict"],
+                "sync try: on_evict fires after the factory"
+            );
+            assert_index_lockstep(&sync_try, "sync try Ok outcome");
+
+            let (mut async_infallible, log) = expired_cache_with_log();
+            let log2 = log.clone();
+            let v = CachedGetOrSetAsync::async_cache_get_or_set_with_mut(
+                &mut async_infallible,
+                1u32,
+                || async move {
+                    log2.lock().unwrap().push("factory");
+                    200u32
+                },
+            )
+            .await;
+            assert_eq!(*v, 200u32);
+            assert_eq!(async_infallible.cache_size(), 1);
+            assert_eq!(async_infallible.cache_evictions(), Some(1));
+            assert_eq!(
+                *log.lock().unwrap(),
+                vec!["factory", "evict"],
+                "async infallible: on_evict fires after the factory, not eagerly on the check"
+            );
+            assert_index_lockstep(&async_infallible, "async infallible Ok outcome");
+
+            let (mut async_try, log) = expired_cache_with_log();
+            let log2 = log.clone();
+            let v: Result<&mut u32, &'static str> =
+                CachedGetOrSetAsync::async_cache_try_get_or_set_with_mut(
+                    &mut async_try,
+                    1u32,
+                    || async move {
+                        log2.lock().unwrap().push("factory");
+                        Ok(200u32)
+                    },
+                )
+                .await;
+            assert_eq!(v.ok(), Some(&mut 200u32));
+            assert_eq!(
+                *log.lock().unwrap(),
+                vec!["factory", "evict"],
+                "async try: on_evict fires after the factory, not eagerly on the check"
+            );
+            assert_eq!(async_try.cache_size(), 1);
+            assert_eq!(async_try.cache_evictions(), Some(1));
+            assert_index_lockstep(&async_try, "async try Ok outcome");
+        }
+
+        // --- Err outcome (fallible variants only): the expired entry is left exactly alone,
+        // no eviction fires or is counted. ---
+        {
+            let mut sync_try = expired_cache();
+            let v: Result<&mut u32, &'static str> =
+                sync_try.cache_try_get_or_set_with_mut(1u32, || Err("nope"));
+            assert_eq!(v.err(), Some("nope"));
+            assert_eq!(sync_try.cache_size(), 1);
+            assert_eq!(sync_try.cache_evictions(), Some(0));
+            assert_index_lockstep(&sync_try, "sync try Err outcome");
+
+            let mut async_try = expired_cache();
+            let v: Result<&mut u32, &'static str> =
+                CachedGetOrSetAsync::async_cache_try_get_or_set_with_mut(
+                    &mut async_try,
+                    1u32,
+                    || async { Err("nope") },
+                )
+                .await;
+            assert_eq!(v.err(), Some("nope"));
+            assert_eq!(async_try.cache_size(), 1);
+            assert_eq!(async_try.cache_evictions(), Some(0));
+            assert_index_lockstep(&async_try, "async try Err outcome");
+        }
+
+        // --- Cancellation (async variants only): dropping the future mid-await leaves the
+        // expired entry exactly alone, no eviction fires or is counted. ---
+        {
+            let mut async_infallible = expired_cache();
+            {
+                let mut fut = Box::pin(CachedGetOrSetAsync::async_cache_get_or_set_with_mut(
+                    &mut async_infallible,
+                    1u32,
+                    std::future::pending::<u32>,
+                ));
+                let waker = std::task::Waker::noop();
+                let mut cx = std::task::Context::from_waker(waker);
+                assert!(matches!(
+                    std::future::Future::poll(fut.as_mut(), &mut cx),
+                    std::task::Poll::Pending
+                ));
+            }
+            assert_eq!(async_infallible.cache_size(), 1);
+            assert_eq!(async_infallible.cache_evictions(), Some(0));
+            assert_index_lockstep(&async_infallible, "async infallible cancellation");
+
+            let mut async_try = expired_cache();
+            {
+                let mut fut = Box::pin(CachedGetOrSetAsync::async_cache_try_get_or_set_with_mut::<
+                    _,
+                    _,
+                    &'static str,
+                >(&mut async_try, 1u32, || {
+                    std::future::pending::<Result<u32, &'static str>>()
+                }));
+                let waker = std::task::Waker::noop();
+                let mut cx = std::task::Context::from_waker(waker);
+                assert!(matches!(
+                    std::future::Future::poll(fut.as_mut(), &mut cx),
+                    std::task::Poll::Pending
+                ));
+            }
+            assert_eq!(async_try.cache_size(), 1);
+            assert_eq!(async_try.cache_evictions(), Some(0));
+            assert_index_lockstep(&async_try, "async try cancellation");
+        }
     }
 }

--- a/src/stores/ttl_sorted.rs
+++ b/src/stores/ttl_sorted.rs
@@ -760,10 +760,13 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> TtlSortedCache<K, V, S> {
 
     /// Set k/v pair without running eviction logic, using the cache's default TTL.
     ///
-    /// The entry is inserted first. If a `size_limit` was specified and capacity is exceeded,
-    /// the next-to-expire entry is dropped after insertion, but only if `.set_with(..).evict()`
-    /// was used — plain `set` never runs eviction logic itself; see
-    /// [`set_with`](Self::set_with) for per-entry TTL overrides and opt-in eviction.
+    /// The entry is inserted first. If a `size_limit` was configured and the insertion
+    /// pushes the map over it, the soonest-to-expire entry is trimmed to restore the
+    /// bound; this size-limit enforcement runs on every `set`, independent of the
+    /// `.evict()` opt-in. The `.set_with(..).evict()` opt-in controls only the separate
+    /// expiry sweep (dropping entries already past their TTL), not size-limit
+    /// enforcement; see [`set_with`](Self::set_with) for per-entry TTL overrides and the
+    /// opt-in sweep.
     ///
     /// If computing the expiry instant overflows (a TTL on the order of hundreds of
     /// years), the entry is stored with no expiry (never expires), matching

--- a/src/stores/ttl_sorted.rs
+++ b/src/stores/ttl_sorted.rs
@@ -3766,6 +3766,166 @@ mod test {
         assert_index_lockstep(&cache, "after trimming the survivor");
     }
 
+    /// A panicking `on_evict` must not desynchronize the map from the expiry index during a
+    /// `retain_latest` size trim either. Unlike `evict_at`'s batch-then-notify drain,
+    /// `retain_latest_at`'s pop loop fires `on_evict` inline per popped entry, so this path
+    /// only stays correct because each iteration finishes its `map` removal and the eviction
+    /// counter bump BEFORE the callback runs. Panic on the third callback (after two full,
+    /// uninterrupted iterations) so the test also proves the ordering holds across repeated
+    /// iterations, not merely on the very first one.
+    #[test]
+    fn retain_latest_on_evict_panic_leaves_the_index_in_lockstep() {
+        let fired = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let cb = std::sync::Arc::clone(&fired);
+        let mut cache = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .on_evict(move |_k, _v| {
+                if cb.fetch_add(1, std::sync::atomic::Ordering::Relaxed) == 2 {
+                    panic!("boom");
+                }
+            })
+            .build()
+            .unwrap();
+        let cutoff = crate::time::Instant::now() + Duration::from_secs(60);
+        // Five entries with strictly ascending expiry (soonest-to-expire first, matching the
+        // order `retain_latest_at`'s pop loop visits them in), plus a never-expiring survivor
+        // that must remain untouched by the trim.
+        for k in 0u32..5 {
+            insert_raw(
+                &mut cache,
+                k,
+                k,
+                Some(cutoff - Duration::from_secs(5) + Duration::from_micros(u64::from(k))),
+            );
+        }
+        insert_raw(&mut cache, 100u32, 100u32, None);
+
+        let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            // Keep only 1 entry: this must trim k=0..4, dropping the far end of the pop loop
+            // to the third callback's panic.
+            let _ = cache.retain_latest_at(1, None);
+        }));
+        assert!(caught.is_err(), "the callback panic must propagate");
+
+        assert_index_lockstep(&cache, "after on_evict panicked mid retain_latest_at");
+        // k=0 and k=1 completed a full (pop, map.remove, counter bump, callback) cycle before
+        // the panic; k=2's own removal also completed before its callback panicked. A reordered
+        // `retain_latest_at` that fires the callback before removing from `map` would strand
+        // k=2 in `map` with its stamp already gone from `keys` -- caught by the lockstep assert
+        // above, but pinned down explicitly here too.
+        assert!(!cache.map.contains_key(&0u32), "k=0 fully removed");
+        assert!(!cache.map.contains_key(&1u32), "k=1 fully removed");
+        assert!(
+            !cache.map.contains_key(&2u32),
+            "k=2 fully removed despite its callback panic"
+        );
+        // The pop loop never reached these: it unwound out of the panicking callback first.
+        assert!(
+            cache.map.contains_key(&3u32),
+            "k=3 untouched by the interrupted trim"
+        );
+        assert!(
+            cache.map.contains_key(&4u32),
+            "k=4 untouched by the interrupted trim"
+        );
+        assert!(
+            cache.map.contains_key(&100u32),
+            "never-expiring survivor untouched"
+        );
+        assert_eq!(
+            cache.cache_evictions(),
+            Some(3),
+            "counter reflects exactly the three rows removed before the panic"
+        );
+        // The survivor is still reachable through the index after the panic.
+        assert_eq!(cache.cache_get(&100u32), Some(&100u32));
+        assert_eq!(cache.retain_latest(0, false), 3);
+        assert_index_lockstep(&cache, "after trimming what the panic left behind");
+    }
+
+    /// The value-`Drop` panic path of the `retain_latest_at` size trim, with no `on_evict`
+    /// configured. Unlike `evict_at` -- which detaches the whole expired prefix from
+    /// `self.keys` in one `split_off` and so must drain `self.map` into a local `Vec` before
+    /// any value drops -- `retain_latest_at`'s pop loop removes one stamp and its map row
+    /// together before that value drops, so a panicking `Drop` mid-trim leaves map and keys
+    /// in lockstep without a collect step. A regression that detached the trim prefix up front
+    /// and dropped per iteration (as the pre-fix `evict_at` did) would orphan the
+    /// not-yet-removed rows: their stamps already gone from `self.keys` while their entries
+    /// linger in `self.map`.
+    #[test]
+    fn retain_latest_no_callback_keeps_map_and_keys_in_lockstep_on_drop_panic() {
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+
+        // A value whose `Drop` panics only when armed. Exactly ONE instance is armed so the
+        // unwind never double-panics into a process abort.
+        struct PanicOnDrop {
+            armed: bool,
+        }
+        impl Drop for PanicOnDrop {
+            fn drop(&mut self) {
+                if self.armed {
+                    panic!("PanicOnDrop::drop fired");
+                }
+            }
+        }
+
+        // No `on_evict` and no `size_limit`: the trim runs through `retain_latest` directly.
+        let mut cache: TtlSortedCache<u32, PanicOnDrop> = TtlSortedCache::builder()
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        // Five finite entries with ascending expiry (soonest first, the pop order). Arm the
+        // THIRD to pop (key 2) so two full iterations complete before it drops -- proving the
+        // remove-before-drop ordering holds across iterations, and leaving keys 3/4 to be
+        // stranded by a batched regression.
+        for k in 0u32..5 {
+            cache
+                .set_with(k, PanicOnDrop { armed: k == 2 })
+                .ttl(Duration::from_secs(10 * (u64::from(k) + 1)))
+                .set();
+        }
+        assert_eq!(cache.map.len(), 5);
+        assert_eq!(cache.keys.len(), 5);
+
+        // Keep 1 -> retain_drop_count = 4: the trim pops keys 0..=3, and the armed value's
+        // Drop panics on the third pop before keys 3/4 are reached.
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let _ = cache.retain_latest(1, false);
+        }));
+        assert!(
+            result.is_err(),
+            "the armed value's Drop must have panicked mid-trim"
+        );
+
+        // Lockstep is the core property: whatever left `self.keys` also left `self.map`.
+        assert_index_lockstep(&cache, "after a Drop panic mid retain_latest trim");
+        assert!(!cache.map.contains_key(&0u32), "key 0 fully removed");
+        assert!(!cache.map.contains_key(&1u32), "key 1 fully removed");
+        assert!(
+            !cache.map.contains_key(&2u32),
+            "the armed row left the map before its Drop panicked"
+        );
+        assert!(
+            cache.map.contains_key(&3u32),
+            "key 3 untouched by the interrupted trim"
+        );
+        assert!(
+            cache.map.contains_key(&4u32),
+            "key 4 untouched by the interrupted trim"
+        );
+        assert_eq!(cache.map.len(), 2);
+        // The counter is bumped before each value drops, so all three removed rows are counted.
+        assert_eq!(
+            cache.cache_evictions(),
+            Some(3),
+            "the counter reflects the three rows removed before the panic"
+        );
+        // The survivors remain reachable through the index for a later trim.
+        assert_eq!(cache.retain_latest(0, false), 2);
+        assert!(cache.map.is_empty());
+        assert!(cache.keys.is_empty());
+    }
+
     /// `retain_latest_at` with the sweep enabled: the tie at the cutoff is kept and
     /// never-expiring entries sort last, exactly as under the old range bounds.
     #[test]

--- a/src/stores/ttl_sorted.rs
+++ b/src/stores/ttl_sorted.rs
@@ -595,18 +595,28 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> TtlSortedCache<K, V, S> {
         }
 
         if self.on_evict.is_none() {
-            let mut evicted = 0u64;
+            // Drain the map FIRST, moving every removed `Entry` into `removed`, and let the
+            // values/keys drop only after the whole prefix has left `self.map` — exactly as
+            // the callback branch below does. A per-iteration drop (dropping each `Entry`
+            // inside the loop) would let a panicking `Drop` for `V` or `K` unwind with the
+            // remaining stamps already detached from `self.keys` but their entries still in
+            // `self.map`: orphaned rows, invisible to a later sweep yet still counted by
+            // `len`. Collecting keeps `self.map` and `self.keys` in lockstep across a panic.
+            let mut removed = Vec::with_capacity(count);
             for stamped in expired {
                 // Invariant: `None` keys are only used as artificial range sentinels
                 // in `evict()`/`retain_latest()` and are never inserted into `self.keys`.
                 let key = stamped
                     .key
                     .expect("evicting: only artificial bounds are none");
-                if self.map.remove(key.0.as_ref()).is_some() {
-                    evicted += 1;
+                if let Some(entry) = self.map.remove(key.0.as_ref()) {
+                    removed.push((key, entry));
                 }
             }
-            self.evictions.fetch_add(evicted, AtomicOrdering::Relaxed);
+            // Count before the drop: a `Drop` panic while `removed` unwinds must not leave
+            // the counter short of what was actually pulled from the map.
+            self.evictions
+                .fetch_add(removed.len() as u64, AtomicOrdering::Relaxed);
             return count;
         }
 
@@ -2496,6 +2506,80 @@ mod test {
         );
         assert_eq!(cache.cache_size(), 1, "never-expiring entry must remain");
         assert_eq!(cache.cache_get(&2u32), Some(&20u32));
+    }
+
+    /// A `Drop` panic mid-sweep must not orphan entries. In the no-callback branch of
+    /// `evict_at`, the whole expired prefix is detached from `self.keys` up front (one
+    /// `split_off`); the map rows are then removed one at a time. If a value's (or key's)
+    /// `Drop` panics before every row has left `self.map`, the not-yet-removed rows are
+    /// orphaned: their stamps are already gone from `self.keys`, so a later sweep never
+    /// reaches them, yet `len` still counts them. The fix drains `self.map` fully into a
+    /// local `Vec` and lets the values drop only after the drain, matching the callback
+    /// branch, so `self.map` and `self.keys` stay in lockstep and the eviction counter
+    /// reflects exactly what was pulled from the map — even across a panicking `Drop`.
+    #[test]
+    fn evict_no_callback_keeps_map_and_keys_in_lockstep_on_drop_panic() {
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+
+        // A value whose `Drop` panics only when armed. Exactly ONE instance is armed so
+        // the unwinding drop of the drain `Vec` (a slice drop continues dropping the
+        // remaining elements after one panics) never double-panics into a process abort.
+        struct PanicOnDrop {
+            armed: bool,
+        }
+        impl Drop for PanicOnDrop {
+            fn drop(&mut self) {
+                if self.armed {
+                    panic!("PanicOnDrop::drop fired");
+                }
+            }
+        }
+
+        // No `on_evict` configured, so `evict()` takes the no-callback branch of `evict_at`.
+        let mut cache: TtlSortedCache<u32, PanicOnDrop> = TtlSortedCache::builder()
+            .ttl(Duration::from_millis(5))
+            .build()
+            .unwrap();
+
+        // Insert the armed value FIRST: sequential inserts give ascending expiry stamps and
+        // `Stamped` orders by (expiry, key), so key 0 is the earliest in the sweep and its
+        // `Drop` runs before the two later rows have left `self.map`. On the pre-fix
+        // per-iteration-drop code that panic orphans keys 1 and 2 in `self.map` while their
+        // stamps are already gone from `self.keys`.
+        cache.set_with(0u32, PanicOnDrop { armed: true }).set();
+        cache.set_with(1u32, PanicOnDrop { armed: false }).set();
+        cache.set_with(2u32, PanicOnDrop { armed: false }).set();
+        assert_eq!(cache.map.len(), 3);
+        assert_eq!(cache.keys.len(), 3);
+
+        // Let the whole 5ms-TTL prefix expire, then sweep. The armed `Drop` panics mid-sweep.
+        std::thread::sleep(std::time::Duration::from_millis(40));
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let _ = cache.evict();
+        }));
+        assert!(
+            result.is_err(),
+            "the armed value's Drop must have panicked during the sweep"
+        );
+
+        // Lockstep is the core property: whatever left `self.keys` must also have left
+        // `self.map`. Pre-fix this failed (map.len() == 2 vs keys.len() == 0: two orphans).
+        assert_eq!(
+            cache.map.len(),
+            cache.keys.len(),
+            "map and keys must stay in lockstep across a Drop panic (no orphaned rows)"
+        );
+        // Every entry had expired, so the sweep drained the whole prefix from both.
+        assert_eq!(cache.map.len(), 0, "all expired entries must have left the map");
+        assert_eq!(cache.cache_size(), 0);
+        // The counter is incremented before the drain `Vec` drops, so it reflects exactly
+        // the three rows pulled from the map. Pre-fix the batched `fetch_add` after the loop
+        // was skipped by the panic, leaving it at 0.
+        assert_eq!(
+            cache.cache_evictions(),
+            Some(3),
+            "eviction counter must match the rows actually removed from the map"
+        );
     }
 
     /// `set_with(..).ttl(..)` called with an EXPLICIT `Duration::ZERO` (not the cache-level

--- a/src/stores/ttl_sorted.rs
+++ b/src/stores/ttl_sorted.rs
@@ -3978,8 +3978,7 @@ mod test {
     /// for every step after it.
     #[cfg(feature = "async")]
     #[tokio::test]
-    async fn async_try_get_or_set_with_mut_hits_and_misses_match_across_absent_expired_and_live()
-     {
+    async fn async_try_get_or_set_with_mut_hits_and_misses_match_across_absent_expired_and_live() {
         use crate::CachedGetOrSetAsync;
 
         let fired = Arc::new(AtomicUsize::new(0));
@@ -5246,10 +5245,11 @@ mod test {
 
             let (mut sync_try, log) = expired_cache_with_log();
             let log2 = log.clone();
-            let v: Result<&mut u32, &'static str> = sync_try.cache_try_get_or_set_with_mut(1u32, || {
-                log2.lock().unwrap().push("factory");
-                Ok(200u32)
-            });
+            let v: Result<&mut u32, &'static str> =
+                sync_try.cache_try_get_or_set_with_mut(1u32, || {
+                    log2.lock().unwrap().push("factory");
+                    Ok(200u32)
+                });
             assert_eq!(v.ok(), Some(&mut 200u32));
             assert_eq!(sync_try.cache_size(), 1);
             assert_eq!(sync_try.cache_evictions(), Some(1));

--- a/src/stores/unbound.rs
+++ b/src/stores/unbound.rs
@@ -256,10 +256,10 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for UnboundCache<K, V, S> {
         Q: std::hash::Hash + Eq + ?Sized,
     {
         if let Some(v) = self.store.get(key) {
-            self.hits.increment();
+            self.hits.increment_mut();
             Some(v)
         } else {
-            self.misses.increment();
+            self.misses.increment_mut();
             None
         }
     }
@@ -269,10 +269,10 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for UnboundCache<K, V, S> {
         Q: std::hash::Hash + Eq + ?Sized,
     {
         if let Some(v) = self.store.get_mut(key) {
-            self.hits.increment();
+            self.hits.increment_mut();
             Some(v)
         } else {
-            self.misses.increment();
+            self.misses.increment_mut();
             None
         }
     }
@@ -282,12 +282,12 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for UnboundCache<K, V, S> {
     fn cache_get_or_set_with_mut<F: FnOnce() -> V>(&mut self, key: K, f: F) -> &mut V {
         match self.store.entry(key) {
             Entry::Occupied(occupied) => {
-                self.hits.increment();
+                self.hits.increment_mut();
                 occupied.into_mut()
             }
 
             Entry::Vacant(vacant) => {
-                self.misses.increment();
+                self.misses.increment_mut();
                 vacant.insert(f())
             }
         }
@@ -299,12 +299,12 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for UnboundCache<K, V, S> {
     ) -> Result<&mut V, E> {
         match self.store.entry(key) {
             Entry::Occupied(occupied) => {
-                self.hits.increment();
+                self.hits.increment_mut();
                 Ok(occupied.into_mut())
             }
 
             Entry::Vacant(vacant) => {
-                self.misses.increment();
+                self.misses.increment_mut();
                 Ok(vacant.insert(f()?))
             }
         }
@@ -428,11 +428,11 @@ where
         async move {
             match self.store.entry(key) {
                 Entry::Occupied(occupied) => {
-                    self.hits.increment();
+                    self.hits.increment_mut();
                     occupied.into_mut()
                 }
                 Entry::Vacant(vacant) => {
-                    self.misses.increment();
+                    self.misses.increment_mut();
                     vacant.insert(f().await)
                 }
             }
@@ -454,11 +454,11 @@ where
         async move {
             let v = match self.store.entry(key) {
                 Entry::Occupied(occupied) => {
-                    self.hits.increment();
+                    self.hits.increment_mut();
                     occupied.into_mut()
                 }
                 Entry::Vacant(vacant) => {
-                    self.misses.increment();
+                    self.misses.increment_mut();
                     vacant.insert(f().await?)
                 }
             };
@@ -897,5 +897,227 @@ mod tests {
             .unwrap();
         // The backing store must have at least the requested capacity.
         assert!(c.store.capacity() >= 32);
+    }
+
+    // --- `increment_mut` soundness / aggregate-correctness certification ---
+    //
+    // `Cached::cache_get` / `cache_get_mut` / `cache_get_or_set_with_mut` (all `&mut self`)
+    // use `StripedCounter::increment_mut`, a non-atomic write to slot 0 that is only sound
+    // with exclusive access. `CachedRead::cache_get_read` (`&self`) still uses the striped,
+    // atomic `increment()`. The tests below certify that:
+    //   1. this is sound under the *only* concurrency shape the crate actually produces for
+    //      an `UnboundCache` shared across threads (an `RwLock`, exactly as the `#[cached]`
+    //      macro wires it for `unsync_reads = true`; `unsync_reads` is rejected at macro
+    //      expansion time when paired with `sync_lock = "mutex"`, and no sharded wrapper or
+    //      `Arc`-without-a-lock path exposes `UnboundCache` directly - see
+    //      `ShardedUnboundCacheBase`, which owns its own per-shard `RwLock<HashMap<..>>` and
+    //      never wraps `UnboundCache`), and
+    //   2. the aggregate stays exact when the two increment paths are interleaved.
+
+    #[test]
+    fn mixed_increment_paths_produce_exact_aggregate_through_lock() {
+        // Mirrors the real concurrency shape: an `RwLock<UnboundCache<..>>`, exactly as
+        // `#[cached(unsync_reads = true)]` generates (write lock for `&mut self` methods
+        // like `cache_get`, read lock for `CachedRead::cache_get_read`). `RwLock` guarantees
+        // no read-lock critical section can run concurrently with a write-lock critical
+        // section, so `increment_mut`'s non-atomic write to slot 0 (under the write lock)
+        // can never race with a concurrent `increment()`/`load()` (under a read lock). If
+        // that invariant were ever violated - e.g. by wiring `unsync_reads` through a
+        // `Mutex`-shaped store that still exposed `&self` reads without exclusion, or by a
+        // future refactor that hands out `UnboundCache` behind a bare `Arc` - this test would
+        // start flaking or losing updates.
+        use std::sync::{Arc, RwLock};
+
+        let mut seed: UnboundCache<u32, u32> = UnboundCache::new();
+        seed.cache_set(1, 100); // present key -> deterministic hit
+        let cache = Arc::new(RwLock::new(seed));
+
+        const THREADS: usize = 8;
+        const ITERS: usize = 500;
+
+        let mut handles = Vec::with_capacity(THREADS);
+        for i in 0..THREADS {
+            let cache = Arc::clone(&cache);
+            handles.push(std::thread::spawn(move || {
+                for _ in 0..ITERS {
+                    if i % 2 == 0 {
+                        // Exclusive path: write lock -> `&mut self` -> `increment_mut`.
+                        let mut guard = cache.write().unwrap();
+                        assert_eq!(guard.cache_get(&1), Some(&100)); // hit
+                        assert_eq!(guard.cache_get(&999), None); // miss
+                    } else {
+                        // Shared path: read lock -> `&self` -> striped `increment`.
+                        let guard = cache.read().unwrap();
+                        assert_eq!(guard.cache_get_read(&1), Some(&100)); // hit
+                        assert_eq!(guard.cache_get_read(&999), None); // miss
+                    }
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let guard = cache.read().unwrap();
+        let expected = (THREADS * ITERS) as u64;
+        assert_eq!(
+            guard.cache_hits(),
+            Some(expected),
+            "hits must equal the exact call count with no lost updates from mixing \
+             increment_mut and increment"
+        );
+        assert_eq!(
+            guard.cache_misses(),
+            Some(expected),
+            "misses must equal the exact call count with no lost updates from mixing \
+             increment_mut and increment"
+        );
+    }
+
+    #[test]
+    fn cache_reset_metrics_and_clone_snapshot_after_mixed_increment_paths() {
+        // `reset()`/`snapshot()`/`cache_reset_metrics` must behave correctly even though
+        // `increment_mut` always writes to slot 0 - the same slot `StripedCounter::snapshot`
+        // collapses the aggregate into - when mixed with `increment`'s striped writes.
+        let mut c: UnboundCache<u32, u32> = UnboundCache::new();
+        c.cache_set(1, 100);
+
+        // 3 hits, 2 misses via increment_mut (through &mut self cache_get).
+        c.cache_get(&1);
+        c.cache_get(&1);
+        c.cache_get(&1);
+        c.cache_get(&999);
+        c.cache_get(&999);
+
+        // 2 hits, 3 misses via increment (through &self CachedRead::cache_get_read).
+        c.cache_get_read(&1);
+        c.cache_get_read(&1);
+        c.cache_get_read(&999);
+        c.cache_get_read(&999);
+        c.cache_get_read(&999);
+
+        assert_eq!(c.cache_hits(), Some(5));
+        assert_eq!(c.cache_misses(), Some(5));
+
+        // `cache_reset_metrics` zeroes both counters regardless of which path last wrote
+        // which slot (including slot 0, last written by `increment_mut`).
+        c.cache_reset_metrics();
+        assert_eq!(c.cache_hits(), Some(0));
+        assert_eq!(c.cache_misses(), Some(0));
+
+        // Counters keep working correctly post-reset, mixing paths again.
+        c.cache_get(&1); // hit, increment_mut
+        c.cache_get_read(&1); // hit, increment
+        c.cache_get(&999); // miss, increment_mut
+        assert_eq!(c.cache_hits(), Some(2));
+        assert_eq!(c.cache_misses(), Some(1));
+
+        // `Clone` uses `StripedCounter::snapshot`, which collapses the aggregate (built
+        // from both increment paths) into the clone's slot 0.
+        let mut cloned = c.clone();
+        assert_eq!(cloned.cache_hits(), c.cache_hits());
+        assert_eq!(cloned.cache_misses(), c.cache_misses());
+
+        // The clone's counters are independent: further increments on the clone (through
+        // either path) must not perturb the original.
+        cloned.cache_get(&1); // hit, increment_mut on the clone
+        assert_eq!(cloned.cache_hits(), Some(3));
+        assert_eq!(
+            c.cache_hits(),
+            Some(2),
+            "clone must not share counter state with the original"
+        );
+
+        // A full `cache_reset` also zeroes counters last written through increment_mut.
+        c.cache_reset();
+        assert_eq!(c.cache_hits(), Some(0));
+        assert_eq!(c.cache_misses(), Some(0));
+    }
+
+    #[test]
+    fn cache_get_mut_hits_and_misses_are_counted_and_mutation_is_visible() {
+        // `cache_get_mut` was switched to `increment_mut` by this diff but had no
+        // dedicated test anywhere in the crate before this one: `cache_get` and
+        // `cache_get_or_set_with_mut` were covered, `cache_get_mut` was not. Certify
+        // both the mutation contract and exact hit/miss accounting through it.
+        let mut c: UnboundCache<u32, u32> = UnboundCache::new();
+        c.cache_set(1, 100);
+
+        // Miss: absent key.
+        assert_eq!(c.cache_get_mut(&999), None);
+        assert_eq!(c.cache_misses(), Some(1));
+        assert_eq!(c.cache_hits(), Some(0));
+
+        // Hit: present key, and the returned reference actually mutates in place.
+        {
+            let v = c.cache_get_mut(&1).expect("key must be present");
+            *v += 1;
+        }
+        assert_eq!(c.cache_hits(), Some(1));
+        assert_eq!(c.cache_misses(), Some(1));
+        assert_eq!(c.cache_get(&1), Some(&101));
+    }
+
+    // The get-or-set families also count through `increment_mut`; their accounting must
+    // be exact on both the hit and the miss arm.
+
+    #[test]
+    fn cache_try_get_or_set_with_hits_and_misses_are_counted() {
+        let mut c: UnboundCache<u32, u32> = UnboundCache::new();
+
+        fn ok(n: u32) -> Result<u32, String> {
+            Ok(n)
+        }
+
+        // 3 misses (fresh keys).
+        assert_eq!(c.cache_try_get_or_set_with(1, || ok(1)).unwrap(), &1);
+        assert_eq!(c.cache_try_get_or_set_with(2, || ok(2)).unwrap(), &2);
+        assert_eq!(c.cache_try_get_or_set_with(3, || ok(3)).unwrap(), &3);
+        assert_eq!(c.cache_misses(), Some(3));
+        assert_eq!(c.cache_hits(), Some(0));
+
+        // 2 hits (existing keys); the factory's return value must be ignored.
+        assert_eq!(c.cache_try_get_or_set_with(1, || ok(99)).unwrap(), &1);
+        assert_eq!(c.cache_try_get_or_set_with(2, || ok(99)).unwrap(), &2);
+        assert_eq!(c.cache_misses(), Some(3));
+        assert_eq!(c.cache_hits(), Some(2));
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn async_get_or_set_with_hits_and_misses_are_counted() {
+        use crate::CachedGetOrSetAsync;
+
+        let mut c: UnboundCache<u32, u32> = UnboundCache::new();
+
+        // Misses: fresh keys via both async methods.
+        assert_eq!(
+            c.async_cache_get_or_set_with_mut(1u32, || async { 1u32 })
+                .await,
+            &1
+        );
+        assert_eq!(
+            c.async_cache_try_get_or_set_with_mut(2u32, || async { Ok::<u32, String>(2) })
+                .await
+                .unwrap(),
+            &2
+        );
+        assert_eq!(c.cache_misses(), Some(2));
+        assert_eq!(c.cache_hits(), Some(0));
+
+        // Hits: same keys again; the factory's return value must be ignored.
+        assert_eq!(
+            c.async_cache_get_or_set_with_mut(1u32, || async { 99u32 })
+                .await,
+            &1
+        );
+        assert_eq!(
+            c.async_cache_try_get_or_set_with_mut(2u32, || async { Ok::<u32, String>(99) })
+                .await
+                .unwrap(),
+            &2
+        );
+        assert_eq!(c.cache_misses(), Some(2));
+        assert_eq!(c.cache_hits(), Some(2));
     }
 }

--- a/tests/v3_cert_expiring_lru_key_lifecycle.rs
+++ b/tests/v3_cert_expiring_lru_key_lifecycle.rs
@@ -1,0 +1,397 @@
+//! Certification of the *key lifecycle* half of the `ExpiringLruCache` perf change.
+//!
+//! Two claims are under test:
+//!
+//! 1. **The key clones are gone.** `cache_set` used to run `k.clone()` on every insert
+//!    whenever an `on_evict` callback was configured, and `cache_clear_with_on_evict` used
+//!    to clone every key via `key_order()`. Neither may clone a key any more.
+//! 2. **Nothing observes a freed or half-moved key.** With the defensive clone removed,
+//!    `on_evict` now borrows the entry's own key. These tests assert the callback sees a
+//!    fully intact heap payload, that the key is still alive while the callback runs, and
+//!    that it is dropped exactly once afterwards.
+//!
+//! `CountedKey` carries its own `Arc<AtomicUsize>` clone/drop counters, so the counts are
+//! per-cache and the tests stay safe under the parallel test harness. The counters do not
+//! participate in `Hash`/`Eq`; `id` alone does.
+
+use cached::{CacheEvict, Cached, Expires, ExpiringLruCache};
+use std::hash::{Hash, Hasher};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug)]
+struct Counters {
+    clones: AtomicUsize,
+    drops: AtomicUsize,
+}
+
+impl Counters {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            clones: AtomicUsize::new(0),
+            drops: AtomicUsize::new(0),
+        })
+    }
+    fn clones(&self) -> usize {
+        self.clones.load(Ordering::Relaxed)
+    }
+    fn drops(&self) -> usize {
+        self.drops.load(Ordering::Relaxed)
+    }
+}
+
+/// A key with a heap payload (`tag`) that is deliberately excluded from `Hash`/`Eq`, plus
+/// instrumentation for clone and drop accounting.
+#[derive(Debug)]
+struct CountedKey {
+    id: u32,
+    tag: String,
+    counters: Arc<Counters>,
+}
+
+impl CountedKey {
+    fn new(id: u32, tag: &str, counters: &Arc<Counters>) -> Self {
+        Self {
+            id,
+            tag: tag.to_string(),
+            counters: Arc::clone(counters),
+        }
+    }
+}
+
+impl Clone for CountedKey {
+    fn clone(&self) -> Self {
+        self.counters.clones.fetch_add(1, Ordering::Relaxed);
+        Self {
+            id: self.id,
+            tag: self.tag.clone(),
+            counters: Arc::clone(&self.counters),
+        }
+    }
+}
+
+impl Drop for CountedKey {
+    fn drop(&mut self) {
+        self.counters.drops.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+impl PartialEq for CountedKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+impl Eq for CountedKey {}
+impl Hash for CountedKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Val {
+    expired: bool,
+}
+impl Val {
+    fn live() -> Self {
+        Self { expired: false }
+    }
+    fn stale() -> Self {
+        Self { expired: true }
+    }
+}
+impl Expires for Val {
+    fn is_expired(&self) -> bool {
+        self.expired
+    }
+}
+
+/// What the callback observed: the key's full heap payload and the drop count at the
+/// moment it ran.
+type Observations = Arc<Mutex<Vec<(String, usize)>>>;
+
+fn cache_with_probe(
+    max_size: usize,
+    counters: &Arc<Counters>,
+) -> (ExpiringLruCache<CountedKey, Val>, Observations) {
+    let obs: Observations = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&obs);
+    let counters = Arc::clone(counters);
+    let cache = ExpiringLruCache::builder()
+        .max_size(max_size)
+        .on_evict(move |k: &CountedKey, _v: &Val| {
+            // Reading `k.tag` here is the point: with the caller-key clone removed, this
+            // borrows the entry's own key. A stale/dangling borrow would show up as a
+            // wrong or corrupted payload (and would trip miri/ASAN).
+            sink.lock()
+                .unwrap()
+                .push((k.tag.clone(), counters.drops.load(Ordering::Relaxed)));
+        })
+        .build()
+        .expect("build ExpiringLruCache");
+    (cache, obs)
+}
+
+fn observed(obs: &Observations) -> Vec<(String, usize)> {
+    obs.lock().unwrap().clone()
+}
+
+/// The instrument must actually count, or every clone assertion below is vacuous.
+#[test]
+fn counted_key_counts_clones_and_drops() {
+    let c = Counters::new();
+    {
+        let k = CountedKey::new(1, "a", &c);
+        assert_eq!(c.clones(), 0);
+        let k2 = k.clone();
+        assert_eq!(c.clones(), 1, "Clone must be counted");
+        assert_eq!(k, k2, "same id compares equal");
+        assert_eq!(c.drops(), 0);
+    }
+    assert_eq!(c.drops(), 2, "both instances dropped at scope end");
+}
+
+// --- claim 1: no key clones ----------------------------------------------------------
+
+#[test]
+fn cache_set_of_new_keys_clones_no_key_even_with_on_evict_configured() {
+    // The pre-change implementation ran `k.clone()` on EVERY cache_set while an on_evict
+    // callback was configured. Three inserts must now cost zero key clones.
+    let counters = Counters::new();
+    let (mut c, obs) = cache_with_probe(8, &counters);
+    c.cache_set(CountedKey::new(1, "a", &counters), Val::live());
+    c.cache_set(CountedKey::new(2, "b", &counters), Val::live());
+    c.cache_set(CountedKey::new(3, "c", &counters), Val::live());
+    assert_eq!(
+        counters.clones(),
+        0,
+        "cache_set must not clone the caller's key"
+    );
+    assert!(observed(&obs).is_empty(), "no evictions happened");
+    assert_eq!(c.cache_size(), 3);
+}
+
+#[test]
+fn cache_set_overwrite_clones_no_key_on_either_the_live_or_expired_branch() {
+    let counters = Counters::new();
+    let (mut c, _obs) = cache_with_probe(8, &counters);
+    c.cache_set(CountedKey::new(1, "stored", &counters), Val::stale());
+    // Expired branch: fires on_evict with the stored key.
+    c.cache_set(CountedKey::new(1, "caller", &counters), Val::live());
+    // Live branch: returns the displaced value, silent.
+    c.cache_set(CountedKey::new(1, "third", &counters), Val::live());
+    assert_eq!(counters.clones(), 0, "neither overwrite branch may clone");
+}
+
+#[test]
+fn cache_set_capacity_eviction_clones_no_key() {
+    let counters = Counters::new();
+    let (mut c, obs) = cache_with_probe(1, &counters);
+    c.cache_set(CountedKey::new(1, "victim", &counters), Val::live());
+    c.cache_set(CountedKey::new(2, "fresh", &counters), Val::live());
+    assert_eq!(counters.clones(), 0);
+    assert_eq!(
+        observed(&obs)
+            .into_iter()
+            .map(|(t, _)| t)
+            .collect::<Vec<_>>(),
+        vec!["victim".to_string()]
+    );
+}
+
+#[test]
+fn cache_get_lazy_sweep_clones_no_key() {
+    let counters = Counters::new();
+    let (mut c, obs) = cache_with_probe(8, &counters);
+    c.cache_set(CountedKey::new(1, "stored", &counters), Val::stale());
+    let probe = CountedKey::new(1, "lookup", &counters);
+    assert!(c.cache_get(&probe).is_none());
+    assert!(c.cache_get_mut(&probe).is_none(), "already swept");
+    assert_eq!(counters.clones(), 0, "the lazy sweep must not clone a key");
+    assert_eq!(
+        observed(&obs)
+            .into_iter()
+            .map(|(t, _)| t)
+            .collect::<Vec<_>>(),
+        vec!["stored".to_string()]
+    );
+}
+
+#[test]
+fn cache_remove_entry_clones_no_key() {
+    let counters = Counters::new();
+    let (mut c, _obs) = cache_with_probe(8, &counters);
+    c.cache_set(CountedKey::new(1, "stored", &counters), Val::live());
+    let probe = CountedKey::new(1, "lookup", &counters);
+    let (k, _) = c.cache_remove_entry(&probe).expect("present");
+    assert_eq!(k.tag, "stored", "the stored key is moved out, not cloned");
+    assert_eq!(counters.clones(), 0);
+}
+
+#[test]
+fn cache_clear_with_on_evict_clones_no_key() {
+    // The pre-change implementation collected `key_order()` (one clone per key) before
+    // popping. `drain_all` must clone nothing.
+    let counters = Counters::new();
+    let (mut c, obs) = cache_with_probe(8, &counters);
+    c.cache_set(CountedKey::new(1, "a", &counters), Val::live());
+    c.cache_set(CountedKey::new(2, "b", &counters), Val::stale());
+    c.cache_set(CountedKey::new(3, "c", &counters), Val::live());
+    c.cache_clear_with_on_evict();
+    assert_eq!(
+        counters.clones(),
+        0,
+        "cache_clear_with_on_evict must not clone any key"
+    );
+    assert_eq!(
+        observed(&obs)
+            .into_iter()
+            .map(|(t, _)| t)
+            .collect::<Vec<_>>(),
+        vec!["c".to_string(), "b".to_string(), "a".to_string()],
+        "MRU -> LRU, expired entries included"
+    );
+    assert_eq!(c.cache_size(), 0);
+}
+
+#[test]
+fn evict_and_retain_clone_no_key() {
+    let counters = Counters::new();
+    let (mut c, _obs) = cache_with_probe(8, &counters);
+    c.cache_set(CountedKey::new(1, "a", &counters), Val::stale());
+    c.cache_set(CountedKey::new(2, "b", &counters), Val::live());
+    assert_eq!(CacheEvict::evict(&mut c), 1);
+    c.retain(|_, _| false);
+    assert_eq!(counters.clones(), 0, "sweeps must not clone keys");
+    assert_eq!(c.cache_size(), 0);
+}
+
+#[test]
+fn set_max_size_shrink_clones_no_key() {
+    let counters = Counters::new();
+    let (mut c, _obs) = cache_with_probe(4, &counters);
+    c.cache_set(CountedKey::new(1, "a", &counters), Val::live());
+    c.cache_set(CountedKey::new(2, "b", &counters), Val::live());
+    c.cache_set(CountedKey::new(3, "c", &counters), Val::live());
+    let _ = c.set_max_size(1);
+    assert_eq!(counters.clones(), 0);
+    assert_eq!(c.cache_size(), 1);
+}
+
+#[test]
+fn get_or_set_family_clones_no_key() {
+    let counters = Counters::new();
+    let (mut c, _obs) = cache_with_probe(8, &counters);
+    c.cache_set(CountedKey::new(1, "stored", &counters), Val::stale());
+    let _ = c.cache_get_or_set_with(CountedKey::new(1, "caller", &counters), Val::live);
+    let r: Result<&Val, ()> =
+        c.cache_try_get_or_set_with(CountedKey::new(2, "other", &counters), || Ok(Val::live()));
+    assert!(r.is_ok());
+    assert_eq!(counters.clones(), 0, "the get_or_set family must not clone");
+}
+
+// --- claim 2: the key handed to on_evict is intact and correctly owned ----------------
+
+#[test]
+fn on_evict_borrows_a_live_intact_key_on_the_cache_set_expired_branch() {
+    let counters = Counters::new();
+    let (mut c, obs) = cache_with_probe(8, &counters);
+    c.cache_set(
+        CountedKey::new(1, "stored-payload", &counters),
+        Val::stale(),
+    );
+    assert_eq!(
+        counters.drops(),
+        0,
+        "the inserted key was moved, not dropped"
+    );
+
+    c.cache_set(CountedKey::new(1, "caller-payload", &counters), Val::live());
+
+    assert_eq!(
+        observed(&obs),
+        vec![("stored-payload".to_string(), 0)],
+        "on_evict must see the STORED key's full payload, and the key must still be \
+         alive (zero drops) while the callback runs"
+    );
+    assert_eq!(
+        counters.drops(),
+        1,
+        "the displaced stored key is dropped exactly once, after the callback returns"
+    );
+    // The surviving entry is the caller's key; nothing else was dropped.
+    let (k, _) = c
+        .cache_remove_entry(&CountedKey::new(1, "probe", &counters))
+        .expect("present");
+    assert_eq!(k.tag, "caller-payload");
+}
+
+#[test]
+fn on_evict_borrows_a_live_intact_key_on_the_capacity_path() {
+    let counters = Counters::new();
+    let (mut c, obs) = cache_with_probe(1, &counters);
+    c.cache_set(CountedKey::new(1, "victim-payload", &counters), Val::live());
+    c.cache_set(CountedKey::new(2, "fresh-payload", &counters), Val::live());
+    assert_eq!(
+        observed(&obs),
+        vec![("victim-payload".to_string(), 0)],
+        "the capacity victim's key must be intact and alive during the callback"
+    );
+    assert_eq!(counters.drops(), 1, "the victim key drops once, afterwards");
+}
+
+#[test]
+fn on_evict_borrows_live_intact_keys_across_a_full_drain() {
+    let counters = Counters::new();
+    let (mut c, obs) = cache_with_probe(8, &counters);
+    c.cache_set(CountedKey::new(1, "one", &counters), Val::live());
+    c.cache_set(CountedKey::new(2, "two", &counters), Val::live());
+    c.cache_clear_with_on_evict();
+    assert_eq!(
+        observed(&obs),
+        vec![("two".to_string(), 0), ("one".to_string(), 0)],
+        "drain_all holds every pair alive until all callbacks have run"
+    );
+    assert_eq!(counters.drops(), 2, "each drained key drops exactly once");
+}
+
+#[test]
+fn every_key_is_dropped_exactly_once_over_a_mixed_workload() {
+    // Cross-check for a leak or a double free hiding behind the removed clone: eight keys
+    // enter the cache across every insert path, and after the cache is dropped the drop
+    // count must equal the number of key instances ever created (8 inserted + 3 borrowed
+    // probes), with zero clones.
+    let counters = Counters::new();
+    let (mut c, _obs) = cache_with_probe(3, &counters);
+
+    c.cache_set(CountedKey::new(1, "k1", &counters), Val::live());
+    c.cache_set(CountedKey::new(2, "k2", &counters), Val::stale());
+    c.cache_set(CountedKey::new(3, "k3", &counters), Val::live());
+    c.cache_set(CountedKey::new(4, "k4", &counters), Val::live()); // capacity eviction
+    c.cache_set(CountedKey::new(2, "k2b", &counters), Val::live()); // over expired (if still held)
+    let _ = c.cache_get_or_set_with(CountedKey::new(5, "k5", &counters), Val::live);
+    let r: Result<&Val, ()> =
+        c.cache_try_get_or_set_with(CountedKey::new(6, "k6", &counters), || Ok(Val::live()));
+    assert!(r.is_ok());
+    c.cache_set(CountedKey::new(7, "k7", &counters), Val::stale());
+
+    {
+        let p1 = CountedKey::new(3, "probe1", &counters);
+        let p2 = CountedKey::new(7, "probe2", &counters);
+        let p3 = CountedKey::new(99, "probe3", &counters);
+        let _ = c.cache_get(&p1);
+        let _ = c.cache_get(&p2);
+        let _ = c.cache_get(&p3);
+    }
+
+    let _ = CacheEvict::evict(&mut c);
+    c.retain(|_, _| true);
+    drop(c);
+
+    assert_eq!(counters.clones(), 0, "no path may clone a key");
+    assert_eq!(
+        counters.drops(),
+        11,
+        "every one of the 8 inserted + 3 probe key instances is dropped exactly once"
+    );
+}

--- a/tests/v3_cert_expiring_lru_lru_ttl_parity.rs
+++ b/tests/v3_cert_expiring_lru_lru_ttl_parity.rs
@@ -1,0 +1,437 @@
+//! Parity certification: `ExpiringLruCache` vs the `LruTtlCache` oracle.
+//!
+//! The stated goal of the perf change was for `ExpiringLruCache` to fire `on_evict` with
+//! the same key instance `LruTtlCache` does. Each test here drives the SAME scenario
+//! through both stores with the same coarse-`Eq` key and asserts (a) the expected key tag
+//! and (b) that the two stores agree. A disagreement on any path is a finding.
+//!
+//! The two stores differ only in how a value becomes stale: `ExpiringLruCache` asks the
+//! value (`Expires::is_expired`), `LruTtlCache` compares a per-entry deadline against the
+//! clock. Where a test needs a stale entry it makes the `ExpiringLruCache` value report
+//! `is_expired() == true` and lets the `LruTtlCache` TTL lapse via a sleep.
+//!
+//! Gated on `time_stores` (the feature `LruTtlCache` lives behind).
+#![cfg(feature = "time_stores")]
+
+use cached::time::Duration;
+use cached::{CacheEvict, Cached, Expires, ExpiringLruCache, LruTtlCache};
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, Mutex};
+
+/// TTL short enough to keep the suite fast, long enough not to flake on a loaded machine.
+const TTL: Duration = Duration::from_millis(60);
+/// Slept when an entry must be past its TTL.
+const LAPSE: std::time::Duration = std::time::Duration::from_millis(180);
+
+#[derive(Debug, Clone)]
+struct TagKey {
+    id: u32,
+    tag: &'static str,
+}
+
+impl TagKey {
+    fn new(id: u32, tag: &'static str) -> Self {
+        Self { id, tag }
+    }
+}
+
+impl PartialEq for TagKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+impl Eq for TagKey {}
+impl Hash for TagKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Val {
+    expired: bool,
+}
+
+impl Val {
+    fn live() -> Self {
+        Self { expired: false }
+    }
+    fn stale() -> Self {
+        Self { expired: true }
+    }
+}
+
+impl Expires for Val {
+    fn is_expired(&self) -> bool {
+        self.expired
+    }
+}
+
+type Log = Arc<Mutex<Vec<&'static str>>>;
+
+fn expiring(max_size: usize) -> (ExpiringLruCache<TagKey, Val>, Log) {
+    let log: Log = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&log);
+    let cache = ExpiringLruCache::builder()
+        .max_size(max_size)
+        .on_evict(move |k: &TagKey, _v: &Val| sink.lock().unwrap().push(k.tag))
+        .build()
+        .expect("build ExpiringLruCache");
+    (cache, log)
+}
+
+fn timed(max_size: usize) -> (LruTtlCache<TagKey, u32>, Log) {
+    let log: Log = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&log);
+    let cache = LruTtlCache::builder()
+        .max_size(max_size)
+        .ttl(TTL)
+        .on_evict(move |k: &TagKey, _v: &u32| sink.lock().unwrap().push(k.tag))
+        .build()
+        .expect("build LruTtlCache");
+    (cache, log)
+}
+
+fn seen(log: &Log) -> Vec<&'static str> {
+    log.lock().unwrap().clone()
+}
+
+/// Assert both stores saw `expected`, and say so in terms of parity when they do not.
+fn assert_parity(expiring_log: &Log, timed_log: &Log, expected: &[&'static str]) {
+    let e = seen(expiring_log);
+    let t = seen(timed_log);
+    assert_eq!(
+        e, t,
+        "ExpiringLruCache and LruTtlCache must agree on the on_evict keys"
+    );
+    assert_eq!(e, expected, "both stores must report the stored key(s)");
+}
+
+#[test]
+fn parity_cache_set_over_expired() {
+    let (mut e, elog) = expiring(8);
+    e.cache_set(TagKey::new(1, "stored"), Val::stale());
+    assert!(e.cache_set(TagKey::new(1, "caller"), Val::live()).is_none());
+
+    let (mut t, tlog) = timed(8);
+    t.cache_set(TagKey::new(1, "stored"), 1);
+    std::thread::sleep(LAPSE);
+    assert!(t.cache_set(TagKey::new(1, "caller"), 2).is_none());
+
+    assert_parity(&elog, &tlog, &["stored"]);
+}
+
+#[test]
+fn parity_cache_get_lazy_sweep() {
+    let (mut e, elog) = expiring(8);
+    e.cache_set(TagKey::new(1, "stored"), Val::stale());
+    assert!(e.cache_get(&TagKey::new(1, "lookup")).is_none());
+
+    let (mut t, tlog) = timed(8);
+    t.cache_set(TagKey::new(1, "stored"), 1);
+    std::thread::sleep(LAPSE);
+    assert!(t.cache_get(&TagKey::new(1, "lookup")).is_none());
+
+    assert_parity(&elog, &tlog, &["stored"]);
+}
+
+#[test]
+fn parity_cache_get_mut_lazy_sweep() {
+    let (mut e, elog) = expiring(8);
+    e.cache_set(TagKey::new(1, "stored"), Val::stale());
+    assert!(e.cache_get_mut(&TagKey::new(1, "lookup")).is_none());
+
+    let (mut t, tlog) = timed(8);
+    t.cache_set(TagKey::new(1, "stored"), 1);
+    std::thread::sleep(LAPSE);
+    assert!(t.cache_get_mut(&TagKey::new(1, "lookup")).is_none());
+
+    assert_parity(&elog, &tlog, &["stored"]);
+}
+
+#[test]
+fn parity_cache_remove_entry_returns_the_stored_key() {
+    let (mut e, elog) = expiring(8);
+    e.cache_set(TagKey::new(1, "stored"), Val::stale());
+    let (ek, _) = e
+        .cache_remove_entry(&TagKey::new(1, "lookup"))
+        .expect("present");
+
+    let (mut t, tlog) = timed(8);
+    t.cache_set(TagKey::new(1, "stored"), 1);
+    std::thread::sleep(LAPSE);
+    let (tk, _) = t
+        .cache_remove_entry(&TagKey::new(1, "lookup"))
+        .expect("present");
+
+    assert_eq!(
+        ek.tag, tk.tag,
+        "both stores must return the same key instance from cache_remove_entry"
+    );
+    assert_eq!(ek.tag, "stored");
+    assert_parity(&elog, &tlog, &["stored"]);
+}
+
+#[test]
+fn parity_capacity_eviction_reports_the_rebound_key() {
+    // An overwrite rebinds the stored key AND promotes the entry to MRU; a later capacity
+    // eviction of that same entry must report the rebound key in both stores. The read of
+    // key 2 puts key 1 back at the LRU position so it is the victim again.
+    let (mut e, elog) = expiring(2);
+    e.cache_set(TagKey::new(1, "first"), Val::live());
+    e.cache_set(TagKey::new(2, "k2"), Val::live());
+    e.cache_set(TagKey::new(1, "second"), Val::live());
+    assert!(e.cache_get(&TagKey::new(2, "?")).is_some());
+    e.cache_set(TagKey::new(3, "k3"), Val::live());
+
+    let (mut t, tlog) = timed(2);
+    t.cache_set(TagKey::new(1, "first"), 1);
+    t.cache_set(TagKey::new(2, "k2"), 2);
+    t.cache_set(TagKey::new(1, "second"), 11);
+    assert!(t.cache_get(&TagKey::new(2, "?")).is_some());
+    t.cache_set(TagKey::new(3, "k3"), 3);
+
+    assert_parity(&elog, &tlog, &["second"]);
+}
+
+#[test]
+fn parity_evict_sweep() {
+    let (mut e, elog) = expiring(8);
+    e.cache_set(TagKey::new(1, "s1"), Val::stale());
+    e.cache_set(TagKey::new(2, "s2"), Val::stale());
+    assert_eq!(CacheEvict::evict(&mut e), 2);
+
+    let (mut t, tlog) = timed(8);
+    t.cache_set(TagKey::new(1, "s1"), 1);
+    t.cache_set(TagKey::new(2, "s2"), 2);
+    std::thread::sleep(LAPSE);
+    assert_eq!(CacheEvict::evict(&mut t), 2);
+
+    // MRU -> LRU sweep order.
+    assert_parity(&elog, &tlog, &["s2", "s1"]);
+}
+
+#[test]
+fn parity_retain_predicate_and_expiry_limbs() {
+    let (mut e, elog) = expiring(8);
+    e.cache_set(TagKey::new(1, "by_pred"), Val::live());
+    e.cache_set(TagKey::new(2, "keep"), Val::live());
+    e.retain(|k, _| k.id != 1);
+
+    let (mut t, tlog) = timed(8);
+    t.cache_set(TagKey::new(1, "by_pred"), 1);
+    t.cache_set(TagKey::new(2, "keep"), 2);
+    t.retain(|k, _| k.id != 1);
+
+    assert_parity(&elog, &tlog, &["by_pred"]);
+
+    // Now the expiry limb: an expired entry is removed WITHOUT consulting the predicate.
+    let (mut e2, elog2) = expiring(8);
+    e2.cache_set(TagKey::new(1, "stale"), Val::stale());
+    e2.retain(|_, _| true);
+
+    let (mut t2, tlog2) = timed(8);
+    t2.cache_set(TagKey::new(1, "stale"), 1);
+    std::thread::sleep(LAPSE);
+    t2.retain(|_, _| true);
+
+    assert_parity(&elog2, &tlog2, &["stale"]);
+}
+
+#[test]
+fn parity_cache_clear_with_on_evict_mru_to_lru() {
+    let (mut e, elog) = expiring(8);
+    e.cache_set(TagKey::new(1, "first"), Val::live());
+    e.cache_set(TagKey::new(2, "k2"), Val::live());
+    e.cache_set(TagKey::new(1, "second"), Val::live());
+    e.cache_clear_with_on_evict();
+
+    let (mut t, tlog) = timed(8);
+    t.cache_set(TagKey::new(1, "first"), 1);
+    t.cache_set(TagKey::new(2, "k2"), 2);
+    t.cache_set(TagKey::new(1, "second"), 11);
+    t.cache_clear_with_on_evict();
+
+    // The overwrite of key 1 promoted it, so the MRU -> LRU drain reports it first.
+    assert_parity(&elog, &tlog, &["second", "k2"]);
+}
+
+#[test]
+fn parity_cache_clear_is_silent() {
+    let (mut e, elog) = expiring(8);
+    e.cache_set(TagKey::new(1, "k1"), Val::live());
+    e.cache_clear();
+
+    let (mut t, tlog) = timed(8);
+    t.cache_set(TagKey::new(1, "k1"), 1);
+    t.cache_clear();
+
+    assert_parity(&elog, &tlog, &[]);
+}
+
+#[test]
+fn parity_set_max_size_shrink() {
+    let (mut e, elog) = expiring(4);
+    e.cache_set(TagKey::new(1, "k1"), Val::live());
+    e.cache_set(TagKey::new(2, "k2"), Val::live());
+    e.cache_set(TagKey::new(3, "k3"), Val::live());
+    let _ = e.set_max_size(1);
+
+    let (mut t, tlog) = timed(4);
+    t.cache_set(TagKey::new(1, "k1"), 1);
+    t.cache_set(TagKey::new(2, "k2"), 2);
+    t.cache_set(TagKey::new(3, "k3"), 3);
+    let _ = t.set_max_size(1);
+
+    assert_parity(&elog, &tlog, &["k1", "k2"]);
+}
+
+#[test]
+fn parity_get_or_set_with_over_expired() {
+    let (mut e, elog) = expiring(8);
+    e.cache_set(TagKey::new(1, "stored"), Val::stale());
+    let _ = e.cache_get_or_set_with(TagKey::new(1, "caller"), Val::live);
+
+    let (mut t, tlog) = timed(8);
+    t.cache_set(TagKey::new(1, "stored"), 1);
+    std::thread::sleep(LAPSE);
+    let _ = t.cache_get_or_set_with(TagKey::new(1, "caller"), || 2);
+
+    assert_parity(&elog, &tlog, &["stored"]);
+}
+
+#[test]
+fn parity_try_get_or_set_with_ok_over_expired() {
+    let (mut e, elog) = expiring(8);
+    e.cache_set(TagKey::new(1, "stored"), Val::stale());
+    let r: Result<&Val, ()> =
+        e.cache_try_get_or_set_with(TagKey::new(1, "caller"), || Ok(Val::live()));
+    assert!(r.is_ok());
+
+    let (mut t, tlog) = timed(8);
+    t.cache_set(TagKey::new(1, "stored"), 1);
+    std::thread::sleep(LAPSE);
+    let r: Result<&u32, ()> = t.cache_try_get_or_set_with(TagKey::new(1, "caller"), || Ok(2));
+    assert!(r.is_ok());
+
+    assert_parity(&elog, &tlog, &["stored"]);
+}
+
+#[test]
+fn parity_try_get_or_set_with_err_over_expired_evicts_nothing() {
+    let (mut e, elog) = expiring(8);
+    e.cache_set(TagKey::new(1, "stored"), Val::stale());
+    let r: Result<&Val, &str> = e.cache_try_get_or_set_with(TagKey::new(1, "caller"), || Err("x"));
+    assert!(r.is_err());
+
+    let (mut t, tlog) = timed(8);
+    t.cache_set(TagKey::new(1, "stored"), 1);
+    std::thread::sleep(LAPSE);
+    let r: Result<&u32, &str> = t.cache_try_get_or_set_with(TagKey::new(1, "caller"), || Err("x"));
+    assert!(r.is_err());
+
+    assert_parity(&elog, &tlog, &[]);
+    assert_eq!(e.cache_size(), 1, "the stale entry survives an Err factory");
+    assert_eq!(t.cache_size(), 1, "the stale entry survives an Err factory");
+}
+
+/// On a fallible get-or-set whose factory returns `Err` over an expired entry, both stores
+/// count the miss: the lookup found no live entry, and whether the initializer then fails
+/// does not change that. Each increments inside the setter, which the inner store invokes
+/// only when the lookup missed.
+///
+/// `LruTtlCache` previously lost this miss (it incremented after the store call, which the
+/// `?` early return skipped) and was the sole outlier in the family; `UnboundCache`,
+/// `LruCache`, `TtlCache` and `ExpiringLruCache` all already counted it.
+///
+/// Neither store fires `on_evict` or counts an eviction here: on `Err` the expired entry is
+/// still physically stored, so firing now would double-fire when a later call really
+/// displaces it. That is asserted in the lru_ttl certification suite.
+#[test]
+fn try_get_or_set_with_err_counts_the_miss_on_both_stores() {
+    let (mut e, _elog) = expiring(8);
+    e.cache_set(TagKey::new(1, "stored"), Val::stale());
+    let r: Result<&Val, &str> = e.cache_try_get_or_set_with(TagKey::new(1, "caller"), || Err("x"));
+    assert!(r.is_err());
+
+    let (mut t, _tlog) = timed(8);
+    t.cache_set(TagKey::new(1, "stored"), 1);
+    std::thread::sleep(LAPSE);
+    let r: Result<&u32, &str> = t.cache_try_get_or_set_with(TagKey::new(1, "caller"), || Err("x"));
+    assert!(r.is_err());
+
+    assert_eq!(
+        e.cache_misses(),
+        Some(1),
+        "ExpiringLruCache counts the miss before running the factory (EXP-2)"
+    );
+    assert_eq!(
+        t.cache_misses(),
+        Some(1),
+        "LruTtlCache counts the miss inside the setter, so an Err factory cannot drop it"
+    );
+}
+
+#[cfg(feature = "async_core")]
+mod async_parity {
+    use super::*;
+    use cached::CachedGetOrSetAsync;
+
+    #[tokio::test]
+    async fn parity_async_get_or_set_with_over_expired() {
+        let (mut e, elog) = expiring(8);
+        e.cache_set(TagKey::new(1, "stored"), Val::stale());
+        let _ = e
+            .async_cache_get_or_set_with(TagKey::new(1, "caller"), || async { Val::live() })
+            .await;
+
+        let (mut t, tlog) = timed(8);
+        t.cache_set(TagKey::new(1, "stored"), 1);
+        tokio::time::sleep(LAPSE).await;
+        let _ = t
+            .async_cache_get_or_set_with(TagKey::new(1, "caller"), || async { 2u32 })
+            .await;
+
+        assert_parity(&elog, &tlog, &["stored"]);
+    }
+
+    #[tokio::test]
+    async fn parity_async_try_get_or_set_with_ok_over_expired() {
+        let (mut e, elog) = expiring(8);
+        e.cache_set(TagKey::new(1, "stored"), Val::stale());
+        let r: Result<&Val, ()> = e
+            .async_cache_try_get_or_set_with(TagKey::new(1, "caller"), || async { Ok(Val::live()) })
+            .await;
+        assert!(r.is_ok());
+
+        let (mut t, tlog) = timed(8);
+        t.cache_set(TagKey::new(1, "stored"), 1);
+        tokio::time::sleep(LAPSE).await;
+        let r: Result<&u32, ()> = t
+            .async_cache_try_get_or_set_with(TagKey::new(1, "caller"), || async { Ok(2u32) })
+            .await;
+        assert!(r.is_ok());
+
+        assert_parity(&elog, &tlog, &["stored"]);
+    }
+
+    #[tokio::test]
+    async fn parity_async_try_get_or_set_with_err_evicts_nothing() {
+        let (mut e, elog) = expiring(8);
+        e.cache_set(TagKey::new(1, "stored"), Val::stale());
+        let r: Result<&Val, &str> = e
+            .async_cache_try_get_or_set_with(TagKey::new(1, "caller"), || async { Err("x") })
+            .await;
+        assert!(r.is_err());
+
+        let (mut t, tlog) = timed(8);
+        t.cache_set(TagKey::new(1, "stored"), 1);
+        tokio::time::sleep(LAPSE).await;
+        let r: Result<&u32, &str> = t
+            .async_cache_try_get_or_set_with(TagKey::new(1, "caller"), || async { Err("x") })
+            .await;
+        assert!(r.is_err());
+
+        assert_parity(&elog, &tlog, &[]);
+    }
+}

--- a/tests/v3_cert_expiring_lru_stored_key.rs
+++ b/tests/v3_cert_expiring_lru_stored_key.rs
@@ -1,0 +1,674 @@
+//! Independent certification of the `ExpiringLruCache` `on_evict` key contract.
+//!
+//! The perf change under certification made `ExpiringLruCache::cache_set` fire `on_evict`
+//! with the **stored** key (the key instance actually held by the entry) rather than the
+//! caller's key, and dropped the unconditional caller-key clone. `tests/
+//! v3_expiring_lru_on_evict_key.rs` covers exactly one path: `cache_set` over an expired
+//! entry.
+//!
+//! This file certifies the contract on **every** path that can fire `on_evict`:
+//!
+//! | path | covered by |
+//! |---|---|
+//! | `cache_set` over an expired entry | `cache_set_over_expired_*` |
+//! | `cache_set` capacity eviction (`LruCache::check_capacity`) | `capacity_eviction_*` |
+//! | `cache_get` / `cache_get_mut` lazy expiry sweep | `cache_get*_lazy_sweep_*` |
+//! | `cache_remove` / `cache_remove_entry` | `cache_remove*_*` |
+//! | `evict()` sweep | `evict_sweep_*` |
+//! | `retain()` (predicate and expiry limbs) | `retain_*` |
+//! | `cache_clear_with_on_evict` | `cache_clear_with_on_evict_*` |
+//! | `set_max_size` shrink | `set_max_size_shrink_*` |
+//! | `cache_get_or_set_with` (sync, infallible) | `get_or_set_with_*` |
+//! | `cache_try_get_or_set_with` (sync, fallible, Ok and Err) | `try_get_or_set_with_*` |
+//! | `async_cache_get_or_set_with` (async, infallible) | `async_get_or_set_with_*` |
+//! | `async_cache_try_get_or_set_with` (async, fallible, Ok and Err) | `async_try_get_or_set_with_*` |
+//!
+//! The observation instrument is a *coarse-`Eq`* key: `TagKey`'s `Hash`/`Eq` cover only
+//! `id`, so `TagKey { id: 1, tag: "stored" }` and `TagKey { id: 1, tag: "caller" }` are
+//! interchangeable for lookup but distinguishable inside the callback. Every assertion
+//! names the exact instance the callback must observe.
+//!
+//! Parity against the `LruTtlCache` oracle lives in
+//! `tests/v3_cert_expiring_lru_lru_ttl_parity.rs`.
+
+use cached::{CacheEvict, Cached, Expires, ExpiringLruCache};
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, Mutex};
+
+// --- instruments ---------------------------------------------------------------------
+
+/// A key whose `Hash`/`Eq` cover only `id`. `tag` rides along uncompared, so two `TagKey`s
+/// with the same `id` are equal-but-distinguishable instances.
+#[derive(Debug, Clone)]
+struct TagKey {
+    id: u32,
+    tag: &'static str,
+}
+
+impl TagKey {
+    fn new(id: u32, tag: &'static str) -> Self {
+        Self { id, tag }
+    }
+}
+
+impl PartialEq for TagKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+impl Eq for TagKey {}
+impl Hash for TagKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
+
+/// A value that decides its own staleness and carries a label so the callback can also be
+/// checked for handing back the *displaced* value rather than the incoming one.
+#[derive(Debug, Clone)]
+struct Val {
+    expired: bool,
+    label: &'static str,
+}
+
+impl Val {
+    fn live(label: &'static str) -> Self {
+        Self {
+            expired: false,
+            label,
+        }
+    }
+    fn stale(label: &'static str) -> Self {
+        Self {
+            expired: true,
+            label,
+        }
+    }
+}
+
+impl Expires for Val {
+    fn is_expired(&self) -> bool {
+        self.expired
+    }
+}
+
+type Log = Arc<Mutex<Vec<(&'static str, &'static str)>>>;
+
+/// Build a cache with a recording `on_evict`; returns the cache and the log of
+/// `(key tag, value label)` pairs in firing order.
+fn cache_with_log(max_size: usize) -> (ExpiringLruCache<TagKey, Val>, Log) {
+    let log: Log = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&log);
+    let cache = ExpiringLruCache::builder()
+        .max_size(max_size)
+        .on_evict(move |k: &TagKey, v: &Val| sink.lock().unwrap().push((k.tag, v.label)))
+        .build()
+        .expect("build ExpiringLruCache");
+    (cache, log)
+}
+
+fn seen(log: &Log) -> Vec<(&'static str, &'static str)> {
+    log.lock().unwrap().clone()
+}
+
+/// Sanity check on the instrument itself: without this, every assertion below is vacuous.
+#[test]
+fn tag_key_is_equal_but_distinguishable() {
+    let a = TagKey::new(1, "stored");
+    let b = TagKey::new(1, "caller");
+    assert_eq!(a, b, "same id must compare equal");
+    assert_ne!(a.tag, b.tag, "tags must differ to tell the instances apart");
+    let hash = |k: &TagKey| {
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        k.hash(&mut h);
+        h.finish()
+    };
+    assert_eq!(hash(&a), hash(&b), "same id must hash equal");
+    assert_ne!(
+        TagKey::new(1, "x"),
+        TagKey::new(2, "x"),
+        "different ids must not compare equal"
+    );
+}
+
+// --- cache_set -----------------------------------------------------------------------
+
+#[test]
+fn cache_set_over_expired_reports_stored_key_and_displaced_value() {
+    let (mut c, log) = cache_with_log(8);
+    c.cache_set(TagKey::new(1, "stored"), Val::stale("old"));
+    assert!(
+        c.cache_set(TagKey::new(1, "caller"), Val::live("new"))
+            .is_none(),
+        "an expired displaced value is filtered from the return"
+    );
+    assert_eq!(
+        seen(&log),
+        vec![("stored", "old")],
+        "on_evict must see the STORED key and the DISPLACED value"
+    );
+    assert_eq!(c.cache_evictions(), Some(1));
+}
+
+#[test]
+fn cache_set_over_live_does_not_fire_but_rebinds_the_stored_key() {
+    // The LRU primitive `order.set` replaces the whole `(K, V)` slot, so overwriting an
+    // existing key silently rebinds the stored key to the caller's instance. This is
+    // NOT `HashMap::insert` semantics (which keeps the original key) -- pinning it here
+    // because every later on_evict on that entry reports the rebound key.
+    let (mut c, log) = cache_with_log(8);
+    c.cache_set(TagKey::new(1, "first"), Val::live("v1"));
+    let displaced = c.cache_set(TagKey::new(1, "second"), Val::live("v2"));
+    assert_eq!(
+        displaced.map(|v| v.label),
+        Some("v1"),
+        "a live displaced value is returned"
+    );
+    assert!(
+        seen(&log).is_empty(),
+        "overwriting a live entry must not fire on_evict"
+    );
+
+    // Observe the stored key through cache_remove_entry, using a third distinct instance.
+    let (stored_key, _) = c
+        .cache_remove_entry(&TagKey::new(1, "probe"))
+        .expect("entry present");
+    assert_eq!(
+        stored_key.tag, "second",
+        "cache_set over a live entry rebinds the stored key to the caller's instance"
+    );
+}
+
+// --- capacity eviction ---------------------------------------------------------------
+
+#[test]
+fn capacity_eviction_reports_the_victims_stored_key() {
+    let (mut c, log) = cache_with_log(2);
+    c.cache_set(TagKey::new(1, "k1"), Val::live("v1"));
+    c.cache_set(TagKey::new(2, "k2"), Val::live("v2"));
+    c.cache_set(TagKey::new(3, "k3"), Val::live("v3")); // evicts LRU = id 1
+    assert_eq!(
+        seen(&log),
+        vec![("k1", "v1")],
+        "capacity eviction reports the victim's own stored key/value"
+    );
+    assert_eq!(c.cache_size(), 2);
+}
+
+#[test]
+fn capacity_eviction_reports_the_rebound_key_after_an_overwrite() {
+    // Combines the two facts above: an overwrite rebinds the stored key (and promotes the
+    // entry to MRU), so a later capacity eviction of that same entry must report the
+    // OVERWRITING key, not the originally inserted one.
+    let (mut c, log) = cache_with_log(2);
+    c.cache_set(TagKey::new(1, "first"), Val::live("v1"));
+    c.cache_set(TagKey::new(2, "k2"), Val::live("v2"));
+    // Overwrite of id 1: rebinds the key AND promotes it to MRU.
+    c.cache_set(TagKey::new(1, "second"), Val::live("v1b"));
+    assert!(seen(&log).is_empty(), "no eviction yet");
+    // Read id 2 to push id 1 back to the LRU position, so it is the next victim.
+    assert!(c.cache_get(&TagKey::new(2, "ignored")).is_some());
+    c.cache_set(TagKey::new(3, "k3"), Val::live("v3"));
+    assert_eq!(
+        seen(&log),
+        vec![("second", "v1b")],
+        "the victim's stored key is the one bound by the most recent cache_set"
+    );
+}
+
+#[test]
+fn capacity_eviction_of_an_expired_victim_fires_exactly_once() {
+    // Both the outer ExpiringLruCache and its inner LruCache hold the same on_evict Arc.
+    // A new-key insert that evicts an expired LRU victim must still fire exactly once
+    // (the inner check_capacity path), never twice.
+    let (mut c, log) = cache_with_log(1);
+    c.cache_set(TagKey::new(1, "victim"), Val::stale("old"));
+    c.cache_set(TagKey::new(2, "fresh"), Val::live("new"));
+    assert_eq!(
+        seen(&log),
+        vec![("victim", "old")],
+        "an expired capacity victim fires on_evict exactly once"
+    );
+    assert_eq!(c.cache_evictions(), Some(1));
+}
+
+// --- lazy expiry sweep on read -------------------------------------------------------
+
+#[test]
+fn cache_get_lazy_sweep_reports_stored_key_not_lookup_key() {
+    let (mut c, log) = cache_with_log(8);
+    c.cache_set(TagKey::new(1, "stored"), Val::stale("old"));
+    assert!(
+        c.cache_get(&TagKey::new(1, "lookup")).is_none(),
+        "an expired entry is not returned"
+    );
+    assert_eq!(
+        seen(&log),
+        vec![("stored", "old")],
+        "the lazy sweep must report the STORED key, not the lookup key"
+    );
+    assert_eq!(c.cache_size(), 0, "the entry is physically removed");
+}
+
+#[test]
+fn cache_get_mut_lazy_sweep_reports_stored_key_not_lookup_key() {
+    let (mut c, log) = cache_with_log(8);
+    c.cache_set(TagKey::new(1, "stored"), Val::stale("old"));
+    assert!(c.cache_get_mut(&TagKey::new(1, "lookup")).is_none());
+    assert_eq!(seen(&log), vec![("stored", "old")]);
+    assert_eq!(c.cache_size(), 0);
+}
+
+// --- explicit removal ----------------------------------------------------------------
+
+#[test]
+fn cache_remove_reports_stored_key_for_a_live_entry() {
+    let (mut c, log) = cache_with_log(8);
+    c.cache_set(TagKey::new(1, "stored"), Val::live("v1"));
+    let removed = c.cache_remove(&TagKey::new(1, "lookup"));
+    assert_eq!(removed.map(|v| v.label), Some("v1"));
+    assert_eq!(seen(&log), vec![("stored", "v1")]);
+}
+
+#[test]
+fn cache_remove_reports_stored_key_for_an_expired_entry_and_returns_none() {
+    let (mut c, log) = cache_with_log(8);
+    c.cache_set(TagKey::new(1, "stored"), Val::stale("old"));
+    assert!(
+        c.cache_remove(&TagKey::new(1, "lookup")).is_none(),
+        "cache_remove filters an expired value from its return"
+    );
+    assert_eq!(seen(&log), vec![("stored", "old")]);
+    assert_eq!(c.cache_size(), 0, "the entry is removed regardless");
+}
+
+#[test]
+fn cache_remove_entry_returns_and_reports_the_stored_key() {
+    let (mut c, log) = cache_with_log(8);
+    c.cache_set(TagKey::new(1, "stored"), Val::stale("old"));
+    let (k, v) = c
+        .cache_remove_entry(&TagKey::new(1, "lookup"))
+        .expect("entry present");
+    assert_eq!(
+        k.tag, "stored",
+        "cache_remove_entry must hand back the STORED key"
+    );
+    assert_eq!(v.label, "old", "and the stored value regardless of expiry");
+    assert_eq!(seen(&log), vec![("stored", "old")]);
+}
+
+#[test]
+fn cache_remove_of_an_absent_key_does_not_fire() {
+    let (mut c, log) = cache_with_log(8);
+    assert!(c.cache_remove(&TagKey::new(9, "ghost")).is_none());
+    assert!(c.cache_remove_entry(&TagKey::new(9, "ghost")).is_none());
+    assert!(seen(&log).is_empty());
+    assert_eq!(c.cache_evictions(), Some(0));
+}
+
+// --- evict() sweep -------------------------------------------------------------------
+
+#[test]
+fn evict_sweep_reports_stored_keys_only_for_expired_entries() {
+    let (mut c, log) = cache_with_log(8);
+    c.cache_set(TagKey::new(1, "s1"), Val::stale("old1"));
+    c.cache_set(TagKey::new(2, "live"), Val::live("keep"));
+    c.cache_set(TagKey::new(3, "s3"), Val::stale("old3"));
+    let removed = CacheEvict::evict(&mut c);
+    assert_eq!(removed, 2);
+    // Sweep order is MRU -> LRU: 3 was inserted last.
+    assert_eq!(
+        seen(&log),
+        vec![("s3", "old3"), ("s1", "old1")],
+        "evict reports each expired entry's own stored key"
+    );
+    assert_eq!(c.cache_size(), 1);
+}
+
+#[test]
+fn evict_sweep_reports_the_rebound_key_after_an_overwrite() {
+    let (mut c, log) = cache_with_log(8);
+    c.cache_set(TagKey::new(1, "first"), Val::live("v1"));
+    // Overwrite the live entry with a stale value under a distinct key instance.
+    c.cache_set(TagKey::new(1, "second"), Val::stale("v2"));
+    assert!(seen(&log).is_empty(), "overwriting a live entry is silent");
+    assert_eq!(CacheEvict::evict(&mut c), 1);
+    assert_eq!(
+        seen(&log),
+        vec![("second", "v2")],
+        "evict reports the key bound by the most recent cache_set"
+    );
+}
+
+#[test]
+fn evict_on_an_all_live_cache_fires_nothing() {
+    let (mut c, log) = cache_with_log(8);
+    c.cache_set(TagKey::new(1, "k1"), Val::live("v1"));
+    assert_eq!(CacheEvict::evict(&mut c), 0);
+    assert!(seen(&log).is_empty());
+    assert_eq!(c.cache_evictions(), Some(0));
+}
+
+// --- retain() ------------------------------------------------------------------------
+
+#[test]
+fn retain_reports_stored_keys_on_both_the_predicate_and_expiry_limbs() {
+    let (mut c, log) = cache_with_log(8);
+    c.cache_set(TagKey::new(1, "drop_by_pred"), Val::live("v1"));
+    c.cache_set(TagKey::new(2, "keep"), Val::live("v2"));
+    c.cache_set(TagKey::new(3, "drop_by_expiry"), Val::stale("v3"));
+
+    // The predicate must also observe the stored key instances.
+    let predicate_saw: Arc<Mutex<Vec<&'static str>>> = Arc::new(Mutex::new(Vec::new()));
+    let probe = Arc::clone(&predicate_saw);
+    c.retain(|k, _v| {
+        probe.lock().unwrap().push(k.tag);
+        k.id != 1
+    });
+
+    // MRU -> LRU is 3, 2, 1. The expired entry (3) is removed WITHOUT consulting `keep`.
+    assert_eq!(
+        &*predicate_saw.lock().unwrap(),
+        &["keep", "drop_by_pred"],
+        "the retain predicate sees stored keys, and is not consulted for expired entries"
+    );
+    assert_eq!(
+        seen(&log),
+        vec![("drop_by_expiry", "v3"), ("drop_by_pred", "v1")],
+        "on_evict fires MRU -> LRU with each removed entry's stored key"
+    );
+    assert_eq!(c.cache_size(), 1);
+    assert_eq!(c.cache_evictions(), Some(2));
+}
+
+#[test]
+fn retain_keeping_everything_fires_nothing() {
+    let (mut c, log) = cache_with_log(8);
+    c.cache_set(TagKey::new(1, "k1"), Val::live("v1"));
+    c.cache_set(TagKey::new(2, "k2"), Val::live("v2"));
+    c.retain(|_, _| true);
+    assert!(seen(&log).is_empty());
+    assert_eq!(c.cache_size(), 2);
+}
+
+#[test]
+fn retain_dropping_everything_reports_every_stored_key() {
+    let (mut c, log) = cache_with_log(8);
+    c.cache_set(TagKey::new(1, "k1"), Val::live("v1"));
+    c.cache_set(TagKey::new(2, "k2"), Val::live("v2"));
+    c.retain(|_, _| false);
+    assert_eq!(seen(&log), vec![("k2", "v2"), ("k1", "v1")]);
+    assert_eq!(c.cache_size(), 0);
+}
+
+// --- cache_clear_with_on_evict / cache_clear ------------------------------------------
+
+#[test]
+fn cache_clear_with_on_evict_reports_stored_keys_mru_to_lru() {
+    let (mut c, log) = cache_with_log(8);
+    c.cache_set(TagKey::new(1, "first"), Val::live("v1"));
+    c.cache_set(TagKey::new(2, "k2"), Val::stale("v2"));
+    // Rebind id 1's stored key; the overwrite also promotes it to MRU.
+    c.cache_set(TagKey::new(1, "second"), Val::live("v1b"));
+    c.cache_clear_with_on_evict();
+    assert_eq!(
+        seen(&log),
+        vec![("second", "v1b"), ("k2", "v2")],
+        "drain reports rebound stored keys, expired entries included, MRU -> LRU"
+    );
+    assert_eq!(c.cache_size(), 0);
+    assert_eq!(c.cache_evictions(), Some(2));
+}
+
+#[test]
+fn cache_clear_with_on_evict_leaves_the_cache_reusable() {
+    // `drain_all` resets the LRU slab sentinels; a cache cleared this way must still
+    // accept inserts and evict correctly afterwards.
+    let (mut c, log) = cache_with_log(2);
+    c.cache_set(TagKey::new(1, "a"), Val::live("v1"));
+    c.cache_set(TagKey::new(2, "b"), Val::live("v2"));
+    c.cache_clear_with_on_evict();
+    log.lock().unwrap().clear();
+
+    c.cache_set(TagKey::new(3, "c"), Val::live("v3"));
+    c.cache_set(TagKey::new(4, "d"), Val::live("v4"));
+    c.cache_set(TagKey::new(5, "e"), Val::live("v5"));
+    assert_eq!(c.cache_size(), 2);
+    assert_eq!(
+        seen(&log),
+        vec![("c", "v3")],
+        "post-drain inserts must still evict the true LRU with its stored key"
+    );
+    assert_eq!(
+        c.cache_get(&TagKey::new(4, "?")).map(|v| v.label),
+        Some("v4")
+    );
+    assert_eq!(
+        c.cache_get(&TagKey::new(5, "?")).map(|v| v.label),
+        Some("v5")
+    );
+}
+
+#[test]
+fn cache_clear_never_fires_on_evict() {
+    let (mut c, log) = cache_with_log(8);
+    c.cache_set(TagKey::new(1, "k1"), Val::live("v1"));
+    c.cache_set(TagKey::new(2, "k2"), Val::stale("v2"));
+    c.cache_clear();
+    assert!(seen(&log).is_empty(), "cache_clear is silent");
+    assert_eq!(c.cache_evictions(), Some(0));
+    assert_eq!(c.cache_size(), 0);
+}
+
+// --- capacity shrink ------------------------------------------------------------------
+
+#[test]
+fn set_max_size_shrink_reports_stored_keys_lru_first() {
+    let (mut c, log) = cache_with_log(4);
+    c.cache_set(TagKey::new(1, "k1"), Val::live("v1"));
+    c.cache_set(TagKey::new(2, "first"), Val::live("v2"));
+    c.cache_set(TagKey::new(3, "k3"), Val::live("v3"));
+    c.cache_set(TagKey::new(4, "k4"), Val::live("v4"));
+    // Rebind id 2's stored key; the overwrite also promotes it to MRU.
+    c.cache_set(TagKey::new(2, "second"), Val::live("v2b"));
+    // Read 3 then 4 back to the front so id 2 is a shrink victim again.
+    assert!(c.cache_get(&TagKey::new(3, "?")).is_some());
+    assert!(c.cache_get(&TagKey::new(4, "?")).is_some());
+
+    let previous = c.set_max_size(2);
+    assert_eq!(previous, Some(4));
+    // MRU -> LRU is 4, 3, 2, 1; shrinking to 2 evicts 1 then 2.
+    assert_eq!(
+        seen(&log),
+        vec![("k1", "v1"), ("second", "v2b")],
+        "shrink evicts LRU-first, reporting each victim's stored key"
+    );
+    assert_eq!(c.cache_size(), 2);
+}
+
+#[test]
+fn try_set_max_size_zero_is_rejected_and_fires_nothing() {
+    let (mut c, log) = cache_with_log(4);
+    c.cache_set(TagKey::new(1, "k1"), Val::live("v1"));
+    assert!(c.try_set_max_size(0).is_err());
+    assert!(
+        seen(&log).is_empty(),
+        "a rejected shrink must evict nothing"
+    );
+    assert_eq!(c.cache_size(), 1);
+}
+
+// --- get_or_set family (sync) ---------------------------------------------------------
+
+#[test]
+fn get_or_set_with_over_expired_reports_the_old_stored_key() {
+    let (mut c, log) = cache_with_log(8);
+    c.cache_set(TagKey::new(1, "stored"), Val::stale("old"));
+    let v = c.cache_get_or_set_with(TagKey::new(1, "caller"), || Val::live("new"));
+    assert_eq!(v.label, "new");
+    assert_eq!(
+        seen(&log),
+        vec![("stored", "old")],
+        "the replaced entry's OLD stored key must reach on_evict, not the caller's key"
+    );
+    assert_eq!(c.cache_evictions(), Some(1));
+}
+
+#[test]
+fn get_or_set_with_over_expired_rebinds_the_stored_key_to_the_caller() {
+    // Agreement with `cache_set`: after the replacement the caller's key is the stored one.
+    let (mut c, _log) = cache_with_log(8);
+    c.cache_set(TagKey::new(1, "stored"), Val::stale("old"));
+    let _ = c.cache_get_or_set_with(TagKey::new(1, "caller"), || Val::live("new"));
+    let (k, _) = c
+        .cache_remove_entry(&TagKey::new(1, "probe"))
+        .expect("entry present");
+    assert_eq!(k.tag, "caller");
+}
+
+#[test]
+fn get_or_set_with_on_a_hit_fires_nothing_and_keeps_the_stored_key() {
+    let (mut c, log) = cache_with_log(8);
+    c.cache_set(TagKey::new(1, "stored"), Val::live("v1"));
+    let v = c.cache_get_or_set_with(TagKey::new(1, "caller"), || Val::live("unused"));
+    assert_eq!(v.label, "v1", "the live value is returned, factory not run");
+    assert!(seen(&log).is_empty());
+    let (k, _) = c
+        .cache_remove_entry(&TagKey::new(1, "probe"))
+        .expect("entry present");
+    assert_eq!(
+        k.tag, "stored",
+        "a hit must not rebind the stored key to the caller's instance"
+    );
+}
+
+#[test]
+fn get_or_set_with_new_key_at_capacity_reports_the_victims_stored_key() {
+    let (mut c, log) = cache_with_log(1);
+    c.cache_set(TagKey::new(1, "victim"), Val::live("v1"));
+    let _ = c.cache_get_or_set_with(TagKey::new(2, "fresh"), || Val::live("v2"));
+    assert_eq!(
+        seen(&log),
+        vec![("victim", "v1")],
+        "the capacity victim is reported once with its own stored key"
+    );
+    assert_eq!(c.cache_evictions(), Some(1));
+}
+
+#[test]
+fn try_get_or_set_with_ok_over_expired_reports_the_old_stored_key() {
+    let (mut c, log) = cache_with_log(8);
+    c.cache_set(TagKey::new(1, "stored"), Val::stale("old"));
+    let v: Result<&Val, ()> =
+        c.cache_try_get_or_set_with(TagKey::new(1, "caller"), || Ok(Val::live("new")));
+    assert_eq!(v.unwrap().label, "new");
+    assert_eq!(seen(&log), vec![("stored", "old")]);
+    assert_eq!(c.cache_evictions(), Some(1));
+}
+
+#[test]
+fn try_get_or_set_with_err_over_expired_fires_nothing_and_keeps_the_stored_key() {
+    // On `Err` the store returns before `order.set` runs, so the expired entry -- and its
+    // original stored key -- must survive untouched, with no on_evict and no eviction.
+    let (mut c, log) = cache_with_log(8);
+    c.cache_set(TagKey::new(1, "stored"), Val::stale("old"));
+    let r: Result<&Val, &str> =
+        c.cache_try_get_or_set_with(TagKey::new(1, "caller"), || Err("boom"));
+    assert_eq!(r.err(), Some("boom"));
+    assert!(seen(&log).is_empty(), "an Err factory must not evict");
+    assert_eq!(c.cache_evictions(), Some(0));
+    assert_eq!(c.cache_size(), 1, "the expired entry stays in place");
+
+    let (k, v) = c
+        .cache_remove_entry(&TagKey::new(1, "probe"))
+        .expect("entry present");
+    assert_eq!(
+        k.tag, "stored",
+        "an Err factory must not rebind the stored key"
+    );
+    assert_eq!(v.label, "old");
+}
+
+// --- get_or_set family (async) --------------------------------------------------------
+
+#[cfg(feature = "async_core")]
+mod async_paths {
+    use super::*;
+    use cached::CachedGetOrSetAsync;
+
+    #[tokio::test]
+    async fn async_get_or_set_with_over_expired_reports_the_old_stored_key() {
+        let (mut c, log) = cache_with_log(8);
+        c.cache_set(TagKey::new(1, "stored"), Val::stale("old"));
+        let v = c
+            .async_cache_get_or_set_with(TagKey::new(1, "caller"), || async { Val::live("new") })
+            .await;
+        assert_eq!(v.label, "new");
+        assert_eq!(
+            seen(&log),
+            vec![("stored", "old")],
+            "the async infallible path must also report the OLD stored key"
+        );
+        assert_eq!(c.cache_evictions(), Some(1));
+        let (k, _) = c
+            .cache_remove_entry(&TagKey::new(1, "probe"))
+            .expect("entry present");
+        assert_eq!(k.tag, "caller", "the replacement rebinds the stored key");
+    }
+
+    #[tokio::test]
+    async fn async_get_or_set_with_on_a_hit_fires_nothing_and_keeps_the_stored_key() {
+        let (mut c, log) = cache_with_log(8);
+        c.cache_set(TagKey::new(1, "stored"), Val::live("v1"));
+        let v = c
+            .async_cache_get_or_set_with(TagKey::new(1, "caller"), || async { Val::live("unused") })
+            .await;
+        assert_eq!(v.label, "v1");
+        assert!(seen(&log).is_empty());
+        let (k, _) = c
+            .cache_remove_entry(&TagKey::new(1, "probe"))
+            .expect("entry present");
+        assert_eq!(k.tag, "stored");
+    }
+
+    #[tokio::test]
+    async fn async_get_or_set_with_new_key_at_capacity_reports_the_victims_stored_key() {
+        let (mut c, log) = cache_with_log(1);
+        c.cache_set(TagKey::new(1, "victim"), Val::live("v1"));
+        let _ = c
+            .async_cache_get_or_set_with(TagKey::new(2, "fresh"), || async { Val::live("v2") })
+            .await;
+        assert_eq!(seen(&log), vec![("victim", "v1")]);
+    }
+
+    #[tokio::test]
+    async fn async_try_get_or_set_with_ok_over_expired_reports_the_old_stored_key() {
+        let (mut c, log) = cache_with_log(8);
+        c.cache_set(TagKey::new(1, "stored"), Val::stale("old"));
+        let v: Result<&Val, ()> = c
+            .async_cache_try_get_or_set_with(TagKey::new(1, "caller"), || async {
+                Ok(Val::live("new"))
+            })
+            .await;
+        assert_eq!(v.unwrap().label, "new");
+        assert_eq!(seen(&log), vec![("stored", "old")]);
+        assert_eq!(c.cache_evictions(), Some(1));
+    }
+
+    #[tokio::test]
+    async fn async_try_get_or_set_with_err_fires_nothing_and_keeps_the_stored_key() {
+        let (mut c, log) = cache_with_log(8);
+        c.cache_set(TagKey::new(1, "stored"), Val::stale("old"));
+        let r: Result<&Val, &str> = c
+            .async_cache_try_get_or_set_with(TagKey::new(1, "caller"), || async { Err("boom") })
+            .await;
+        assert_eq!(r.err(), Some("boom"));
+        assert!(seen(&log).is_empty());
+        assert_eq!(c.cache_evictions(), Some(0));
+        let (k, v) = c
+            .cache_remove_entry(&TagKey::new(1, "probe"))
+            .expect("entry present");
+        assert_eq!(k.tag, "stored");
+        assert_eq!(v.label, "old");
+    }
+}

--- a/tests/v3_cert_lru_ttl_perf.rs
+++ b/tests/v3_cert_lru_ttl_perf.rs
@@ -1,0 +1,1170 @@
+//! Outside-in certification of the `LruTtlCache` (non-sharded) performance rework:
+//! single-clock-sample threading (`entry_live_at`), `drain_all`-backed clearing,
+//! hash reuse via `pop_raw_with_hash`, and the pre-sized eager collectors.
+//!
+//! Every test here pins an **observable** contract from outside the store: no
+//! private state is touched, so the tests remain valid if the internals are
+//! rewritten again.
+//!
+//! The instruments used deliberately go beyond the happy path:
+//!
+//! * A **counting** `BuildHasher` makes "the hash is reused, not recomputed" and
+//!   "clearing performs zero hashing" directly observable: the number of
+//!   `build_hasher()` calls per public operation is asserted exactly.
+//! * A **colliding** `BuildHasher` (every key hashes to `0`) forces every entry
+//!   into one bucket chain, so any removal path that trusts the hash instead of
+//!   the `Eq` probe removes the wrong entry and is caught.
+//! * A **slow-cloning** key/value type stretches an eager collector pass past an
+//!   entry's expiry, which distinguishes "one clock sample for the whole pass"
+//!   from "a clock read per entry".
+//! * A **lazily consumed** `iter()` held across an expiry pins the deliberately
+//!   *opposite* convention for the lazy iterator.
+#![cfg(feature = "time_stores")]
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{BuildHasher, Hasher};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use cached::time::Duration;
+use cached::{CacheTtl, Cached, CachedExt, CachedIter, CachedPeek, CloneCached, LruTtlCache};
+
+// ── timing constants ─────────────────────────────────────────────────────────
+//
+// The gaps are deliberately generous: every assertion needs only "the sleep is
+// longer than the ttl" (or the reverse), so a descheduled test thread widens the
+// margin instead of flipping the result.
+
+/// TTL short enough that `PAST_TTL` reliably outlives it.
+const TTL: Duration = Duration::from_millis(150);
+/// Sleep that puts an entry inserted under [`TTL`] comfortably past its expiry.
+const PAST_TTL: std::time::Duration = std::time::Duration::from_millis(400);
+/// TTL used by the eager-collector snapshot tests: must be much longer than the
+/// microseconds between the last insert and the collector call, and much shorter
+/// than [`SLOW_CLONE`].
+const SNAPSHOT_TTL: Duration = Duration::from_millis(500);
+/// Time a "slow" `Clone` burns, stretching one eager collector pass well past
+/// [`SNAPSHOT_TTL`].
+const SLOW_CLONE: std::time::Duration = std::time::Duration::from_millis(900);
+
+// ── instruments ──────────────────────────────────────────────────────────────
+
+/// A `BuildHasher` that hashes every key to `0`, so all entries land in one
+/// bucket chain and only the `K: Eq` probe can tell them apart.
+#[derive(Clone, Default)]
+struct CollideBuildHasher;
+
+struct CollideHasher;
+
+impl Hasher for CollideHasher {
+    fn write(&mut self, _bytes: &[u8]) {}
+    fn finish(&self) -> u64 {
+        0
+    }
+}
+
+impl BuildHasher for CollideBuildHasher {
+    type Hasher = CollideHasher;
+    fn build_hasher(&self) -> Self::Hasher {
+        CollideHasher
+    }
+}
+
+/// A deterministic `BuildHasher` that counts how many hashers it has handed out.
+/// One `build_hasher()` call == one key hashed.
+#[derive(Clone)]
+struct CountingBuildHasher {
+    built: Arc<AtomicUsize>,
+}
+
+impl CountingBuildHasher {
+    fn new() -> (Self, Arc<AtomicUsize>) {
+        let built = Arc::new(AtomicUsize::new(0));
+        (
+            Self {
+                built: built.clone(),
+            },
+            built,
+        )
+    }
+}
+
+impl BuildHasher for CountingBuildHasher {
+    type Hasher = DefaultHasher;
+    fn build_hasher(&self) -> Self::Hasher {
+        self.built.fetch_add(1, Ordering::Relaxed);
+        // `DefaultHasher::new()` is deterministic within a process, so the hash a
+        // probe computes is the same one a later lookup for the same key computes.
+        DefaultHasher::new()
+    }
+}
+
+/// A deterministic FNV-1a `BuildHasher`: a real custom hasher (not the crate
+/// default, not a degenerate one) for the end-to-end custom-hasher pass.
+#[derive(Clone, Default)]
+struct FnvBuildHasher;
+
+struct FnvHasher(u64);
+
+impl Hasher for FnvHasher {
+    fn write(&mut self, bytes: &[u8]) {
+        for &b in bytes {
+            self.0 ^= u64::from(b);
+            self.0 = self.0.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+    fn finish(&self) -> u64 {
+        self.0
+    }
+}
+
+impl BuildHasher for FnvBuildHasher {
+    type Hasher = FnvHasher;
+    fn build_hasher(&self) -> Self::Hasher {
+        FnvHasher(0xcbf2_9ce4_8422_2325)
+    }
+}
+
+/// Records every `on_evict` firing as `(key, value)` in order.
+type Log<K, V> = Arc<Mutex<Vec<(K, V)>>>;
+
+fn log<K, V>() -> Log<K, V> {
+    Arc::new(Mutex::new(Vec::new()))
+}
+
+fn drain<K: Clone, V: Clone>(l: &Log<K, V>) -> Vec<(K, V)> {
+    l.lock().expect("on_evict log poisoned").clone()
+}
+
+/// A value whose `Clone` optionally sleeps, used to stretch an eager collector pass.
+#[derive(Debug, PartialEq, Eq)]
+struct SlowClone {
+    id: u32,
+    slow: bool,
+}
+
+impl Clone for SlowClone {
+    fn clone(&self) -> Self {
+        if self.slow {
+            std::thread::sleep(SLOW_CLONE);
+        }
+        Self {
+            id: self.id,
+            slow: self.slow,
+        }
+    }
+}
+
+/// A key whose `Clone` optionally sleeps (`key_order` clones keys, not values).
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct SlowKey {
+    id: u32,
+    slow: bool,
+}
+
+impl Clone for SlowKey {
+    fn clone(&self) -> Self {
+        if self.slow {
+            std::thread::sleep(SLOW_CLONE);
+        }
+        Self {
+            id: self.id,
+            slow: self.slow,
+        }
+    }
+}
+
+// ── builders ─────────────────────────────────────────────────────────────────
+
+fn collide_cache(
+    max_size: usize,
+    ttl: Duration,
+    l: Log<u32, u32>,
+) -> LruTtlCache<u32, u32, CollideBuildHasher> {
+    LruTtlCache::<u32, u32>::builder()
+        .max_size(max_size)
+        .ttl(ttl)
+        .hasher(CollideBuildHasher)
+        .on_evict(move |k: &u32, v: &u32| l.lock().expect("on_evict log poisoned").push((*k, *v)))
+        .build()
+        .expect("build LruTtlCache with a colliding hasher")
+}
+
+fn logging_cache(max_size: usize, ttl: Duration, l: Log<u32, u32>) -> LruTtlCache<u32, u32> {
+    LruTtlCache::<u32, u32>::builder()
+        .max_size(max_size)
+        .ttl(ttl)
+        .on_evict(move |k: &u32, v: &u32| l.lock().expect("on_evict log poisoned").push((*k, *v)))
+        .build()
+        .expect("build LruTtlCache")
+}
+
+// =============================================================================
+// CHANGE 3 -- `pop_raw_with_hash`: the probe's hash is reused, not recomputed.
+// =============================================================================
+
+// The perf claim itself, made observable: a `cache_get` that finds an EXPIRED
+// entry hashes the key exactly ONCE. Reverting the lazy sweep to `pop_raw`
+// (which re-hashes) makes this 2.
+#[test]
+fn cache_get_lazy_sweep_hashes_the_key_exactly_once() {
+    let (hasher, built) = CountingBuildHasher::new();
+    let mut c = LruTtlCache::<u32, u32>::builder()
+        .max_size(8)
+        .ttl(TTL)
+        .hasher(hasher)
+        .build()
+        .expect("build LruTtlCache with a counting hasher");
+    c.cache_set(1, 10);
+    std::thread::sleep(PAST_TTL);
+
+    built.store(0, Ordering::Relaxed);
+    assert_eq!(c.cache_get(&1), None, "the entry has expired");
+    assert_eq!(
+        built.load(Ordering::Relaxed),
+        1,
+        "the expired-entry sweep must reuse the probe's hash: exactly one hash per call"
+    );
+    assert_eq!(c.cache_size(), 0, "the expired entry must be gone");
+
+    // The plain paths hash once too, so the assertion above is a real bound and
+    // not an accident of the miss path.
+    built.store(0, Ordering::Relaxed);
+    assert_eq!(c.cache_get(&1), None, "absent key");
+    assert_eq!(
+        built.load(Ordering::Relaxed),
+        1,
+        "an absent-key miss must hash exactly once"
+    );
+
+    c.cache_set(2, 20);
+    built.store(0, Ordering::Relaxed);
+    assert_eq!(c.cache_get(&2), Some(&20));
+    assert_eq!(
+        built.load(Ordering::Relaxed),
+        1,
+        "a live hit must hash exactly once"
+    );
+}
+
+#[test]
+fn cache_get_mut_lazy_sweep_hashes_the_key_exactly_once() {
+    let (hasher, built) = CountingBuildHasher::new();
+    let mut c = LruTtlCache::<u32, u32>::builder()
+        .max_size(8)
+        .ttl(TTL)
+        .hasher(hasher)
+        .build()
+        .expect("build LruTtlCache with a counting hasher");
+    c.cache_set(1, 10);
+    std::thread::sleep(PAST_TTL);
+
+    built.store(0, Ordering::Relaxed);
+    assert_eq!(c.cache_get_mut(&1), None);
+    assert_eq!(
+        built.load(Ordering::Relaxed),
+        1,
+        "cache_get_mut's expired-entry sweep must reuse the probe's hash"
+    );
+    assert_eq!(c.cache_size(), 0);
+}
+
+/// Build a 4-entry colliding cache in which exactly `doomed` has a short ttl
+/// (inserted at its natural position in the insertion order, so the doomed entry
+/// occupies every possible position in the shared bucket chain across a sweep of
+/// `doomed` values). Returns the cache and its `on_evict` log; the caller sleeps
+/// past [`TTL`] before probing.
+fn colliding_cache_with_one_doomed_key(
+    doomed: u32,
+) -> (LruTtlCache<u32, u32, CollideBuildHasher>, Log<u32, u32>) {
+    const LONG: Duration = Duration::from_secs(60);
+    let l = log();
+    let mut c = collide_cache(8, LONG, l.clone());
+    for k in 1..=4u32 {
+        if k == doomed {
+            c.set_ttl(TTL);
+            c.cache_set(k, k * 10);
+            c.set_ttl(LONG);
+        } else {
+            c.cache_set(k, k * 10);
+        }
+    }
+    assert_eq!(c.cache_size(), 4);
+    (c, l)
+}
+
+/// Recency order (MRU -> LRU) of keys 1..=4 minus `doomed`.
+fn survivors_of(doomed: u32) -> Vec<u32> {
+    (1..=4u32).rev().filter(|k| *k != doomed).collect()
+}
+
+// With every key colliding, a removal that trusts the hash rather than the `Eq`
+// probe evicts an arbitrary neighbour from the shared bucket chain. Sweeping the
+// doomed key at EVERY position in the chain leaves no ordering the mutation can
+// hide behind.
+#[test]
+fn lazy_sweep_under_hash_collisions_removes_only_the_expired_key() {
+    for doomed in 1..=4u32 {
+        let (mut c, l) = colliding_cache_with_one_doomed_key(doomed);
+        std::thread::sleep(PAST_TTL);
+
+        assert_eq!(c.cache_get(&doomed), None, "key {doomed} has expired");
+        assert_eq!(
+            drain(&l),
+            vec![(doomed, doomed * 10)],
+            "exactly the expired entry must be evicted, with its own key and value"
+        );
+        assert_eq!(c.cache_size(), 3);
+        assert_eq!(
+            c.key_order(),
+            survivors_of(doomed),
+            "the colliding neighbours must be untouched, in their original recency order"
+        );
+        for k in 1..=4u32 {
+            if k != doomed {
+                assert_eq!(c.cache_get(&k), Some(&(k * 10)), "survivor {k}");
+            }
+        }
+        assert_eq!(
+            drain(&l),
+            vec![(doomed, doomed * 10)],
+            "no further evictions from reading the survivors"
+        );
+    }
+}
+
+#[test]
+fn lazy_sweep_mut_under_hash_collisions_removes_only_the_expired_key() {
+    for doomed in 1..=4u32 {
+        let (mut c, l) = colliding_cache_with_one_doomed_key(doomed);
+        std::thread::sleep(PAST_TTL);
+
+        assert_eq!(c.cache_get_mut(&doomed), None);
+        assert_eq!(drain(&l), vec![(doomed, doomed * 10)]);
+        assert_eq!(c.key_order(), survivors_of(doomed));
+        for k in 1..=4u32 {
+            if k != doomed {
+                assert_eq!(c.cache_get_mut(&k), Some(&mut (k * 10)), "survivor {k}");
+            }
+        }
+    }
+}
+
+// `cache_remove` / `cache_remove_entry` go through `pop_raw`, which computes the
+// hash itself and then calls `pop_raw_with_hash`. Same collision trap.
+#[test]
+fn cache_remove_under_hash_collisions_removes_only_the_named_key() {
+    let l = log();
+    let mut c = collide_cache(8, Duration::from_secs(60), l.clone());
+    c.cache_set(1, 10);
+    c.cache_set(2, 20);
+    c.cache_set(3, 30);
+
+    assert_eq!(c.cache_remove(&2), Some(20));
+    assert_eq!(drain(&l), vec![(2, 20)]);
+    assert_eq!(c.key_order(), vec![3, 1]);
+
+    assert_eq!(c.cache_remove_entry(&1), Some((1, 10)));
+    assert_eq!(c.key_order(), vec![3]);
+    assert_eq!(
+        c.cache_remove(&1),
+        None,
+        "removing an already-removed key must be a no-op"
+    );
+    assert_eq!(
+        drain(&l),
+        vec![(2, 20), (1, 10)],
+        "no callback for the absent key"
+    );
+    assert_eq!(c.cache_get(&3), Some(&30));
+}
+
+// Borrowed lookup (`K = String`, `Q = str`): the reused hash comes from the
+// `&str`, and must still find the `String`-keyed entry among colliding keys.
+#[test]
+fn borrowed_key_lazy_sweep_under_hash_collisions_removes_only_the_expired_key() {
+    let l: Log<String, u32> = log();
+    let l2 = l.clone();
+    let mut c = LruTtlCache::<String, u32>::builder()
+        .max_size(8)
+        .ttl(TTL)
+        .hasher(CollideBuildHasher)
+        .on_evict(move |k: &String, v: &u32| {
+            l2.lock()
+                .expect("on_evict log poisoned")
+                .push((k.clone(), *v))
+        })
+        .build()
+        .expect("build String-keyed LruTtlCache with a colliding hasher");
+
+    c.cache_set("doomed".to_string(), 1);
+    std::thread::sleep(PAST_TTL);
+    c.cache_set("alpha".to_string(), 2);
+    c.cache_set("beta".to_string(), 3);
+
+    assert_eq!(c.cache_get("doomed"), None, "expired, looked up as &str");
+    assert_eq!(
+        drain(&l),
+        vec![("doomed".to_string(), 1)],
+        "on_evict must receive the STORED String key"
+    );
+    assert_eq!(c.cache_size(), 2);
+    assert_eq!(c.cache_get("alpha"), Some(&2));
+    assert_eq!(c.cache_get("beta"), Some(&3));
+}
+
+// `evict` / `retain` remove by LRU slot index (the stored key is re-hashed), so
+// collisions exercise a different lookup than the `pop_raw*` family.
+#[test]
+fn evict_and_retain_under_hash_collisions_remove_only_the_right_entries() {
+    let l = log();
+    let mut c = collide_cache(8, TTL, l.clone());
+    c.cache_set(1, 10); // doomed
+    c.cache_set(2, 20); // doomed
+    std::thread::sleep(PAST_TTL);
+    c.cache_set(3, 30);
+    c.cache_set(4, 40);
+    c.cache_set(5, 50);
+
+    assert_eq!(c.evict(), 2, "exactly the two expired entries are swept");
+    let mut fired = drain(&l);
+    fired.sort_unstable();
+    assert_eq!(fired, vec![(1, 10), (2, 20)]);
+    assert_eq!(c.key_order(), vec![5, 4, 3]);
+
+    c.retain(|k, _v| *k != 4);
+    assert_eq!(
+        c.key_order(),
+        vec![5, 3],
+        "retain must drop exactly the predicate's rejects and keep survivor order"
+    );
+    assert_eq!(c.cache_get(&3), Some(&30));
+    assert_eq!(c.cache_get(&5), Some(&50));
+    assert_eq!(c.cache_get(&4), None);
+}
+
+// Capacity eviction under collisions still picks the LRU victim.
+#[test]
+fn capacity_eviction_under_hash_collisions_evicts_the_lru_entry() {
+    let l = log();
+    let mut c = collide_cache(2, Duration::from_secs(60), l.clone());
+    c.cache_set(1, 10);
+    c.cache_set(2, 20);
+    assert_eq!(c.cache_get(&1), Some(&10)); // 2 becomes the LRU
+    c.cache_set(3, 30);
+
+    assert_eq!(drain(&l), vec![(2, 20)], "the LRU entry must be the victim");
+    assert_eq!(c.cache_size(), 2);
+    assert_eq!(c.key_order(), vec![3, 1]);
+}
+
+// A real (non-degenerate, non-default) custom hasher end to end: `LruTtlCache`
+// had no custom-hasher coverage at all before this file.
+#[test]
+fn custom_fnv_hasher_lru_ttl_end_to_end() {
+    let l: Log<String, u32> = log();
+    let l2 = l.clone();
+    let mut c = LruTtlCache::<String, u32>::builder()
+        .max_size(3)
+        .ttl(TTL)
+        .hasher(FnvBuildHasher)
+        .on_evict(move |k: &String, v: &u32| {
+            l2.lock()
+                .expect("on_evict log poisoned")
+                .push((k.clone(), *v))
+        })
+        .build()
+        .expect("build LruTtlCache with FnvBuildHasher");
+
+    c.cache_set("a".to_string(), 1);
+    c.cache_set("b".to_string(), 2);
+    c.cache_set("c".to_string(), 3);
+    assert_eq!(c.cache_get("a"), Some(&1));
+    assert_eq!(c.cache_get("b"), Some(&2));
+    assert_eq!(c.cache_get("c"), Some(&3));
+    assert_eq!(c.cache_get("absent"), None);
+    assert_eq!(c.cache_peek("a"), Some(&1));
+    assert_eq!(c.cache_peek_with_expiry_status("a"), (Some(1), false));
+
+    // Capacity eviction: after the reads above the LRU is "a".
+    c.cache_set("d".to_string(), 4);
+    assert_eq!(drain(&l), vec![("a".to_string(), 1)]);
+    assert_eq!(c.cache_size(), 3);
+
+    // Expiry + lazy sweep under the custom hasher.
+    std::thread::sleep(PAST_TTL);
+    assert_eq!(c.cache_get("b"), None, "expired under the custom hasher");
+    assert_eq!(c.cache_size(), 2);
+    assert_eq!(c.evict(), 2, "the rest expire too");
+    assert_eq!(c.cache_size(), 0);
+    assert_eq!(
+        drain(&l).len(),
+        4,
+        "one callback per removed entry: 1 capacity + 1 lazy + 2 swept"
+    );
+
+    // Still usable afterwards.
+    c.cache_set("e".to_string(), 5);
+    assert_eq!(c.cache_get("e"), Some(&5));
+}
+
+// =============================================================================
+// CHANGE 2 -- `drain_all`-backed clearing.
+// =============================================================================
+
+// `drain_all` clears the hash table wholesale and walks the LRU chain: it must
+// perform ZERO hashing. A key-by-key drain would hash once per entry.
+#[test]
+fn cache_clear_with_on_evict_performs_no_hashing() {
+    let (hasher, built) = CountingBuildHasher::new();
+    let fired = Arc::new(AtomicUsize::new(0));
+    let fired2 = fired.clone();
+    let mut c = LruTtlCache::<u32, u32>::builder()
+        .max_size(16)
+        .ttl(Duration::from_secs(60))
+        .hasher(hasher)
+        .on_evict(move |_k: &u32, _v: &u32| {
+            fired2.fetch_add(1, Ordering::Relaxed);
+        })
+        .build()
+        .expect("build LruTtlCache with a counting hasher");
+    for i in 0..8u32 {
+        c.cache_set(i, i * 10);
+    }
+
+    built.store(0, Ordering::Relaxed);
+    c.cache_clear_with_on_evict();
+    assert_eq!(
+        built.load(Ordering::Relaxed),
+        0,
+        "drain_all must not hash any key"
+    );
+    assert_eq!(fired.load(Ordering::Relaxed), 8, "one callback per entry");
+    assert_eq!(c.cache_size(), 0);
+}
+
+// Every entry fires exactly once with its own key and value, even when the LRU
+// slab already has holes from capacity evictions, and the counters agree.
+#[test]
+fn cache_clear_with_on_evict_fires_once_per_entry_after_capacity_evictions() {
+    let l = log();
+    let mut c = logging_cache(3, Duration::from_secs(60), l.clone());
+    for i in 1..=5u32 {
+        c.cache_set(i, i * 10);
+    }
+    // Capacity 3: inserting 4 and 5 evicted 1 and 2 (recording two firings and
+    // two evictions), leaving slab holes for the drain to walk over.
+    assert_eq!(drain(&l), vec![(1, 10), (2, 20)]);
+    assert_eq!(c.cache_size(), 3);
+    assert_eq!(c.cache_evictions(), Some(2));
+
+    c.cache_clear_with_on_evict();
+
+    assert_eq!(
+        drain(&l),
+        vec![(1, 10), (2, 20), (5, 50), (4, 40), (3, 30)],
+        "the drain must fire once per surviving entry, MRU -> LRU, with correct keys/values"
+    );
+    let m = c.metrics();
+    assert_eq!(m.entry_count, Some(0), "no entries left");
+    assert_eq!(
+        m.evictions,
+        Some(5),
+        "2 capacity evictions + 3 drained entries"
+    );
+    assert_eq!(m.capacity, Some(3), "capacity is unchanged by a clear");
+    assert_eq!(c.key_order(), Vec::<u32>::new());
+    assert_eq!(CachedIter::iter(&c).count(), 0);
+}
+
+// Zero-entry boundary: the drain of an empty cache must fire nothing and must
+// not touch the eviction counter (the `count > 0` guard).
+#[test]
+fn cache_clear_with_on_evict_on_an_empty_cache_fires_nothing() {
+    let l = log();
+    let mut c = logging_cache(4, Duration::from_secs(60), l.clone());
+
+    c.cache_clear_with_on_evict();
+    assert_eq!(drain(&l), Vec::new(), "nothing to evict");
+    assert_eq!(c.cache_evictions(), Some(0));
+    assert_eq!(c.cache_size(), 0);
+
+    // Fill, drain, then drain again: the second drain is also a no-op.
+    c.cache_set(1, 10);
+    c.cache_set(2, 20);
+    c.cache_clear_with_on_evict();
+    assert_eq!(drain(&l), vec![(2, 20), (1, 10)]);
+    assert_eq!(c.cache_evictions(), Some(2));
+
+    c.cache_clear_with_on_evict();
+    assert_eq!(
+        drain(&l),
+        vec![(2, 20), (1, 10)],
+        "a second drain of an empty cache must fire nothing"
+    );
+    assert_eq!(
+        c.cache_evictions(),
+        Some(2),
+        "and must not move the eviction counter"
+    );
+
+    // The cache is still fully functional after the empty drains.
+    c.cache_set(3, 30);
+    assert_eq!(c.cache_get(&3), Some(&30));
+    assert_eq!(c.cache_size(), 1);
+}
+
+// Under collisions the drain still yields every entry exactly once (the table is
+// cleared wholesale, so a bucket chain must not swallow entries).
+#[test]
+fn cache_clear_with_on_evict_under_hash_collisions_drains_every_entry_once() {
+    let l = log();
+    let mut c = collide_cache(8, Duration::from_secs(60), l.clone());
+    for i in 1..=6u32 {
+        c.cache_set(i, i * 10);
+    }
+
+    c.cache_clear_with_on_evict();
+    assert_eq!(
+        drain(&l),
+        vec![(6, 60), (5, 50), (4, 40), (3, 30), (2, 20), (1, 10)],
+        "every colliding entry drains exactly once, MRU -> LRU"
+    );
+    assert_eq!(c.cache_size(), 0);
+    assert_eq!(c.cache_evictions(), Some(6));
+
+    // Reusable, and the hash table really was emptied (no stale bucket entries).
+    c.cache_set(1, 111);
+    assert_eq!(c.cache_get(&1), Some(&111));
+    assert_eq!(c.cache_size(), 1);
+}
+
+// =============================================================================
+// CHANGE 1 -- one clock sample per call, threaded through.
+// =============================================================================
+
+// The eager collectors hoist ONE clock reading for the whole pass. A slow `Clone`
+// stretches the pass past a later entry's expiry: with a per-entry clock read the
+// entry judged last would be dropped from the view.
+#[test]
+fn iter_order_judges_every_entry_against_one_pass_start_snapshot() {
+    let mut c: LruTtlCache<u32, SlowClone> = LruTtlCache::new(4, SNAPSHOT_TTL);
+    c.cache_set(1, SlowClone { id: 1, slow: false });
+    c.cache_set(
+        2,
+        SlowClone {
+            id: 2,
+            slow: true, // cloning entry 2 outlasts entry 1's ttl
+        },
+    );
+
+    // MRU -> LRU is 2, 1: entry 1 is judged only after entry 2's slow clone.
+    let ordered = c.iter_order();
+    assert_eq!(
+        ordered.iter().map(|(k, _)| *k).collect::<Vec<_>>(),
+        vec![2, 1],
+        "an entry live at the start of the pass must stay in the view for the whole pass"
+    );
+    assert_eq!(ordered[1].1.id, 1, "the value must travel with its key");
+}
+
+#[test]
+fn value_order_judges_every_entry_against_one_pass_start_snapshot() {
+    let mut c: LruTtlCache<u32, SlowClone> = LruTtlCache::new(4, SNAPSHOT_TTL);
+    c.cache_set(1, SlowClone { id: 1, slow: false });
+    c.cache_set(2, SlowClone { id: 2, slow: true });
+
+    let vals = c.value_order();
+    assert_eq!(
+        vals.iter().map(|v| v.id).collect::<Vec<_>>(),
+        vec![2, 1],
+        "value_order must apply one pass-start snapshot to every entry"
+    );
+}
+
+#[test]
+fn key_order_judges_every_entry_against_one_pass_start_snapshot() {
+    let mut c: LruTtlCache<SlowKey, u32> = LruTtlCache::new(4, SNAPSHOT_TTL);
+    c.cache_set(SlowKey { id: 1, slow: false }, 10);
+    c.cache_set(SlowKey { id: 2, slow: true }, 20);
+
+    let keys = c.key_order();
+    assert_eq!(
+        keys.iter().map(|k| k.id).collect::<Vec<_>>(),
+        vec![2, 1],
+        "key_order must apply one pass-start snapshot to every entry"
+    );
+}
+
+// The lazy `iter()` deliberately does the OPPOSITE: it reads the clock per item,
+// so an entry that expires while the iterator is parked must not be yielded.
+#[test]
+fn lazy_iter_drops_entries_that_expire_mid_iteration() {
+    let mut c: LruTtlCache<u32, u32> = LruTtlCache::new(4, TTL);
+    c.cache_set(1, 10);
+    c.cache_set(2, 20);
+
+    let mut it = CachedIter::iter(&c);
+    assert_eq!(it.next(), Some((&2, &20)), "MRU first, still live");
+    std::thread::sleep(PAST_TTL);
+    assert_eq!(
+        it.next(),
+        None,
+        "an entry that expires while the lazy iterator is parked must not be yielded"
+    );
+}
+
+#[test]
+fn lazy_iter_yields_every_live_entry() {
+    let mut c: LruTtlCache<u32, u32> = LruTtlCache::new(4, Duration::from_secs(60));
+    c.cache_set(1, 10);
+    c.cache_set(2, 20);
+    c.cache_set(3, 30);
+    let seen: Vec<(u32, u32)> = CachedIter::iter(&c).map(|(k, v)| (*k, *v)).collect();
+    assert_eq!(seen, vec![(3, 30), (2, 20), (1, 10)]);
+}
+
+// `retain` must not consult the predicate for already-expired entries: they are
+// removed on the expiry test alone (and the predicate is a `FnMut` that may have
+// side effects, so calling it extra times is observable).
+#[test]
+fn retain_never_consults_the_predicate_for_expired_entries() {
+    let l = log();
+    let mut c = logging_cache(8, TTL, l.clone());
+    c.cache_set(1, 10); // doomed
+    c.cache_set(2, 20); // doomed
+    std::thread::sleep(PAST_TTL);
+    c.cache_set(3, 30);
+    c.cache_set(4, 40);
+
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let seen2 = seen.clone();
+    c.retain(move |k, v| {
+        seen2.lock().expect("predicate log poisoned").push((*k, *v));
+        *k != 4
+    });
+
+    assert_eq!(
+        seen.lock().expect("predicate log poisoned").clone(),
+        vec![(4, 40), (3, 30)],
+        "the predicate must see only the live entries, MRU -> LRU"
+    );
+    assert_eq!(c.key_order(), vec![3]);
+    assert_eq!(
+        drain(&l),
+        vec![(4, 40), (2, 20), (1, 10)],
+        "on_evict fires MRU -> LRU for both the predicate's rejects and the expired entries"
+    );
+    assert_eq!(
+        c.cache_evictions(),
+        Some(3),
+        "2 expired + 1 predicate reject"
+    );
+}
+
+// Zero-removed and all-removed sweeps: the pre-sized collectors must produce the
+// same results at both extremes.
+#[test]
+fn evict_and_retain_at_the_zero_and_all_extremes() {
+    let l = log();
+    let mut c = logging_cache(8, Duration::from_secs(60), l.clone());
+    for i in 1..=4u32 {
+        c.cache_set(i, i * 10);
+    }
+
+    assert_eq!(c.evict(), 0, "nothing is expired");
+    assert_eq!(drain(&l), Vec::new());
+    assert_eq!(c.key_order(), vec![4, 3, 2, 1], "order untouched");
+    assert_eq!(c.cache_evictions(), Some(0));
+
+    c.retain(|_k, _v| true);
+    assert_eq!(
+        c.key_order(),
+        vec![4, 3, 2, 1],
+        "retain-all removes nothing"
+    );
+    assert_eq!(c.cache_evictions(), Some(0));
+
+    c.retain(|_k, _v| false);
+    assert_eq!(
+        drain(&l),
+        vec![(4, 40), (3, 30), (2, 20), (1, 10)],
+        "retain-none removes everything, MRU -> LRU"
+    );
+    assert_eq!(c.cache_size(), 0);
+    assert_eq!(c.cache_evictions(), Some(4));
+    assert_eq!(c.evict(), 0, "an empty cache sweeps nothing");
+
+    // Still usable, and the collectors agree on the empty cache.
+    assert_eq!(c.key_order(), Vec::<u32>::new());
+    assert!(c.iter_order().is_empty());
+    assert!(c.value_order().is_empty());
+    c.cache_set(9, 90);
+    assert_eq!(c.cache_get(&9), Some(&90));
+}
+
+#[test]
+fn evict_removes_every_entry_when_all_have_expired() {
+    let l = log();
+    let mut c = logging_cache(8, TTL, l.clone());
+    for i in 1..=4u32 {
+        c.cache_set(i, i * 10);
+    }
+    std::thread::sleep(PAST_TTL);
+
+    // The collectors filter all of them out while they are still stored.
+    assert_eq!(c.cache_size(), 4, "len is the RAW stored count");
+    assert!(c.key_order().is_empty());
+    assert!(c.iter_order().is_empty());
+    assert!(c.value_order().is_empty());
+    assert_eq!(CachedIter::iter(&c).count(), 0);
+
+    assert_eq!(c.evict(), 4);
+    assert_eq!(
+        drain(&l),
+        vec![(4, 40), (3, 30), (2, 20), (1, 10)],
+        "one callback per swept entry, MRU -> LRU, with correct values"
+    );
+    let m = c.metrics();
+    assert_eq!(m.entry_count, Some(0));
+    assert_eq!(m.evictions, Some(4));
+}
+
+// `refresh_on_hit` with expiry disabled: `compute_expires_at` yields `None`, and
+// the code falls back to the entry's EXISTING expiry. Dropping that fallback
+// would silently make refreshed entries immortal.
+#[test]
+fn refresh_on_hit_with_a_disabled_ttl_keeps_the_original_expiry() {
+    // One case per converted refresh site.
+    #[allow(clippy::type_complexity)]
+    let sites: Vec<(&str, Box<dyn Fn(&mut LruTtlCache<u32, u32>)>)> = vec![
+        (
+            "cache_get",
+            Box::new(|c: &mut LruTtlCache<u32, u32>| {
+                assert_eq!(c.cache_get(&1), Some(&10));
+            }),
+        ),
+        (
+            "cache_get_mut",
+            Box::new(|c: &mut LruTtlCache<u32, u32>| {
+                assert_eq!(c.cache_get_mut(&1), Some(&mut 10));
+            }),
+        ),
+        (
+            "cache_get_or_set_with",
+            Box::new(|c: &mut LruTtlCache<u32, u32>| {
+                assert_eq!(*c.cache_get_or_set_with(1, || 999), 10);
+            }),
+        ),
+        (
+            "cache_try_get_or_set_with",
+            Box::new(|c: &mut LruTtlCache<u32, u32>| {
+                assert_eq!(
+                    c.cache_try_get_or_set_with(1, || Ok::<u32, ()>(999))
+                        .copied(),
+                    Ok(10)
+                );
+            }),
+        ),
+        (
+            "cache_get_with_expiry_status",
+            Box::new(|c: &mut LruTtlCache<u32, u32>| {
+                assert_eq!(c.cache_get_with_expiry_status(&1), (Some(10), false));
+            }),
+        ),
+    ];
+
+    for (name, hit) in sites {
+        let mut c: LruTtlCache<u32, u32> = LruTtlCache::builder()
+            .max_size(4)
+            .ttl(TTL)
+            .refresh_on_hit(true)
+            .build()
+            .expect("build refreshing LruTtlCache");
+        c.cache_set(1, 10);
+        // Disable expiry for FUTURE inserts; the stored entry keeps its deadline.
+        assert_eq!(c.unset_ttl(), Some(TTL));
+
+        hit(&mut c);
+
+        std::thread::sleep(PAST_TTL);
+        assert_eq!(
+            c.cache_peek(&1),
+            None,
+            "{name}: a refresh under a disabled ttl must keep the original expiry, not make the entry immortal"
+        );
+    }
+}
+
+// The complement: with a live ttl, repeated hits keep pushing the deadline out,
+// so the entry outlives an interval far longer than the ttl.
+#[test]
+fn refresh_on_hit_keeps_an_entry_alive_across_repeated_hits() {
+    let mut c: LruTtlCache<u32, u32> = LruTtlCache::builder()
+        .max_size(4)
+        .ttl(TTL)
+        .refresh_on_hit(true)
+        .build()
+        .expect("build refreshing LruTtlCache");
+    c.cache_set(1, 10);
+    // Total elapsed (5 * 100ms) far exceeds the 150ms ttl.
+    for _ in 0..5 {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        assert_eq!(c.cache_get(&1), Some(&10), "each hit must renew the ttl");
+    }
+    std::thread::sleep(PAST_TTL);
+    assert_eq!(c.cache_get(&1), None, "and it must still expire once idle");
+}
+
+// `cache_set` judges the DISPLACED entry against the same clock sample that
+// produced the new entry's expiry. The displaced-live and displaced-expired arms
+// must keep their distinct return/accounting behaviour.
+#[test]
+fn cache_set_displacement_accounting_across_the_expiry_boundary() {
+    let l = log();
+    let mut c = logging_cache(4, TTL, l.clone());
+    c.cache_set(1, 10);
+    assert_eq!(
+        c.cache_set(1, 11),
+        Some(10),
+        "displacing a live entry returns it"
+    );
+    assert_eq!(drain(&l), Vec::new(), "and fires no callback");
+    assert_eq!(c.cache_evictions(), Some(0));
+
+    std::thread::sleep(PAST_TTL);
+    assert_eq!(
+        c.cache_set(1, 12),
+        None,
+        "displacing an expired entry filters the old value"
+    );
+    assert_eq!(
+        drain(&l),
+        vec![(1, 11)],
+        "and fires on_evict with the displaced value"
+    );
+    assert_eq!(c.cache_evictions(), Some(1));
+    assert_eq!(c.cache_get(&1), Some(&12), "the new value is live");
+}
+
+// The `get_or_set` family replaces an expired entry: the callback must see the
+// STORED key/value of the displaced entry, and the factory must run.
+#[test]
+fn get_or_set_family_replacing_an_expired_entry_fires_on_evict_once() {
+    let l = log();
+    let mut c = logging_cache(4, TTL, l.clone());
+    c.cache_set(1, 10);
+    std::thread::sleep(PAST_TTL);
+
+    let ran = Arc::new(AtomicUsize::new(0));
+    let ran2 = ran.clone();
+    assert_eq!(
+        *c.cache_get_or_set_with(1, move || {
+            ran2.fetch_add(1, Ordering::Relaxed);
+            111
+        }),
+        111
+    );
+    assert_eq!(ran.load(Ordering::Relaxed), 1, "the factory must run");
+    assert_eq!(drain(&l), vec![(1, 10)], "the displaced entry is evicted");
+    assert_eq!(c.cache_evictions(), Some(1));
+
+    // Same for the fallible variant.
+    c.cache_set(2, 20);
+    std::thread::sleep(PAST_TTL);
+    assert_eq!(
+        c.cache_try_get_or_set_with(2, || Ok::<u32, ()>(222))
+            .copied(),
+        Ok(222)
+    );
+    assert_eq!(drain(&l), vec![(1, 10), (2, 20)]);
+
+    // A failing factory over an expired entry: the store keeps whatever it had,
+    // and the error propagates.
+    c.cache_set(3, 30);
+    std::thread::sleep(PAST_TTL);
+    assert_eq!(
+        c.cache_try_get_or_set_with(3, || Err::<u32, &str>("boom")),
+        Err("boom")
+    );
+}
+
+// =============================================================================
+// Miss accounting on the fallible `get_or_set` error path.
+//
+// A lookup that did not find a live entry is a MISS regardless of whether the
+// initializer then fails: the store was consulted, nothing usable was found, and
+// the caller had to compute. Every other store in the crate counts it that way --
+// `UnboundCache` (unbound.rs), `LruCache` (lru.rs), `TtlCache` (ttl.rs) and
+// `ExpiringLruCache` (expiring_lru.rs) all increment `misses` BEFORE running the
+// factory. `LruTtlCache` counted it after, so an `Err` factory silently lost the
+// miss. Fixed by counting inside the setter, as `TtlCache` does.
+//
+// The eviction side is deliberately the opposite and must stay that way: on `Err`
+// the expired entry is still physically stored, so `on_evict` must NOT fire and
+// `evictions` must NOT move -- otherwise the next call that really does replace
+// the entry double-fires for the same physical entry.
+// =============================================================================
+
+#[test]
+fn try_get_or_set_with_counts_a_miss_when_the_factory_fails_on_an_absent_key() {
+    let mut c: LruTtlCache<u32, u32> = LruTtlCache::new(4, Duration::from_secs(60));
+
+    assert_eq!(
+        c.cache_try_get_or_set_with(1, || Err::<u32, &str>("boom")),
+        Err("boom")
+    );
+    assert_eq!(
+        c.cache_misses(),
+        Some(1),
+        "an absent-key lookup is a miss even when the factory fails"
+    );
+    assert_eq!(c.cache_hits(), Some(0));
+    assert_eq!(c.cache_size(), 0, "a failed factory must store nothing");
+    assert_eq!(c.cache_evictions(), Some(0));
+
+    // The retry that succeeds counts a second, separate miss.
+    assert_eq!(
+        c.cache_try_get_or_set_with(1, || Ok::<u32, &str>(10))
+            .copied(),
+        Ok(10)
+    );
+    assert_eq!(c.cache_misses(), Some(2));
+    assert_eq!(c.cache_hits(), Some(0));
+}
+
+#[test]
+fn try_get_or_set_with_counts_a_miss_when_the_factory_fails_over_an_expired_entry() {
+    let l = log();
+    let mut c = logging_cache(4, TTL, l.clone());
+    c.cache_set(1, 10);
+    std::thread::sleep(PAST_TTL);
+    c.cache_reset_metrics();
+
+    assert_eq!(
+        c.cache_try_get_or_set_with(1, || Err::<u32, &str>("boom")),
+        Err("boom")
+    );
+    assert_eq!(
+        c.cache_misses(),
+        Some(1),
+        "finding only an expired entry is a miss even when the factory fails"
+    );
+    assert_eq!(c.cache_hits(), Some(0));
+    // ... but the entry is still physically stored, so nothing was evicted yet.
+    assert_eq!(
+        drain(&l),
+        Vec::new(),
+        "on_evict must not fire while the expired entry is still stored"
+    );
+    assert_eq!(c.cache_evictions(), Some(0));
+    assert_eq!(c.cache_size(), 1, "the expired entry is left in place");
+
+    // The later call that really replaces it fires on_evict exactly once, for the
+    // one physical entry: no double-fire from the earlier failure.
+    assert_eq!(
+        c.cache_try_get_or_set_with(1, || Ok::<u32, &str>(11))
+            .copied(),
+        Ok(11)
+    );
+    assert_eq!(drain(&l), vec![(1, 10)], "exactly one eviction, once");
+    assert_eq!(c.cache_evictions(), Some(1));
+    assert_eq!(c.cache_misses(), Some(2), "the replacement is a miss too");
+}
+
+#[test]
+fn try_get_or_set_with_counts_a_hit_and_skips_the_factory_on_a_live_entry() {
+    // The complement: a live entry must not be turned into a miss by the fix.
+    let mut c: LruTtlCache<u32, u32> = LruTtlCache::new(4, Duration::from_secs(60));
+    c.cache_set(1, 10);
+    c.cache_reset_metrics();
+
+    let ran = Arc::new(AtomicUsize::new(0));
+    let ran2 = ran.clone();
+    assert_eq!(
+        c.cache_try_get_or_set_with(1, move || {
+            ran2.fetch_add(1, Ordering::Relaxed);
+            Err::<u32, &str>("boom")
+        })
+        .copied(),
+        Ok(10)
+    );
+    assert_eq!(ran.load(Ordering::Relaxed), 0, "the factory must not run");
+    assert_eq!(c.cache_hits(), Some(1));
+    assert_eq!(c.cache_misses(), Some(0));
+}
+
+// The infallible sibling must keep counting exactly one miss per replacement, so
+// moving the counter into the setter cannot double-count.
+#[test]
+fn get_or_set_with_counts_exactly_one_miss_per_replacement() {
+    let mut c: LruTtlCache<u32, u32> = LruTtlCache::new(4, TTL);
+    assert_eq!(*c.cache_get_or_set_with(1, || 10), 10);
+    assert_eq!(c.cache_misses(), Some(1), "absent key: one miss");
+    assert_eq!(*c.cache_get_or_set_with(1, || 99), 10);
+    assert_eq!(c.cache_misses(), Some(1), "live hit: no new miss");
+    assert_eq!(c.cache_hits(), Some(1));
+
+    std::thread::sleep(PAST_TTL);
+    assert_eq!(*c.cache_get_or_set_with(1, || 11), 11);
+    assert_eq!(c.cache_misses(), Some(2), "expired replacement: one miss");
+    assert_eq!(c.cache_hits(), Some(1));
+}
+
+#[cfg(feature = "async")]
+#[tokio::test]
+async fn async_try_get_or_set_with_counts_a_miss_when_the_factory_fails() {
+    use cached::CachedGetOrSetAsync;
+
+    let l = log();
+    let mut c = logging_cache(4, TTL, l.clone());
+
+    // Absent key.
+    assert_eq!(
+        CachedGetOrSetAsync::async_cache_try_get_or_set_with(&mut c, 1, || async {
+            Err::<u32, &str>("boom")
+        })
+        .await,
+        Err("boom")
+    );
+    assert_eq!(
+        c.cache_misses(),
+        Some(1),
+        "an absent-key lookup is a miss even when the async factory fails"
+    );
+    assert_eq!(c.cache_size(), 0);
+
+    // Expired entry.
+    c.cache_set(2, 20);
+    std::thread::sleep(PAST_TTL);
+    c.cache_reset_metrics();
+    assert_eq!(
+        CachedGetOrSetAsync::async_cache_try_get_or_set_with(&mut c, 2, || async {
+            Err::<u32, &str>("boom")
+        })
+        .await,
+        Err("boom")
+    );
+    assert_eq!(
+        c.cache_misses(),
+        Some(1),
+        "finding only an expired entry is a miss even when the async factory fails"
+    );
+    assert_eq!(
+        drain(&l),
+        Vec::new(),
+        "the expired entry is still stored, so nothing was evicted"
+    );
+    assert_eq!(c.cache_evictions(), Some(0));
+
+    // A live entry is still a hit, and the factory does not run.
+    c.cache_set(3, 30);
+    c.cache_reset_metrics();
+    let v = CachedGetOrSetAsync::async_cache_try_get_or_set_with(&mut c, 3, || async {
+        Err::<u32, &str>("boom")
+    })
+    .await;
+    assert_eq!(v.copied(), Ok(30));
+    assert_eq!(c.cache_hits(), Some(1));
+    assert_eq!(c.cache_misses(), Some(0));
+}

--- a/tests/v3_cert_lru_ttl_perf.rs
+++ b/tests/v3_cert_lru_ttl_perf.rs
@@ -898,21 +898,38 @@ fn refresh_on_hit_with_a_disabled_ttl_keeps_the_original_expiry() {
 
 // The complement: with a live ttl, repeated hits keep pushing the deadline out,
 // so the entry outlives an interval far longer than the ttl.
+//
+// This uses its own local ttl/interval, deliberately NOT the file-wide `TTL`
+// (150ms): with a 100ms inter-hit sleep, `TTL` left only a ~50ms scheduling
+// margin before an unrenewed entry would expire, so a >50ms stall under CI load
+// flipped the "each hit must renew the ttl" assertion spuriously. The interval
+// below leaves a much wider per-hit margin while the total time across all hits
+// still comfortably exceeds the ttl, so an entry that silently stopped being
+// renewed is still caught -- only the deliberately-past-expiry sleep at the end
+// decides the final, idle-expiry assertion.
 #[test]
 fn refresh_on_hit_keeps_an_entry_alive_across_repeated_hits() {
+    const RENEWAL_TTL: Duration = Duration::from_secs(1);
+    const HIT_INTERVAL: std::time::Duration = std::time::Duration::from_millis(300);
+    const IDLE_PAST_TTL: std::time::Duration = std::time::Duration::from_millis(1500);
+
     let mut c: LruTtlCache<u32, u32> = LruTtlCache::builder()
         .max_size(4)
-        .ttl(TTL)
+        .ttl(RENEWAL_TTL)
         .refresh_on_hit(true)
         .build()
         .expect("build refreshing LruTtlCache");
     c.cache_set(1, 10);
-    // Total elapsed (5 * 100ms) far exceeds the 150ms ttl.
-    for _ in 0..5 {
-        std::thread::sleep(std::time::Duration::from_millis(100));
+    // Six hits at 300ms apart: each single interval is well under the 1s ttl (a
+    // large scheduling stall would have to eat ~700ms before it could flip a hit
+    // to a spurious expiry), but the 1.8s total across all six hits comfortably
+    // exceeds the ttl -- so an entry that is NOT refreshed on each hit would
+    // already be gone well before the last iteration.
+    for _ in 0..6 {
+        std::thread::sleep(HIT_INTERVAL);
         assert_eq!(c.cache_get(&1), Some(&10), "each hit must renew the ttl");
     }
-    std::thread::sleep(PAST_TTL);
+    std::thread::sleep(IDLE_PAST_TTL);
     assert_eq!(c.cache_get(&1), None, "and it must still expire once idle");
 }
 
@@ -1167,4 +1184,166 @@ async fn async_try_get_or_set_with_counts_a_miss_when_the_factory_fails() {
     assert_eq!(v.copied(), Ok(30));
     assert_eq!(c.cache_hits(), Some(1));
     assert_eq!(c.cache_misses(), Some(0));
+}
+
+// =============================================================================
+// The `_mut` methods directly (EXP-2 pin).
+//
+// The tests above drive the contract through the shared-reference wrapper
+// (`cache_try_get_or_set_with` / `async_cache_try_get_or_set_with`), which is a
+// provided default that delegates straight to the `_mut` method
+// (`Cached::cache_try_get_or_set_with`, `CachedGetOrSetAsync::async_cache_try_get_or_set_with`
+// in src/lib.rs). `LruTtlCache` itself only implements the `_mut` variants
+// (src/stores/lru_ttl.rs:778 sync, :1118 async), so calling the `_mut` methods
+// below exercises the exact code the store owns, with no indirection through a
+// default method that a future change could alter independently. Same
+// contract, named explicitly: on `Err`, exactly one miss, no `on_evict`, no
+// eviction, and no entry inserted -- for both an absent key and an expired one.
+// =============================================================================
+
+#[test]
+fn try_get_or_set_with_mut_counts_a_miss_and_inserts_nothing_when_the_factory_fails_on_an_absent_key(
+) {
+    let l = log();
+    let mut c = logging_cache(4, Duration::from_secs(60), l.clone());
+
+    assert_eq!(
+        c.cache_try_get_or_set_with_mut(1, || Err::<u32, &str>("boom")),
+        Err("boom")
+    );
+    assert_eq!(
+        c.cache_misses(),
+        Some(1),
+        "an absent-key lookup through cache_try_get_or_set_with_mut is a miss even when the factory fails"
+    );
+    assert_eq!(c.cache_hits(), Some(0));
+    assert_eq!(c.cache_size(), 0, "a failed factory must insert nothing");
+    assert_eq!(drain(&l), Vec::new(), "on_evict must not fire");
+    assert_eq!(c.cache_evictions(), Some(0));
+
+    // A second failing call over the same still-absent key counts a second,
+    // separate miss: the first failure must not have left anything behind.
+    assert_eq!(
+        c.cache_try_get_or_set_with_mut(1, || Err::<u32, &str>("boom again")),
+        Err("boom again")
+    );
+    assert_eq!(c.cache_misses(), Some(2));
+    assert_eq!(c.cache_size(), 0);
+}
+
+#[test]
+fn try_get_or_set_with_mut_counts_a_miss_and_inserts_nothing_when_the_factory_fails_over_an_expired_entry(
+) {
+    let l = log();
+    let mut c = logging_cache(4, TTL, l.clone());
+    c.cache_set(1, 10);
+    std::thread::sleep(PAST_TTL);
+    c.cache_reset_metrics();
+
+    assert_eq!(
+        c.cache_try_get_or_set_with_mut(1, || Err::<u32, &str>("boom")),
+        Err("boom")
+    );
+    assert_eq!(
+        c.cache_misses(),
+        Some(1),
+        "finding only an expired entry through cache_try_get_or_set_with_mut is a miss even when the factory fails"
+    );
+    assert_eq!(c.cache_hits(), Some(0));
+    assert_eq!(
+        drain(&l),
+        Vec::new(),
+        "on_evict must not fire while the expired entry is still stored"
+    );
+    assert_eq!(c.cache_evictions(), Some(0));
+    assert_eq!(
+        c.cache_size(),
+        1,
+        "the expired entry is left in place, not replaced by a failed factory"
+    );
+
+    // A later call that really succeeds fires on_evict exactly once, for the one
+    // physical entry: no double-fire from the earlier failure.
+    assert_eq!(
+        c.cache_try_get_or_set_with_mut(1, || Ok::<u32, &str>(11)),
+        Ok(&mut 11)
+    );
+    assert_eq!(drain(&l), vec![(1, 10)], "exactly one eviction, once");
+    assert_eq!(c.cache_evictions(), Some(1));
+    assert_eq!(c.cache_misses(), Some(2), "the replacement is a miss too");
+}
+
+#[cfg(feature = "async")]
+#[tokio::test]
+async fn async_try_get_or_set_with_mut_counts_a_miss_and_inserts_nothing_when_the_factory_fails() {
+    use cached::CachedGetOrSetAsync;
+
+    let l = log();
+    let mut c = logging_cache(4, TTL, l.clone());
+
+    // Absent key.
+    assert_eq!(
+        CachedGetOrSetAsync::async_cache_try_get_or_set_with_mut(&mut c, 1, || async {
+            Err::<u32, &str>("boom")
+        })
+        .await,
+        Err("boom")
+    );
+    assert_eq!(
+        c.cache_misses(),
+        Some(1),
+        "an absent-key lookup through async_cache_try_get_or_set_with_mut is a miss even when the factory fails"
+    );
+    assert_eq!(c.cache_size(), 0, "a failed factory must insert nothing");
+    assert_eq!(drain(&l), Vec::new());
+    assert_eq!(c.cache_evictions(), Some(0));
+
+    // Expired entry.
+    c.cache_set(2, 20);
+    std::thread::sleep(PAST_TTL);
+    c.cache_reset_metrics();
+    assert_eq!(
+        CachedGetOrSetAsync::async_cache_try_get_or_set_with_mut(&mut c, 2, || async {
+            Err::<u32, &str>("boom")
+        })
+        .await,
+        Err("boom")
+    );
+    assert_eq!(
+        c.cache_misses(),
+        Some(1),
+        "finding only an expired entry through async_cache_try_get_or_set_with_mut is a miss even when the factory fails"
+    );
+    assert_eq!(
+        drain(&l),
+        Vec::new(),
+        "the expired entry is still stored, so on_evict must not fire"
+    );
+    assert_eq!(c.cache_evictions(), Some(0));
+    assert_eq!(
+        c.cache_size(),
+        1,
+        "only the expired key-2 entry is stored; key 1's absent-key attempt inserted nothing"
+    );
+
+    // A live entry is still a hit, and the factory does not run.
+    c.cache_set(3, 30);
+    c.cache_reset_metrics();
+    let v = CachedGetOrSetAsync::async_cache_try_get_or_set_with_mut(&mut c, 3, || async {
+        Err::<u32, &str>("boom")
+    })
+    .await;
+    assert_eq!(v.copied(), Ok(30));
+    assert_eq!(c.cache_hits(), Some(1));
+    assert_eq!(c.cache_misses(), Some(0));
+
+    // The later call that really replaces the expired key-2 entry fires on_evict
+    // exactly once for it: no double-fire from the earlier failed attempt.
+    let v2 = CachedGetOrSetAsync::async_cache_try_get_or_set_with_mut(&mut c, 2, || async {
+        Ok::<u32, &str>(22)
+    })
+    .await;
+    assert_eq!(v2.copied(), Ok(22));
+    assert_eq!(drain(&l), vec![(2, 20)], "exactly one eviction, once");
+    assert_eq!(c.cache_evictions(), Some(1));
 }

--- a/tests/v3_cert_lru_ttl_perf.rs
+++ b/tests/v3_cert_lru_ttl_perf.rs
@@ -1202,8 +1202,8 @@ async fn async_try_get_or_set_with_counts_a_miss_when_the_factory_fails() {
 // =============================================================================
 
 #[test]
-fn try_get_or_set_with_mut_counts_a_miss_and_inserts_nothing_when_the_factory_fails_on_an_absent_key(
-) {
+fn try_get_or_set_with_mut_counts_a_miss_and_inserts_nothing_when_the_factory_fails_on_an_absent_key()
+ {
     let l = log();
     let mut c = logging_cache(4, Duration::from_secs(60), l.clone());
 
@@ -1232,8 +1232,8 @@ fn try_get_or_set_with_mut_counts_a_miss_and_inserts_nothing_when_the_factory_fa
 }
 
 #[test]
-fn try_get_or_set_with_mut_counts_a_miss_and_inserts_nothing_when_the_factory_fails_over_an_expired_entry(
-) {
+fn try_get_or_set_with_mut_counts_a_miss_and_inserts_nothing_when_the_factory_fails_over_an_expired_entry()
+ {
     let l = log();
     let mut c = logging_cache(4, TTL, l.clone());
     c.cache_set(1, 10);

--- a/tests/v3_cert_sharded_lru_clock_sample.rs
+++ b/tests/v3_cert_sharded_lru_clock_sample.rs
@@ -1,0 +1,248 @@
+/*!
+Certification: the pre-lock clock sample on the sharded LRU-family stores.
+
+`ShardedLruTtlCache::cache_get` / `cache_set` read the clock **once, before acquiring the
+shard write lock**, and every expiry decision (and the `expires_at` seeded on a write) is made
+against that sample. The observable consequence is deliberate and documented: a caller that
+queues behind the shard lock for longer than the TTL still judges the entry by the clock it
+read before it queued.
+
+These tests pin that deterministically instead of hoping for a race. `retain` is the only
+public API that runs caller code while a shard's write lock is held, so its predicate is used
+as a lock holder of a controlled duration; the reader/writer under test is released only after
+the TTL has already elapsed in real time.
+
+The contrast case is `ShardedExpiringLruCache`, which has no clock at all: liveness comes from
+`Expires::is_expired()`, evaluated on the stored value *under* the lock, so the same setup gives
+the opposite answer.
+
+No Redis server required.
+*/
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use cached::{ConcurrentCacheBase, ConcurrentCached, Expires, ShardedExpiringLruCache};
+
+/// TTL used by the LRU-TTL tests. Long enough that the sample the queued caller takes is
+/// comfortably inside the entry's lifetime even on a badly loaded machine.
+#[cfg(feature = "time_stores")]
+const TTL: Duration = Duration::from_millis(500);
+/// How long the lock holder keeps the shard's write lock. Must exceed `TTL` so the queued
+/// caller is released only after the entry has expired in real time.
+#[cfg(feature = "time_stores")]
+const HOLD: Duration = Duration::from_millis(1200);
+
+/// Spin until the lock-holder thread reports that it is inside `retain`'s predicate, i.e. the
+/// shard write lock is held. No sleeps are used for ordering.
+fn wait_for(flag: &AtomicBool) {
+    while !flag.load(Ordering::Acquire) {
+        std::hint::spin_loop();
+        std::thread::yield_now();
+    }
+}
+
+#[cfg(feature = "time_stores")]
+mod lru_ttl {
+    use super::*;
+    use cached::ShardedLruTtlCache;
+
+    /// A `cache_get` that samples the clock while the entry is live, then queues behind the
+    /// shard lock past the entry's expiry, is served the value as a live hit. The very next
+    /// `cache_get` (a fresh sample) sees the expiry and evicts.
+    ///
+    /// If the clock sample were moved back inside the critical section, the first read would
+    /// return `None` and this test would fail.
+    #[test]
+    fn cache_get_decides_expiry_on_the_clock_sampled_before_the_shard_lock() {
+        let evicted: Arc<Mutex<Vec<(u32, u32)>>> = Arc::new(Mutex::new(Vec::new()));
+        let evicted2 = Arc::clone(&evicted);
+        let store = ShardedLruTtlCache::<u32, u32>::builder()
+            .shards(1)
+            .per_shard_max_size(8)
+            .ttl(TTL)
+            .on_evict(move |k: &u32, v: &u32| evicted2.lock().unwrap().push((*k, *v)))
+            .build()
+            .expect("build ShardedLruTtlCache");
+        ConcurrentCached::cache_set(&store, 1, 10).unwrap();
+
+        let holding = Arc::new(AtomicBool::new(false));
+        let holding2 = Arc::clone(&holding);
+        let holder = std::thread::spawn({
+            let store = store.clone();
+            move || {
+                // `retain` runs `keep` under the shard write lock. Sampled at entry, key 1 is
+                // still live, so it is kept, not swept.
+                store.retain(move |_k, _v| {
+                    holding2.store(true, Ordering::Release);
+                    std::thread::sleep(HOLD);
+                    true
+                });
+            }
+        });
+        wait_for(&holding);
+
+        // Sampled now (well inside the TTL), served after `HOLD` (well past it).
+        let queued = ConcurrentCached::cache_get(&store, &1).unwrap();
+        holder.join().expect("lock holder must not panic");
+
+        assert_eq!(
+            queued,
+            Some(10),
+            "expiry must be judged against the clock read before the lock was acquired"
+        );
+        assert_eq!(
+            ConcurrentCacheBase::cache_hits(&store),
+            Some(1),
+            "the queued read counted a hit, not a miss"
+        );
+        assert!(
+            evicted.lock().unwrap().is_empty(),
+            "a read served as live must not evict"
+        );
+
+        // A fresh sample sees the expiry: miss, removal, one eviction, callback.
+        let before = store.metrics().evictions.expect("evictions tracked");
+        assert_eq!(ConcurrentCached::cache_get(&store, &1).unwrap(), None);
+        assert_eq!(
+            store.metrics().evictions.expect("evictions tracked") - before,
+            1
+        );
+        assert_eq!(*evicted.lock().unwrap(), vec![(1, 10)]);
+        assert_eq!(ConcurrentCacheBase::cache_size(&store).unwrap(), Some(0));
+    }
+
+    /// `cache_set` seeds `expires_at` from the same pre-lock sample, so a write that queues
+    /// behind the shard lock for longer than the TTL lands already expired. The entry is
+    /// really stored (the following read evicts it and fires `on_evict` with its value), it
+    /// is just dead on arrival.
+    ///
+    /// If the clock sample were taken after the lock, the entry would be live and the read
+    /// below would return `Some(20)`.
+    #[test]
+    fn cache_set_seeds_expiry_from_the_clock_sampled_before_the_shard_lock() {
+        let evicted: Arc<Mutex<Vec<(u32, u32)>>> = Arc::new(Mutex::new(Vec::new()));
+        let evicted2 = Arc::clone(&evicted);
+        let store = ShardedLruTtlCache::<u32, u32>::builder()
+            .shards(1)
+            .per_shard_max_size(8)
+            .ttl(TTL)
+            .on_evict(move |k: &u32, v: &u32| evicted2.lock().unwrap().push((*k, *v)))
+            .build()
+            .expect("build ShardedLruTtlCache");
+        ConcurrentCached::cache_set(&store, 1, 10).unwrap();
+
+        let holding = Arc::new(AtomicBool::new(false));
+        let holding2 = Arc::clone(&holding);
+        let holder = std::thread::spawn({
+            let store = store.clone();
+            move || {
+                store.retain(move |_k, _v| {
+                    holding2.store(true, Ordering::Release);
+                    std::thread::sleep(HOLD);
+                    true
+                });
+            }
+        });
+        wait_for(&holding);
+
+        assert_eq!(
+            ConcurrentCached::cache_set(&store, 2, 20).unwrap(),
+            None,
+            "fresh key: no displaced value"
+        );
+        holder.join().expect("lock holder must not panic");
+
+        assert_eq!(
+            ConcurrentCacheBase::cache_size(&store).unwrap(),
+            Some(2),
+            "the queued write must have stored the entry"
+        );
+        let before = store.metrics().evictions.expect("evictions tracked");
+        assert_eq!(
+            ConcurrentCached::cache_get(&store, &2).unwrap(),
+            None,
+            "the entry's expiry was seeded from the pre-lock sample, so it is already expired"
+        );
+        assert_eq!(
+            store.metrics().evictions.expect("evictions tracked") - before,
+            1,
+            "the already-expired entry must be removed and counted exactly once"
+        );
+        assert_eq!(
+            *evicted.lock().unwrap(),
+            vec![(2, 20)],
+            "on_evict must receive the stored key and the value that was written"
+        );
+    }
+}
+
+// --- contrast: the `Expires`-driven store has no clock sample to hoist -------------------
+
+#[derive(Clone, Debug)]
+struct Flagged {
+    #[allow(dead_code)]
+    v: u32,
+    dead: Arc<AtomicBool>,
+}
+
+impl Expires for Flagged {
+    fn is_expired(&self) -> bool {
+        self.dead.load(Ordering::Acquire)
+    }
+}
+
+/// `ShardedExpiringLruCache` asks the *stored value* whether it is expired, inside the
+/// critical section. A value that becomes expired while a reader is queued behind the shard
+/// lock is therefore seen as expired by that reader -- the opposite of the LRU-TTL store's
+/// pre-lock sample, and the reason no clock hoist is possible here.
+#[test]
+fn expiring_lru_evaluates_is_expired_under_the_lock_not_before() {
+    let dead = Arc::new(AtomicBool::new(false));
+    let evicted: Arc<Mutex<Vec<u32>>> = Arc::new(Mutex::new(Vec::new()));
+    let evicted2 = Arc::clone(&evicted);
+    let store = ShardedExpiringLruCache::<u32, Flagged>::builder()
+        .shards(1)
+        .per_shard_max_size(8)
+        .on_evict(move |k: &u32, _v: &Flagged| evicted2.lock().unwrap().push(*k))
+        .build()
+        .expect("build ShardedExpiringLruCache");
+    ConcurrentCached::cache_set(
+        &store,
+        1,
+        Flagged {
+            v: 10,
+            dead: Arc::clone(&dead),
+        },
+    )
+    .unwrap();
+
+    let holding = Arc::new(AtomicBool::new(false));
+    let holding2 = Arc::clone(&holding);
+    let holder = std::thread::spawn({
+        let store = store.clone();
+        move || {
+            // The predicate sees a live value (`dead` is still false) and keeps it.
+            store.retain(move |_k, _v| {
+                holding2.store(true, Ordering::Release);
+                std::thread::sleep(Duration::from_millis(300));
+                true
+            });
+        }
+    });
+    wait_for(&holding);
+
+    // Flip the value to expired while the reader is (about to be) queued.
+    dead.store(true, Ordering::Release);
+    let queued = ConcurrentCached::cache_get(&store, &1).unwrap();
+    holder.join().expect("lock holder must not panic");
+
+    assert!(
+        queued.is_none(),
+        "liveness is read from the value under the lock, so the flip is observed"
+    );
+    assert_eq!(ConcurrentCacheBase::cache_size(&store).unwrap(), Some(0));
+    assert_eq!(*evicted.lock().unwrap(), vec![1]);
+    assert_eq!(ConcurrentCacheBase::cache_misses(&store), Some(1));
+}

--- a/tests/v3_cert_sharded_lru_clock_sample.rs
+++ b/tests/v3_cert_sharded_lru_clock_sample.rs
@@ -1,7 +1,7 @@
 /*!
 Certification: the pre-lock clock sample on the sharded LRU-family stores.
 
-`ShardedLruTtlCache::cache_get` / `cache_set` read the clock **once, before acquiring the
+`ShardedLruTtlCache::cache_get` / `cache_set` sample the clock **before acquiring the
 shard write lock**, and every expiry decision (and the `expires_at` seeded on a write) is made
 against that sample. The observable consequence is deliberate and documented: a caller that
 queues behind the shard lock for longer than the TTL still judges the entry by the clock it

--- a/tests/v3_cert_sharded_lru_concurrency.rs
+++ b/tests/v3_cert_sharded_lru_concurrency.rs
@@ -1,0 +1,487 @@
+/*!
+Certification: per-shard eviction counters and lazy-expiry removal under real concurrency.
+
+Eviction counting on the expiry-aware sharded LRU stores is split across two families of
+counters (`Shard::evictions` for expiry/removes/retain/clear, the inner `LruCache`'s counter
+for capacity pressure) and summed on read. A split like that is exactly where a race loses or
+double-counts an eviction, and where a lazily-expired entry can be removed twice.
+
+The invariants pinned here hold for *any* interleaving, so they are checked with many threads
+hammering the same shard and the same key:
+
+- N concurrent readers of one expired key: exactly one removal, one `on_evict`, one eviction
+  counted, and N misses;
+- concurrent removes across shards: `metrics().evictions` equals the number of removes that
+  actually returned an entry, and `on_evict` fires exactly once per removed key;
+- concurrent inserts past capacity: `inserts == survivors + evictions` exactly, over all shards.
+
+No Redis server required.
+*/
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Barrier, Mutex};
+
+use cached::{
+    ConcurrentCacheBase, ConcurrentCached, Expires, ShardedExpiringLruCache, ShardedLruCache,
+};
+
+const THREADS: usize = 16;
+
+#[derive(Clone, Debug, PartialEq)]
+struct Val {
+    v: u32,
+    dead: bool,
+}
+
+impl Expires for Val {
+    fn is_expired(&self) -> bool {
+        self.dead
+    }
+}
+
+fn live(v: u32) -> Val {
+    Val { v, dead: false }
+}
+
+fn dead(v: u32) -> Val {
+    Val { v, dead: true }
+}
+
+// --- one expired key, many readers -------------------------------------------------------
+
+/// Every reader must observe the miss, but only the one that wins the shard lock may remove
+/// the entry, fire `on_evict`, and count the eviction.
+#[test]
+fn expiring_lru_concurrent_reads_of_one_expired_key_evict_exactly_once() {
+    // Repeated: the interesting interleavings (a second reader arriving between the first
+    // reader's liveness decision and its removal) are rare, so one round is not enough.
+    for _round in 0..80 {
+        let evicted: Arc<Mutex<Vec<(u32, u32)>>> = Arc::new(Mutex::new(Vec::new()));
+        let evicted2 = Arc::clone(&evicted);
+        let store = ShardedExpiringLruCache::<u32, Val>::builder()
+            .shards(1)
+            .per_shard_max_size(8)
+            .on_evict(move |k: &u32, v: &Val| evicted2.lock().unwrap().push((*k, v.v)))
+            .build()
+            .expect("build ShardedExpiringLruCache");
+        ConcurrentCached::cache_set(&store, 7, dead(70)).unwrap();
+        let before = store.metrics().evictions.expect("evictions tracked");
+
+        let barrier = Arc::new(Barrier::new(THREADS));
+        let mut handles = Vec::new();
+        for _ in 0..THREADS {
+            let store = store.clone();
+            let barrier = Arc::clone(&barrier);
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                ConcurrentCached::cache_get(&store, &7).unwrap()
+            }));
+        }
+        let results: Vec<Option<Val>> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+        assert!(
+            results.iter().all(Option::is_none),
+            "an expired entry must never be served"
+        );
+        assert_eq!(
+            *evicted.lock().unwrap(),
+            vec![(7, 70)],
+            "on_evict must fire exactly once for the single removal"
+        );
+        assert_eq!(
+            store.metrics().evictions.expect("evictions tracked") - before,
+            1,
+            "exactly one eviction may be counted no matter how many readers raced"
+        );
+        assert_eq!(
+            ConcurrentCacheBase::cache_misses(&store),
+            Some(THREADS as u64),
+            "every racing read counts its own miss"
+        );
+        assert_eq!(ConcurrentCacheBase::cache_hits(&store), Some(0));
+        assert_eq!(ConcurrentCacheBase::cache_size(&store).unwrap(), Some(0));
+    }
+}
+
+/// The same race with a live key: no removals, and every reader counts a hit.
+#[test]
+fn expiring_lru_concurrent_reads_of_one_live_key_count_every_hit() {
+    let store = ShardedExpiringLruCache::<u32, Val>::builder()
+        .shards(1)
+        .per_shard_max_size(8)
+        .on_evict(|_, _| panic!("a live read must never evict"))
+        .build()
+        .expect("build ShardedExpiringLruCache");
+    ConcurrentCached::cache_set(&store, 7, live(70)).unwrap();
+
+    let reads_per_thread = 200u64;
+    let barrier = Arc::new(Barrier::new(THREADS));
+    let mut handles = Vec::new();
+    for _ in 0..THREADS {
+        let store = store.clone();
+        let barrier = Arc::clone(&barrier);
+        handles.push(std::thread::spawn(move || {
+            barrier.wait();
+            for _ in 0..reads_per_thread {
+                assert_eq!(
+                    ConcurrentCached::cache_get(&store, &7).unwrap(),
+                    Some(live(70))
+                );
+            }
+        }));
+    }
+    for h in handles {
+        h.join().unwrap();
+    }
+    assert_eq!(
+        ConcurrentCacheBase::cache_hits(&store),
+        Some(THREADS as u64 * reads_per_thread),
+        "the per-shard hit counter must not lose an increment under contention"
+    );
+    assert_eq!(ConcurrentCacheBase::cache_misses(&store), Some(0));
+    assert_eq!(store.metrics().evictions, Some(0));
+}
+
+#[cfg(feature = "time_stores")]
+mod lru_ttl {
+    use super::*;
+    use cached::ShardedLruTtlCache;
+    use std::time::Duration;
+
+    /// TTL-expiry flavour of the same race. Every thread samples the clock after the TTL has
+    /// already elapsed, so all of them must miss, and exactly one may evict.
+    #[test]
+    fn concurrent_reads_of_one_expired_key_evict_exactly_once() {
+        for _round in 0..40 {
+            let evicted: Arc<Mutex<Vec<(u32, u32)>>> = Arc::new(Mutex::new(Vec::new()));
+            let evicted2 = Arc::clone(&evicted);
+            let store = ShardedLruTtlCache::<u32, u32>::builder()
+                .shards(1)
+                .per_shard_max_size(8)
+                .ttl(Duration::from_millis(5))
+                .on_evict(move |k: &u32, v: &u32| evicted2.lock().unwrap().push((*k, *v)))
+                .build()
+                .expect("build ShardedLruTtlCache");
+            ConcurrentCached::cache_set(&store, 7, 70).unwrap();
+            let before = store.metrics().evictions.expect("evictions tracked");
+            // Every thread samples the clock only after this sleep, i.e. after the TTL.
+            std::thread::sleep(Duration::from_millis(25));
+
+            let barrier = Arc::new(Barrier::new(THREADS));
+            let mut handles = Vec::new();
+            for _ in 0..THREADS {
+                let store = store.clone();
+                let barrier = Arc::clone(&barrier);
+                handles.push(std::thread::spawn(move || {
+                    barrier.wait();
+                    ConcurrentCached::cache_get(&store, &7).unwrap()
+                }));
+            }
+            let results: Vec<Option<u32>> =
+                handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+            assert!(
+                results.iter().all(Option::is_none),
+                "every reader sampled the clock after the TTL elapsed, so none may be served"
+            );
+            assert_eq!(*evicted.lock().unwrap(), vec![(7, 70)]);
+            assert_eq!(
+                store.metrics().evictions.expect("evictions tracked") - before,
+                1,
+                "exactly one eviction may be counted no matter how many readers raced"
+            );
+            assert_eq!(
+                ConcurrentCacheBase::cache_misses(&store),
+                Some(THREADS as u64)
+            );
+            assert_eq!(ConcurrentCacheBase::cache_size(&store).unwrap(), Some(0));
+        }
+    }
+
+    /// A racing `cache_get` (lazy expiry, counted on the shard's non-capacity counter) and
+    /// `cache_set` (displaced-expired, counted on the same counter) over one expired key must
+    /// between them produce exactly one eviction and one `on_evict` -- never two, never none.
+    #[test]
+    fn concurrent_expired_read_and_overwrite_evict_exactly_once() {
+        for _round in 0..40 {
+            let fires = Arc::new(AtomicU64::new(0));
+            let fires2 = Arc::clone(&fires);
+            let store = ShardedLruTtlCache::<u32, u32>::builder()
+                .shards(1)
+                .per_shard_max_size(8)
+                .ttl(Duration::from_millis(10))
+                .on_evict(move |_k: &u32, _v: &u32| {
+                    fires2.fetch_add(1, Ordering::Relaxed);
+                })
+                .build()
+                .expect("build ShardedLruTtlCache");
+            ConcurrentCached::cache_set(&store, 1, 10).unwrap();
+            let before = store.metrics().evictions.expect("evictions tracked");
+            std::thread::sleep(Duration::from_millis(30));
+
+            let barrier = Arc::new(Barrier::new(2));
+            let reader = std::thread::spawn({
+                let store = store.clone();
+                let barrier = Arc::clone(&barrier);
+                move || {
+                    barrier.wait();
+                    ConcurrentCached::cache_get(&store, &1).unwrap()
+                }
+            });
+            let writer = std::thread::spawn({
+                let store = store.clone();
+                let barrier = Arc::clone(&barrier);
+                move || {
+                    barrier.wait();
+                    ConcurrentCached::cache_set(&store, 1, 11).unwrap()
+                }
+            });
+            // Whichever thread won the shard lock, the reader never sees the stale 10: it
+            // either misses (it went first and evicted) or reads the freshly written 11.
+            let read = reader.join().unwrap();
+            assert!(
+                read.is_none() || read == Some(11),
+                "a reader must never be served the expired value; got {read:?}"
+            );
+            assert_eq!(
+                writer.join().unwrap(),
+                None,
+                "an expired displaced value is filtered from the return"
+            );
+
+            assert_eq!(
+                store.metrics().evictions.expect("evictions tracked") - before,
+                1,
+                "the expired entry must be accounted for exactly once across both racers"
+            );
+            assert_eq!(
+                fires.load(Ordering::Relaxed),
+                1,
+                "on_evict must fire exactly once for the one expired entry"
+            );
+            // The write always wins the key back, whichever order the two ran in.
+            assert_eq!(
+                ConcurrentCacheBase::cache_size(&store).unwrap(),
+                Some(1),
+                "the written entry is stored regardless of the interleaving"
+            );
+        }
+    }
+
+    /// Removes spread over every shard: the summed per-shard counters must equal the number of
+    /// removes that actually removed something, and every removed key must be reported once.
+    #[test]
+    fn concurrent_removes_across_shards_count_every_eviction_exactly_once() {
+        let seen: Arc<Mutex<Vec<u32>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen2 = Arc::clone(&seen);
+        let store = ShardedLruTtlCache::<u32, u32>::builder()
+            .shards(8)
+            .per_shard_max_size(4096)
+            .ttl(Duration::from_secs(3600))
+            .on_evict(move |k: &u32, _v: &u32| seen2.lock().unwrap().push(*k))
+            .build()
+            .expect("build ShardedLruTtlCache");
+
+        let per_thread = 500u32;
+        for t in 0..THREADS as u32 {
+            for i in 0..per_thread {
+                ConcurrentCached::cache_set(&store, t * per_thread + i, i).unwrap();
+            }
+        }
+        let total = THREADS as u32 * per_thread;
+        assert_eq!(
+            ConcurrentCacheBase::cache_size(&store).unwrap(),
+            Some(total as usize),
+            "no capacity eviction may happen in this fixture"
+        );
+        let before = store.metrics().evictions.expect("evictions tracked");
+
+        // Every thread tries to remove EVERY key, so the same key is contended by all of them;
+        // only one remove per key may report an entry.
+        let barrier = Arc::new(Barrier::new(THREADS));
+        let mut handles = Vec::new();
+        for _ in 0..THREADS {
+            let store = store.clone();
+            let barrier = Arc::clone(&barrier);
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                let mut removed = 0u64;
+                for k in 0..total {
+                    if ConcurrentCached::cache_remove(&store, &k)
+                        .unwrap()
+                        .is_some()
+                    {
+                        removed += 1;
+                    }
+                }
+                removed
+            }));
+        }
+        let removed: u64 = handles.into_iter().map(|h| h.join().unwrap()).sum();
+
+        assert_eq!(
+            removed, total as u64,
+            "each key may be removed by exactly one thread"
+        );
+        assert_eq!(
+            store.metrics().evictions.expect("evictions tracked") - before,
+            removed,
+            "the summed per-shard counters must match the removals exactly"
+        );
+        assert_eq!(
+            ConcurrentCacheBase::cache_evictions(&store),
+            store.metrics().evictions,
+            "the trait method and metrics() must agree after concurrent mutation"
+        );
+        let mut fired = seen.lock().unwrap().clone();
+        fired.sort_unstable();
+        let expected: Vec<u32> = (0..total).collect();
+        assert_eq!(fired, expected, "every key must fire on_evict exactly once");
+        assert!(store.is_empty());
+    }
+
+    /// Concurrent inserts past capacity, all landing on one shard: every insert either survives
+    /// or is counted as exactly one eviction. This is the accounting identity the per-shard
+    /// counters must preserve under contention.
+    #[test]
+    fn concurrent_capacity_evictions_balance_against_survivors() {
+        let store = ShardedLruTtlCache::<u32, u32>::builder()
+            .shards(1)
+            .per_shard_max_size(32)
+            .ttl(Duration::from_secs(3600))
+            .build()
+            .expect("build ShardedLruTtlCache");
+
+        let per_thread = 500u32;
+        let barrier = Arc::new(Barrier::new(THREADS));
+        let mut handles = Vec::new();
+        for t in 0..THREADS as u32 {
+            let store = store.clone();
+            let barrier = Arc::clone(&barrier);
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                for i in 0..per_thread {
+                    // Distinct keys per thread: no overwrites, so every insert adds an entry.
+                    ConcurrentCached::cache_set(&store, t * per_thread + i, i).unwrap();
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let inserts = u64::from(per_thread) * THREADS as u64;
+        let survivors = ConcurrentCacheBase::cache_size(&store).unwrap().unwrap() as u64;
+        assert_eq!(survivors, 32, "the shard must be full at its cap");
+        assert_eq!(
+            store.metrics().evictions.expect("evictions tracked"),
+            inserts - survivors,
+            "every insert not still stored must have been evicted exactly once"
+        );
+    }
+}
+
+/// The plain sharded LRU store keeps a single eviction family (the inner `LruCache` counter);
+/// the same accounting identity must hold for it under concurrency, across many shards.
+#[test]
+fn sharded_lru_concurrent_capacity_evictions_balance_against_survivors() {
+    let fires = Arc::new(AtomicU64::new(0));
+    let fires2 = Arc::clone(&fires);
+    let store = ShardedLruCache::<u32, u32>::builder()
+        .shards(8)
+        .per_shard_max_size(16)
+        .on_evict(move |_k: &u32, _v: &u32| {
+            fires2.fetch_add(1, Ordering::Relaxed);
+        })
+        .build()
+        .expect("build ShardedLruCache");
+
+    let per_thread = 500u32;
+    let barrier = Arc::new(Barrier::new(THREADS));
+    let mut handles = Vec::new();
+    for t in 0..THREADS as u32 {
+        let store = store.clone();
+        let barrier = Arc::clone(&barrier);
+        handles.push(std::thread::spawn(move || {
+            barrier.wait();
+            for i in 0..per_thread {
+                ConcurrentCached::cache_set(&store, t * per_thread + i, i).unwrap();
+            }
+        }));
+    }
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    let inserts = u64::from(per_thread) * THREADS as u64;
+    let survivors = ConcurrentCacheBase::cache_size(&store).unwrap().unwrap() as u64;
+    let evictions = store.metrics().evictions.expect("evictions tracked");
+    assert_eq!(
+        evictions,
+        inserts - survivors,
+        "every insert not still stored must have been evicted exactly once"
+    );
+    assert_eq!(
+        fires.load(Ordering::Relaxed),
+        evictions,
+        "on_evict must fire exactly as often as an eviction is counted"
+    );
+}
+
+/// `cache_clear_with_on_evict` racing concurrent inserts: the callback must fire exactly once
+/// per entry it actually drained, and the eviction counter must move by the same amount. Any
+/// entry inserted after its shard was drained simply survives.
+#[test]
+fn sharded_lru_clear_with_on_evict_races_inserts_without_double_firing() {
+    for _round in 0..20 {
+        let seen: Arc<Mutex<Vec<u32>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen2 = Arc::clone(&seen);
+        let store = ShardedLruCache::<u32, u32>::builder()
+            .shards(8)
+            .per_shard_max_size(4096)
+            .on_evict(move |k: &u32, _v: &u32| seen2.lock().unwrap().push(*k))
+            .build()
+            .expect("build ShardedLruCache");
+        for i in 0..400u32 {
+            ConcurrentCached::cache_set(&store, i, i).unwrap();
+        }
+
+        let go = Arc::new(AtomicBool::new(false));
+        let inserter = std::thread::spawn({
+            let store = store.clone();
+            let go = Arc::clone(&go);
+            move || {
+                while !go.load(Ordering::Acquire) {
+                    std::hint::spin_loop();
+                }
+                for i in 1000..1400u32 {
+                    ConcurrentCached::cache_set(&store, i, i).unwrap();
+                }
+            }
+        });
+        go.store(true, Ordering::Release);
+        store.cache_clear_with_on_evict();
+        inserter.join().unwrap();
+
+        let fired = seen.lock().unwrap().clone();
+        let mut sorted = fired.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(
+            sorted.len(),
+            fired.len(),
+            "no entry may be handed to on_evict twice"
+        );
+        assert_eq!(
+            store.metrics().evictions.expect("evictions tracked"),
+            fired.len() as u64,
+            "the eviction counter must match the number of drained entries"
+        );
+        let survivors = ConcurrentCacheBase::cache_size(&store).unwrap().unwrap();
+        assert_eq!(
+            fired.len() + survivors,
+            800,
+            "every entry is either drained exactly once or still stored"
+        );
+    }
+}

--- a/tests/v3_cert_sharded_lru_semantics.rs
+++ b/tests/v3_cert_sharded_lru_semantics.rs
@@ -829,20 +829,26 @@ mod refresh_on_hit {
     /// reports the previous value.
     #[test]
     fn runtime_toggle_switches_the_read_path_both_ways() {
+        // A comfortably large TTL (relative to the 150 ms poll interval below) so that only the
+        // deliberate past-expiry sleeps decide expiry, never scheduling jitter in the CI runner.
+        let ttl = Duration::from_millis(1000);
         let store = ShardedLruTtlCache::<u32, u32>::builder()
             .shards(1)
             .per_shard_max_size(8)
-            .ttl(Duration::from_millis(400))
+            .ttl(ttl)
             .build()
             .expect("build ShardedLruTtlCache");
         assert!(!store.refresh_on_hit(), "the builder default is off");
 
-        // Off: repeated reads do not push the expiry out.
+        // Off: repeated reads do not push the expiry out. Poll a few times inside the TTL
+        // window (their results are irrelevant here), then deliberately sleep well past the
+        // TTL before checking that the original expiry stood.
         ConcurrentCached::cache_set(&store, 1, 10).unwrap();
         for _ in 0..3 {
             std::thread::sleep(Duration::from_millis(150));
             let _ = ConcurrentCached::cache_get(&store, &1).unwrap();
         }
+        std::thread::sleep(Duration::from_millis(900));
         assert_eq!(
             ConcurrentCached::cache_get(&store, &1).unwrap(),
             None,
@@ -855,7 +861,9 @@ mod refresh_on_hit {
         );
         assert!(store.refresh_on_hit());
 
-        // On: the same read pattern keeps the entry alive well past one TTL.
+        // On: the same read pattern keeps the entry alive well past one TTL. Each hit renews
+        // the deadline, so the gap the scheduler must blow through to falsify this is the full
+        // 1000 ms TTL minus the 150 ms poll interval, not a shrinking cumulative margin.
         ConcurrentCached::cache_set(&store, 2, 20).unwrap();
         for _ in 0..3 {
             std::thread::sleep(Duration::from_millis(150));
@@ -868,7 +876,7 @@ mod refresh_on_hit {
 
         // And back off again: the entry now expires on the last refreshed deadline.
         assert!(store.set_refresh_on_hit(false));
-        std::thread::sleep(Duration::from_millis(600));
+        std::thread::sleep(Duration::from_millis(1300));
         assert_eq!(ConcurrentCached::cache_get(&store, &2).unwrap(), None);
     }
 
@@ -902,16 +910,20 @@ mod refresh_on_hit {
     /// `cache_peek` and `cache_contains` neither renew the expiry nor promote recency.
     #[test]
     fn peek_and_contains_do_not_refresh_the_expiry() {
+        // A comfortably large TTL (relative to the 100 ms poll interval below) so that only the
+        // deliberate past-expiry sleep at the end decides expiry, never scheduling jitter in the
+        // CI runner: only the intentional final sleep should ever flip this to expired.
+        let ttl = Duration::from_millis(1000);
         let store = ShardedLruTtlCache::<u32, u32>::builder()
             .shards(1)
             .per_shard_max_size(8)
-            .ttl(Duration::from_millis(400))
+            .ttl(ttl)
             .refresh_on_hit(true)
             .build()
             .expect("build ShardedLruTtlCache");
         ConcurrentCached::cache_set(&store, 1, 10).unwrap();
-        // Three peeks inside the entry's single 400 ms lifetime; if any of them refreshed the
-        // expiry the final read below would still be a hit.
+        // Three peeks well inside the entry's single 1000 ms lifetime; if any of them refreshed
+        // the expiry the final read below would still be a hit.
         for _ in 0..3 {
             std::thread::sleep(Duration::from_millis(100));
             assert_eq!(store.peek(&1), Some(10), "peek still reads the live value");
@@ -921,7 +933,8 @@ mod refresh_on_hit {
                 Some(10)
             );
         }
-        std::thread::sleep(Duration::from_millis(200));
+        // Deliberately push well past the TTL now that the peeks are done.
+        std::thread::sleep(Duration::from_millis(1000));
         assert_eq!(
             ConcurrentCached::cache_get(&store, &1).unwrap(),
             None,

--- a/tests/v3_cert_sharded_lru_semantics.rs
+++ b/tests/v3_cert_sharded_lru_semantics.rs
@@ -1,0 +1,1024 @@
+/*!
+Certification: the sharded LRU-family stores against their single-owner siblings as an oracle,
+plus the paths the single-lookup rewrite left thin.
+
+The sharded stores are documented as sharded versions of the single-owner ones, so with one
+shard they must answer an identical op script identically: same per-op return values, same
+`on_evict` victim sequence (which is exactly the recency chain, observed from outside), and the
+same hit / miss / eviction / entry counts. Any recency change from the single-lookup `cache_get`
+or the callback-dependent write path shows up as a diff against that oracle.
+
+Also covered here, from the public API only:
+
+- overwrite recency: `cache_set` over an existing key promotes it to MRU everywhere, with or
+  without an `on_evict` callback, so the sharded stores and the oracle agree;
+- `refresh_on_hit`, including the runtime toggle, the expired-entry case, the interaction with
+  `unset_ttl`, and the read paths that must NOT refresh;
+- `copy_from` metric provenance (a fresh cache must not inherit the source's counters);
+- `cache_clear_with_on_evict`'s `drain_all`: every key and value delivered exactly once.
+
+No Redis server required.
+*/
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use cached::{
+    Cached, ConcurrentCacheBase, ConcurrentCached, Expires, ExpiringLruCache, LruCache,
+    ShardedExpiringLruCache, ShardedLruCache,
+};
+
+// --- oracle harness ----------------------------------------------------------------------
+
+#[derive(Clone, Debug, PartialEq)]
+enum Op<V> {
+    Set(u32, V),
+    Get(u32),
+    Remove(u32),
+}
+
+/// Everything an op script can observe from outside: the per-op return values, the `on_evict`
+/// victims in firing order, and the final counters.
+#[derive(Debug, PartialEq)]
+struct Trace<V> {
+    returns: Vec<Option<V>>,
+    victims: Vec<(u32, V)>,
+    hits: Option<u64>,
+    misses: Option<u64>,
+    evictions: Option<u64>,
+    size: usize,
+}
+
+/// A script that exercises inserts, capacity eviction, live/absent reads, and explicit
+/// removes -- but never overwrites an existing key (overwrite recency is pinned separately by
+/// `overwrite_promotion_agrees_across_the_sharded_stores_and_the_single_owner_oracle`).
+fn script<V: Clone>(v: impl Fn(u32) -> V) -> Vec<Op<V>> {
+    vec![
+        Op::Set(1, v(10)),
+        Op::Set(2, v(20)),
+        Op::Set(3, v(30)),
+        Op::Set(4, v(40)),
+        Op::Get(1),
+        Op::Get(999),
+        Op::Get(2),
+        Op::Set(5, v(50)), // capacity eviction: key 3 is least-recently-used
+        Op::Get(3),
+        Op::Remove(4),
+        Op::Set(6, v(60)),
+        Op::Set(7, v(70)),
+        Op::Get(1),
+        Op::Get(5),
+        Op::Get(6),
+        Op::Get(7),
+        Op::Set(8, v(80)),
+        Op::Remove(999),
+        Op::Get(8),
+    ]
+}
+
+// --- ShardedLruCache vs LruCache ----------------------------------------------------------
+
+#[test]
+fn sharded_lru_answers_the_op_script_exactly_like_the_single_owner_lru() {
+    let ops = script(|n| n);
+
+    let single = {
+        let victims: Arc<Mutex<Vec<(u32, u32)>>> = Arc::new(Mutex::new(Vec::new()));
+        let victims2 = Arc::clone(&victims);
+        let mut c = LruCache::<u32, u32>::builder()
+            .max_size(4)
+            .on_evict(move |k: &u32, v: &u32| victims2.lock().unwrap().push((*k, *v)))
+            .build()
+            .expect("build LruCache");
+        let returns = ops
+            .iter()
+            .map(|op| match op {
+                Op::Set(k, v) => c.cache_set(*k, *v),
+                Op::Get(k) => c.cache_get(k).copied(),
+                Op::Remove(k) => c.cache_remove(k),
+            })
+            .collect();
+        Trace {
+            returns,
+            victims: victims.lock().unwrap().clone(),
+            hits: c.cache_hits(),
+            misses: c.cache_misses(),
+            evictions: c.cache_evictions(),
+            size: c.cache_size(),
+        }
+    };
+
+    let sharded = {
+        let victims: Arc<Mutex<Vec<(u32, u32)>>> = Arc::new(Mutex::new(Vec::new()));
+        let victims2 = Arc::clone(&victims);
+        let c = ShardedLruCache::<u32, u32>::builder()
+            .shards(1)
+            .per_shard_max_size(4)
+            .on_evict(move |k: &u32, v: &u32| victims2.lock().unwrap().push((*k, *v)))
+            .build()
+            .expect("build ShardedLruCache");
+        let returns = ops
+            .iter()
+            .map(|op| match op {
+                Op::Set(k, v) => ConcurrentCached::cache_set(&c, *k, *v).unwrap(),
+                Op::Get(k) => ConcurrentCached::cache_get(&c, k).unwrap(),
+                Op::Remove(k) => ConcurrentCached::cache_remove(&c, k).unwrap(),
+            })
+            .collect();
+        let m = c.metrics();
+        Trace {
+            returns,
+            victims: victims.lock().unwrap().clone(),
+            hits: m.hits,
+            misses: m.misses,
+            evictions: m.evictions,
+            size: m.entry_count.expect("sharded stores report an entry count"),
+        }
+    };
+
+    assert_eq!(
+        sharded, single,
+        "a one-shard ShardedLruCache must be observationally identical to LruCache"
+    );
+    assert!(
+        !single.victims.is_empty(),
+        "the script must actually evict something for the comparison to be meaningful"
+    );
+}
+
+// --- ShardedExpiringLruCache vs ExpiringLruCache ------------------------------------------
+
+#[derive(Clone, Debug, PartialEq)]
+struct Val {
+    v: u32,
+    dead: bool,
+}
+
+impl Expires for Val {
+    fn is_expired(&self) -> bool {
+        self.dead
+    }
+}
+
+fn live(v: u32) -> Val {
+    Val { v, dead: false }
+}
+
+fn dead(v: u32) -> Val {
+    Val { v, dead: true }
+}
+
+#[test]
+fn sharded_expiring_lru_answers_the_op_script_exactly_like_the_single_owner_store() {
+    // Value-driven expiry needs no clock, so expired entries can be scripted deterministically:
+    // keys 6 and 8 are inserted already expired.
+    let mut ops = script(live);
+    for op in &mut ops {
+        if let Op::Set(k, v) = op
+            && (*k == 6 || *k == 8)
+        {
+            *v = dead(v.v);
+        }
+    }
+
+    let single = {
+        let victims: Arc<Mutex<Vec<(u32, Val)>>> = Arc::new(Mutex::new(Vec::new()));
+        let victims2 = Arc::clone(&victims);
+        let mut c = ExpiringLruCache::<u32, Val>::builder()
+            .max_size(4)
+            .on_evict(move |k: &u32, v: &Val| victims2.lock().unwrap().push((*k, v.clone())))
+            .build()
+            .expect("build ExpiringLruCache");
+        let returns = ops
+            .iter()
+            .map(|op| match op {
+                Op::Set(k, v) => c.cache_set(*k, v.clone()),
+                Op::Get(k) => c.cache_get(k).cloned(),
+                Op::Remove(k) => c.cache_remove(k),
+            })
+            .collect();
+        Trace {
+            returns,
+            victims: victims.lock().unwrap().clone(),
+            hits: c.cache_hits(),
+            misses: c.cache_misses(),
+            evictions: c.cache_evictions(),
+            size: c.cache_size(),
+        }
+    };
+
+    let sharded = {
+        let victims: Arc<Mutex<Vec<(u32, Val)>>> = Arc::new(Mutex::new(Vec::new()));
+        let victims2 = Arc::clone(&victims);
+        let c = ShardedExpiringLruCache::<u32, Val>::builder()
+            .shards(1)
+            .per_shard_max_size(4)
+            .on_evict(move |k: &u32, v: &Val| victims2.lock().unwrap().push((*k, v.clone())))
+            .build()
+            .expect("build ShardedExpiringLruCache");
+        let returns = ops
+            .iter()
+            .map(|op| match op {
+                Op::Set(k, v) => ConcurrentCached::cache_set(&c, *k, v.clone()).unwrap(),
+                Op::Get(k) => ConcurrentCached::cache_get(&c, k).unwrap(),
+                Op::Remove(k) => ConcurrentCached::cache_remove(&c, k).unwrap(),
+            })
+            .collect();
+        let m = c.metrics();
+        Trace {
+            returns,
+            victims: victims.lock().unwrap().clone(),
+            hits: m.hits,
+            misses: m.misses,
+            evictions: m.evictions,
+            size: m.entry_count.expect("sharded stores report an entry count"),
+        }
+    };
+
+    assert_eq!(
+        sharded, single,
+        "a one-shard ShardedExpiringLruCache must be observationally identical to \
+         ExpiringLruCache, including the expired-on-read removals"
+    );
+    assert!(
+        single
+            .victims
+            .iter()
+            .any(|(_, v): &(u32, Val)| v.is_expired()),
+        "the script must actually hit the expired-on-read path"
+    );
+}
+
+/// Overwrite recency, stated in one place: `cache_set` over an EXISTING key promotes that key
+/// to most-recently-used, in the single-owner stores and in the sharded ones, and whether or
+/// not an `on_evict` callback is configured. Configuring a purely observational callback must
+/// not change which entry a capacity eviction picks.
+///
+/// The scenario is the smallest one that makes the promotion externally visible: capacity 2,
+/// insert 1 and 2, overwrite 1, then insert 3. Under promote-on-set the victim is key 2; the
+/// pre-3.0 in-place behavior would evict key 1 instead. Every variant is asserted against the
+/// same oracle outcome, so the contract cannot be "fixed" in one store and left in the others.
+#[test]
+fn overwrite_promotion_agrees_across_the_sharded_stores_and_the_single_owner_oracle() {
+    /// What survives the scenario, observed from outside: the value for each of keys 1..=3.
+    type Outcome = [Option<u32>; 3];
+
+    /// Promote-on-set: key 1 was rewritten (so promoted) and survives with its new value;
+    /// key 2 became the least-recently-used entry and is the capacity victim.
+    const EXPECTED: Outcome = [Some(11), None, Some(30)];
+
+    // --- oracle: single-owner LruCache ---
+    let oracle: Outcome = {
+        let mut c = LruCache::<u32, u32>::builder()
+            .max_size(2)
+            .build()
+            .expect("build LruCache");
+        c.cache_set(1, 10);
+        c.cache_set(2, 20);
+        c.cache_set(1, 11);
+        c.cache_set(3, 30);
+        [
+            c.cache_get(&1).copied(),
+            c.cache_get(&2).copied(),
+            c.cache_get(&3).copied(),
+        ]
+    };
+    assert_eq!(
+        oracle, EXPECTED,
+        "single-owner: overwriting key 1 promotes it, so key 2 is the eviction victim"
+    );
+
+    // --- oracle: single-owner ExpiringLruCache ---
+    let expiring_oracle: Outcome = {
+        let mut c = ExpiringLruCache::<u32, Val>::builder()
+            .max_size(2)
+            .build()
+            .expect("build ExpiringLruCache");
+        c.cache_set(1, live(10));
+        c.cache_set(2, live(20));
+        c.cache_set(1, live(11));
+        c.cache_set(3, live(30));
+        [
+            c.cache_get(&1).map(|v| v.v),
+            c.cache_get(&2).map(|v| v.v),
+            c.cache_get(&3).map(|v| v.v),
+        ]
+    };
+    assert_eq!(
+        expiring_oracle, oracle,
+        "ExpiringLruCache must agree with the LruCache oracle on overwrite recency"
+    );
+
+    // --- ShardedLruCache, with and without a callback ---
+    for with_on_evict in [false, true] {
+        let builder = ShardedLruCache::<u32, u32>::builder()
+            .shards(1)
+            .per_shard_max_size(2);
+        let c = if with_on_evict {
+            builder.on_evict(|_, _| {}).build()
+        } else {
+            builder.build()
+        }
+        .expect("build ShardedLruCache");
+        ConcurrentCached::cache_set(&c, 1, 10).unwrap();
+        ConcurrentCached::cache_set(&c, 2, 20).unwrap();
+        ConcurrentCached::cache_set(&c, 1, 11).unwrap();
+        ConcurrentCached::cache_set(&c, 3, 30).unwrap();
+        let got: Outcome = [
+            ConcurrentCached::cache_get(&c, &1).unwrap(),
+            ConcurrentCached::cache_get(&c, &2).unwrap(),
+            ConcurrentCached::cache_get(&c, &3).unwrap(),
+        ];
+        assert_eq!(
+            got, oracle,
+            "ShardedLruCache (on_evict={with_on_evict}) must match the single-owner oracle"
+        );
+    }
+
+    // --- ShardedExpiringLruCache, with and without a callback (the two write branches) ---
+    for with_on_evict in [false, true] {
+        let builder = ShardedExpiringLruCache::<u32, Val>::builder()
+            .shards(1)
+            .per_shard_max_size(2);
+        let c = if with_on_evict {
+            builder.on_evict(|_, _| {}).build()
+        } else {
+            builder.build()
+        }
+        .expect("build ShardedExpiringLruCache");
+        ConcurrentCached::cache_set(&c, 1, live(10)).unwrap();
+        ConcurrentCached::cache_set(&c, 2, live(20)).unwrap();
+        ConcurrentCached::cache_set(&c, 1, live(11)).unwrap();
+        ConcurrentCached::cache_set(&c, 3, live(30)).unwrap();
+        let got: Outcome = [
+            ConcurrentCached::cache_get(&c, &1).unwrap().map(|v| v.v),
+            ConcurrentCached::cache_get(&c, &2).unwrap().map(|v| v.v),
+            ConcurrentCached::cache_get(&c, &3).unwrap().map(|v| v.v),
+        ];
+        assert_eq!(
+            got, oracle,
+            "ShardedExpiringLruCache (on_evict={with_on_evict}) must match the single-owner \
+             oracle: attaching an observational callback must not change eviction order"
+        );
+    }
+
+    // --- LruTtlCache / ShardedLruTtlCache, same scenario under a TTL long enough not to fire ---
+    #[cfg(feature = "time_stores")]
+    {
+        use cached::{LruTtlCache, ShardedLruTtlCache};
+        let ttl = std::time::Duration::from_secs(3600);
+
+        let timed_oracle: Outcome = {
+            let mut c = LruTtlCache::<u32, u32>::builder()
+                .max_size(2)
+                .ttl(ttl)
+                .build()
+                .expect("build LruTtlCache");
+            c.cache_set(1, 10);
+            c.cache_set(2, 20);
+            c.cache_set(1, 11);
+            c.cache_set(3, 30);
+            [
+                c.cache_get(&1).copied(),
+                c.cache_get(&2).copied(),
+                c.cache_get(&3).copied(),
+            ]
+        };
+        assert_eq!(
+            timed_oracle, oracle,
+            "LruTtlCache must agree with the LruCache oracle on overwrite recency"
+        );
+
+        for with_on_evict in [false, true] {
+            let builder = ShardedLruTtlCache::<u32, u32>::builder()
+                .shards(1)
+                .per_shard_max_size(2)
+                .ttl(ttl);
+            let c = if with_on_evict {
+                builder.on_evict(|_, _| {}).build()
+            } else {
+                builder.build()
+            }
+            .expect("build ShardedLruTtlCache");
+            ConcurrentCached::cache_set(&c, 1, 10).unwrap();
+            ConcurrentCached::cache_set(&c, 2, 20).unwrap();
+            ConcurrentCached::cache_set(&c, 1, 11).unwrap();
+            ConcurrentCached::cache_set(&c, 3, 30).unwrap();
+            let got: Outcome = [
+                ConcurrentCached::cache_get(&c, &1).unwrap(),
+                ConcurrentCached::cache_get(&c, &2).unwrap(),
+                ConcurrentCached::cache_get(&c, &3).unwrap(),
+            ];
+            assert_eq!(
+                got, oracle,
+                "ShardedLruTtlCache (on_evict={with_on_evict}) must match the single-owner \
+                 oracle: attaching an observational callback must not change eviction order"
+            );
+        }
+    }
+}
+
+// --- cache_clear_with_on_evict / drain_all ------------------------------------------------
+
+#[test]
+fn clear_with_on_evict_delivers_every_key_and_value_exactly_once_across_shards() {
+    let seen: Arc<Mutex<Vec<(u32, u32)>>> = Arc::new(Mutex::new(Vec::new()));
+    let seen2 = Arc::clone(&seen);
+    let store = ShardedLruCache::<u32, u32>::builder()
+        // Per-shard capacity far above any plausible skew for 500 keys over 16 shards, so no
+        // capacity eviction can perturb the exactly-once count.
+        .shards(16)
+        .per_shard_max_size(512)
+        .on_evict(move |k: &u32, v: &u32| seen2.lock().unwrap().push((*k, *v)))
+        .build()
+        .expect("build ShardedLruCache");
+    for i in 0..500u32 {
+        ConcurrentCached::cache_set(&store, i, i * 7).unwrap();
+    }
+    // Read some entries back so the recency chains are not plain insertion order.
+    for i in (0..500u32).step_by(3) {
+        assert_eq!(
+            ConcurrentCached::cache_get(&store, &i).unwrap(),
+            Some(i * 7)
+        );
+    }
+    let before = store.metrics().evictions.expect("evictions tracked");
+
+    store.cache_clear_with_on_evict();
+
+    let mut fired = seen.lock().unwrap().clone();
+    assert_eq!(
+        fired.len(),
+        500,
+        "one callback per entry, no more and no less"
+    );
+    fired.sort_unstable();
+    let expected: Vec<(u32, u32)> = (0..500u32).map(|i| (i, i * 7)).collect();
+    assert_eq!(
+        fired, expected,
+        "every stored key must be delivered exactly once, paired with its own value"
+    );
+    assert_eq!(
+        store.metrics().evictions.expect("evictions tracked") - before,
+        500
+    );
+    assert!(store.is_empty());
+    assert_eq!(store.shard_sizes().iter().sum::<usize>(), 0);
+}
+
+/// `deep_clone` on the plain sharded LRU store: its eviction total lives entirely in the
+/// per-shard inner `LruCache` counters (it has no separate non-capacity family), so the clone
+/// must report the same total and then diverge independently. The sibling stores' per-shard
+/// counters are covered by their own tests; this is the one that has neither.
+#[test]
+fn sharded_lru_deep_clone_carries_the_eviction_total_and_stays_independent() {
+    let store = ShardedLruCache::<u32, u32>::builder()
+        .shards(4)
+        .per_shard_max_size(4)
+        .build()
+        .expect("build ShardedLruCache");
+    for i in 0..100u32 {
+        ConcurrentCached::cache_set(&store, i, i).unwrap();
+    }
+    assert_eq!(
+        ConcurrentCached::cache_remove(&store, &99).unwrap(),
+        Some(99)
+    );
+    let total = store.metrics().evictions.expect("evictions tracked");
+    assert!(total > 0, "the fixture must produce evictions");
+    let hits_before = store.metrics().hits;
+
+    let cloned = store.deep_clone();
+    assert_eq!(
+        cloned.metrics().evictions,
+        Some(total),
+        "the clone must report the source's eviction total"
+    );
+    assert_eq!(
+        ConcurrentCacheBase::cache_evictions(&cloned),
+        Some(total),
+        "the trait method must agree with metrics() on the clone"
+    );
+    assert_eq!(cloned.metrics().entry_count, store.metrics().entry_count);
+    assert_eq!(cloned.metrics().hits, hits_before);
+
+    // Independent from here on. `clear()` empties the clone without counting anything, so the
+    // insert below cannot trigger a capacity eviction and the delta is exactly the one remove.
+    cloned.clear();
+    assert_eq!(
+        cloned.metrics().evictions,
+        Some(total),
+        "plain clear() must not count evictions"
+    );
+    ConcurrentCached::cache_set(&cloned, 1000, 1000).unwrap();
+    assert_eq!(
+        ConcurrentCached::cache_remove(&cloned, &1000).unwrap(),
+        Some(1000)
+    );
+    assert_eq!(cloned.metrics().evictions, Some(total + 1));
+    assert_eq!(
+        store.metrics().evictions,
+        Some(total),
+        "the source must be untouched by the clone"
+    );
+}
+
+#[test]
+fn clear_with_on_evict_on_an_empty_cache_fires_nothing_and_counts_nothing() {
+    let fires = Arc::new(AtomicU64::new(0));
+    let fires2 = Arc::clone(&fires);
+    let store = ShardedLruCache::<u32, u32>::builder()
+        .shards(4)
+        .per_shard_max_size(16)
+        .on_evict(move |_k: &u32, _v: &u32| {
+            fires2.fetch_add(1, Ordering::Relaxed);
+        })
+        .build()
+        .expect("build ShardedLruCache");
+
+    store.cache_clear_with_on_evict();
+    assert_eq!(fires.load(Ordering::Relaxed), 0);
+    assert_eq!(store.metrics().evictions, Some(0));
+
+    // Draining a cache that only has entries in *some* shards must not count the empty ones.
+    ConcurrentCached::cache_set(&store, 1, 10).unwrap();
+    store.cache_clear_with_on_evict();
+    assert_eq!(fires.load(Ordering::Relaxed), 1);
+    assert_eq!(store.metrics().evictions, Some(1));
+
+    // ... and a second drain of the now-empty cache adds nothing.
+    store.cache_clear_with_on_evict();
+    assert_eq!(fires.load(Ordering::Relaxed), 1);
+    assert_eq!(store.metrics().evictions, Some(1));
+}
+
+/// `drain_all` takes the whole chain, expired entries included: an expired entry is still a
+/// stored entry, so it is handed to `on_evict` and counted like any other.
+#[test]
+fn clear_with_on_evict_drains_expired_entries_too() {
+    let seen: Arc<Mutex<Vec<u32>>> = Arc::new(Mutex::new(Vec::new()));
+    let seen2 = Arc::clone(&seen);
+    let store = ShardedExpiringLruCache::<u32, Val>::builder()
+        .shards(1)
+        .per_shard_max_size(16)
+        .on_evict(move |k: &u32, _v: &Val| seen2.lock().unwrap().push(*k))
+        .build()
+        .expect("build ShardedExpiringLruCache");
+    ConcurrentCached::cache_set(&store, 1, live(10)).unwrap();
+    ConcurrentCached::cache_set(&store, 2, dead(20)).unwrap();
+    ConcurrentCached::cache_set(&store, 3, live(30)).unwrap();
+
+    store.cache_clear_with_on_evict();
+
+    assert_eq!(
+        *seen.lock().unwrap(),
+        vec![3, 2, 1],
+        "expired entries are drained in chain order alongside live ones"
+    );
+    assert_eq!(store.metrics().evictions, Some(3));
+    assert!(store.is_empty());
+}
+
+// --- copy_from metric provenance ----------------------------------------------------------
+
+#[test]
+fn sharded_lru_copy_from_starts_from_clean_counters() {
+    let source_fires = Arc::new(AtomicU64::new(0));
+    let source_fires2 = Arc::clone(&source_fires);
+    let source = ShardedLruCache::<u32, u32>::builder()
+        .shards(1)
+        .per_shard_max_size(8)
+        .on_evict(move |_k: &u32, _v: &u32| {
+            source_fires2.fetch_add(1, Ordering::Relaxed);
+        })
+        .build()
+        .expect("build ShardedLruCache");
+    for i in 0..40u32 {
+        ConcurrentCached::cache_set(&source, i, i).unwrap();
+    }
+    for i in 32..40u32 {
+        assert_eq!(ConcurrentCached::cache_get(&source, &i).unwrap(), Some(i));
+    }
+    let source_evictions = source.metrics().evictions.expect("evictions tracked");
+    assert!(source_evictions >= 32, "the source must carry a history");
+    let source_fires_before = source_fires.load(Ordering::Relaxed);
+
+    // Same capacity: nothing is dropped, so the new cache starts at zero on every counter.
+    let same = ShardedLruCache::<u32, u32>::builder()
+        .shards(1)
+        .per_shard_max_size(8)
+        .copy_from(&source)
+        .expect("copy_from must succeed");
+    let m = same.metrics();
+    assert_eq!(
+        m.evictions,
+        Some(0),
+        "a copy must not inherit the source's eviction history"
+    );
+    assert_eq!(m.hits, Some(0));
+    assert_eq!(m.misses, Some(0));
+    assert_eq!(m.entry_count, Some(8));
+
+    // Smaller target: exactly the entries that did not fit are evicted, counted, and reported
+    // to the NEW cache's callback -- never to the source's.
+    let dropped: Arc<Mutex<Vec<u32>>> = Arc::new(Mutex::new(Vec::new()));
+    let dropped2 = Arc::clone(&dropped);
+    let small = ShardedLruCache::<u32, u32>::builder()
+        .shards(1)
+        .per_shard_max_size(3)
+        .on_evict(move |k: &u32, _v: &u32| dropped2.lock().unwrap().push(*k))
+        .copy_from(&source)
+        .expect("copy_from must succeed");
+    assert_eq!(
+        small.metrics().entry_count,
+        Some(3),
+        "the copy is bounded by its own capacity"
+    );
+    assert_eq!(
+        small.metrics().evictions,
+        Some(5),
+        "the 5 entries that did not fit must each count exactly one eviction"
+    );
+    assert_eq!(
+        dropped.lock().unwrap().len(),
+        5,
+        "the new cache's callback receives the entries that did not fit"
+    );
+    assert_eq!(
+        source_fires.load(Ordering::Relaxed),
+        source_fires_before,
+        "copy_from reads the source, so the source's callback must stay silent"
+    );
+    assert_eq!(
+        source.metrics().evictions,
+        Some(source_evictions),
+        "the source's counters must be untouched by a copy"
+    );
+
+    // Copying preserves recency: the survivors are the most-recently-used entries.
+    for i in 37..40u32 {
+        assert!(
+            ConcurrentCached::cache_contains(&small, &i).unwrap(),
+            "the most-recently-used entries must survive the shrinking copy"
+        );
+    }
+}
+
+#[test]
+fn sharded_expiring_lru_copy_from_starts_from_clean_counters() {
+    let source = ShardedExpiringLruCache::<u32, Val>::builder()
+        .shards(1)
+        .per_shard_max_size(8)
+        .build()
+        .expect("build ShardedExpiringLruCache");
+    for i in 0..40u32 {
+        ConcurrentCached::cache_set(&source, i, live(i)).unwrap();
+    }
+    let source_evictions = source.metrics().evictions.expect("evictions tracked");
+    assert!(source_evictions >= 32);
+
+    let copy = ShardedExpiringLruCache::<u32, Val>::builder()
+        .shards(1)
+        .per_shard_max_size(8)
+        .copy_from(&source)
+        .expect("copy_from must succeed");
+    assert_eq!(copy.metrics().evictions, Some(0));
+    assert_eq!(copy.metrics().hits, Some(0));
+    assert_eq!(copy.metrics().misses, Some(0));
+
+    // An expired entry in the source is skipped by the copy, and skipping is not an eviction.
+    ConcurrentCached::cache_set(&source, 100, dead(100)).unwrap();
+    let copy2 = ShardedExpiringLruCache::<u32, Val>::builder()
+        .shards(1)
+        .per_shard_max_size(64)
+        .copy_from(&source)
+        .expect("copy_from must succeed");
+    assert!(!ConcurrentCached::cache_contains(&copy2, &100).unwrap());
+    assert_eq!(
+        copy2.metrics().evictions,
+        Some(0),
+        "skipping an expired source entry is not an eviction on the copy"
+    );
+}
+
+// --- refresh_on_hit -----------------------------------------------------------------------
+
+#[cfg(feature = "time_stores")]
+mod refresh_on_hit {
+    use super::*;
+    use cached::{
+        CacheTtl, ConcurrentCachePeek, ConcurrentCacheTtl, LruTtlCache, ShardedLruTtlCache,
+    };
+    use std::time::Duration;
+
+    /// One-shard parity with `LruTtlCache` over the same script, with expiry kept out of the
+    /// picture (long TTL) so the comparison is purely about recency and counters.
+    #[test]
+    fn sharded_lru_ttl_answers_the_op_script_exactly_like_the_single_owner_store() {
+        let ops = script(|n| n);
+
+        let single = {
+            let victims: Arc<Mutex<Vec<(u32, u32)>>> = Arc::new(Mutex::new(Vec::new()));
+            let victims2 = Arc::clone(&victims);
+            let mut c = LruTtlCache::<u32, u32>::builder()
+                .max_size(4)
+                .ttl(Duration::from_secs(3600))
+                .on_evict(move |k: &u32, v: &u32| victims2.lock().unwrap().push((*k, *v)))
+                .build()
+                .expect("build LruTtlCache");
+            let returns = ops
+                .iter()
+                .map(|op| match op {
+                    Op::Set(k, v) => c.cache_set(*k, *v),
+                    Op::Get(k) => c.cache_get(k).copied(),
+                    Op::Remove(k) => c.cache_remove(k),
+                })
+                .collect();
+            Trace {
+                returns,
+                victims: victims.lock().unwrap().clone(),
+                hits: c.cache_hits(),
+                misses: c.cache_misses(),
+                evictions: c.cache_evictions(),
+                size: c.cache_size(),
+            }
+        };
+
+        let sharded = {
+            let victims: Arc<Mutex<Vec<(u32, u32)>>> = Arc::new(Mutex::new(Vec::new()));
+            let victims2 = Arc::clone(&victims);
+            let c = ShardedLruTtlCache::<u32, u32>::builder()
+                .shards(1)
+                .per_shard_max_size(4)
+                .ttl(Duration::from_secs(3600))
+                .on_evict(move |k: &u32, v: &u32| victims2.lock().unwrap().push((*k, *v)))
+                .build()
+                .expect("build ShardedLruTtlCache");
+            let returns = ops
+                .iter()
+                .map(|op| match op {
+                    Op::Set(k, v) => ConcurrentCached::cache_set(&c, *k, *v).unwrap(),
+                    Op::Get(k) => ConcurrentCached::cache_get(&c, k).unwrap(),
+                    Op::Remove(k) => ConcurrentCached::cache_remove(&c, k).unwrap(),
+                })
+                .collect();
+            let m = c.metrics();
+            Trace {
+                returns,
+                victims: victims.lock().unwrap().clone(),
+                hits: m.hits,
+                misses: m.misses,
+                evictions: m.evictions,
+                size: m.entry_count.expect("sharded stores report an entry count"),
+            }
+        };
+
+        assert_eq!(
+            sharded, single,
+            "a one-shard ShardedLruTtlCache must be observationally identical to LruTtlCache"
+        );
+    }
+
+    /// Lazy TTL expiry must agree with the single-owner store too: same return, same eviction
+    /// accounting, same callback.
+    #[test]
+    fn lazy_expiry_matches_the_single_owner_store() {
+        let single_fires = Arc::new(AtomicU64::new(0));
+        let single_fires2 = Arc::clone(&single_fires);
+        let mut single = LruTtlCache::<u32, u32>::builder()
+            .max_size(4)
+            .ttl(Duration::from_millis(60))
+            .on_evict(move |_k: &u32, _v: &u32| {
+                single_fires2.fetch_add(1, Ordering::Relaxed);
+            })
+            .build()
+            .expect("build LruTtlCache");
+        let sharded_fires = Arc::new(AtomicU64::new(0));
+        let sharded_fires2 = Arc::clone(&sharded_fires);
+        let sharded = ShardedLruTtlCache::<u32, u32>::builder()
+            .shards(1)
+            .per_shard_max_size(4)
+            .ttl(Duration::from_millis(60))
+            .on_evict(move |_k: &u32, _v: &u32| {
+                sharded_fires2.fetch_add(1, Ordering::Relaxed);
+            })
+            .build()
+            .expect("build ShardedLruTtlCache");
+
+        single.cache_set(1, 10);
+        ConcurrentCached::cache_set(&sharded, 1, 10).unwrap();
+        std::thread::sleep(Duration::from_millis(200));
+
+        assert_eq!(single.cache_get(&1).copied(), None);
+        assert_eq!(ConcurrentCached::cache_get(&sharded, &1).unwrap(), None);
+        assert_eq!(single.cache_size(), 0, "the expired entry is removed");
+        assert_eq!(
+            ConcurrentCacheBase::cache_size(&sharded).unwrap(),
+            Some(0),
+            "the sharded store must remove it too"
+        );
+        assert_eq!(single_fires.load(Ordering::Relaxed), 1);
+        assert_eq!(sharded_fires.load(Ordering::Relaxed), 1);
+        assert_eq!(single.cache_evictions(), Some(1));
+        assert_eq!(sharded.metrics().evictions, Some(1));
+        assert_eq!(single.cache_misses(), Some(1));
+        assert_eq!(ConcurrentCacheBase::cache_misses(&sharded), Some(1));
+    }
+
+    /// `set_refresh_on_hit` flips the behaviour at runtime, in both directions, and the getter
+    /// reports the previous value.
+    #[test]
+    fn runtime_toggle_switches_the_read_path_both_ways() {
+        let store = ShardedLruTtlCache::<u32, u32>::builder()
+            .shards(1)
+            .per_shard_max_size(8)
+            .ttl(Duration::from_millis(400))
+            .build()
+            .expect("build ShardedLruTtlCache");
+        assert!(!store.refresh_on_hit(), "the builder default is off");
+
+        // Off: repeated reads do not push the expiry out.
+        ConcurrentCached::cache_set(&store, 1, 10).unwrap();
+        for _ in 0..3 {
+            std::thread::sleep(Duration::from_millis(150));
+            let _ = ConcurrentCached::cache_get(&store, &1).unwrap();
+        }
+        assert_eq!(
+            ConcurrentCached::cache_get(&store, &1).unwrap(),
+            None,
+            "without refresh_on_hit the original expiry stands"
+        );
+
+        assert!(
+            !store.set_refresh_on_hit(true),
+            "the setter returns the previous value"
+        );
+        assert!(store.refresh_on_hit());
+
+        // On: the same read pattern keeps the entry alive well past one TTL.
+        ConcurrentCached::cache_set(&store, 2, 20).unwrap();
+        for _ in 0..3 {
+            std::thread::sleep(Duration::from_millis(150));
+            assert_eq!(
+                ConcurrentCached::cache_get(&store, &2).unwrap(),
+                Some(20),
+                "each hit must renew the expiry"
+            );
+        }
+
+        // And back off again: the entry now expires on the last refreshed deadline.
+        assert!(store.set_refresh_on_hit(false));
+        std::thread::sleep(Duration::from_millis(600));
+        assert_eq!(ConcurrentCached::cache_get(&store, &2).unwrap(), None);
+    }
+
+    /// A refreshing read must not resurrect an already-expired entry: the liveness predicate
+    /// fails, so the entry is removed and counted rather than given a new lease.
+    #[test]
+    fn a_refreshing_read_never_resurrects_an_expired_entry() {
+        let seen: Arc<Mutex<Vec<(u32, u32)>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen2 = Arc::clone(&seen);
+        let store = ShardedLruTtlCache::<u32, u32>::builder()
+            .shards(1)
+            .per_shard_max_size(8)
+            .ttl(Duration::from_millis(60))
+            .refresh_on_hit(true)
+            .on_evict(move |k: &u32, v: &u32| seen2.lock().unwrap().push((*k, *v)))
+            .build()
+            .expect("build ShardedLruTtlCache");
+        ConcurrentCached::cache_set(&store, 1, 10).unwrap();
+        std::thread::sleep(Duration::from_millis(200));
+
+        assert_eq!(ConcurrentCached::cache_get(&store, &1).unwrap(), None);
+        assert_eq!(ConcurrentCacheBase::cache_size(&store).unwrap(), Some(0));
+        assert_eq!(*seen.lock().unwrap(), vec![(1, 10)]);
+        assert_eq!(store.metrics().evictions, Some(1));
+        // Still gone on the next read, i.e. nothing was re-armed.
+        assert_eq!(ConcurrentCached::cache_get(&store, &1).unwrap(), None);
+        assert_eq!(store.metrics().evictions, Some(1));
+    }
+
+    /// The side-effect-free reads must stay side-effect-free under `refresh_on_hit`:
+    /// `cache_peek` and `cache_contains` neither renew the expiry nor promote recency.
+    #[test]
+    fn peek_and_contains_do_not_refresh_the_expiry() {
+        let store = ShardedLruTtlCache::<u32, u32>::builder()
+            .shards(1)
+            .per_shard_max_size(8)
+            .ttl(Duration::from_millis(400))
+            .refresh_on_hit(true)
+            .build()
+            .expect("build ShardedLruTtlCache");
+        ConcurrentCached::cache_set(&store, 1, 10).unwrap();
+        // Three peeks inside the entry's single 400 ms lifetime; if any of them refreshed the
+        // expiry the final read below would still be a hit.
+        for _ in 0..3 {
+            std::thread::sleep(Duration::from_millis(100));
+            assert_eq!(store.peek(&1), Some(10), "peek still reads the live value");
+            assert!(ConcurrentCached::cache_contains(&store, &1).unwrap());
+            assert_eq!(
+                ConcurrentCachePeek::cache_peek(&store, &1).unwrap(),
+                Some(10)
+            );
+        }
+        std::thread::sleep(Duration::from_millis(200));
+        assert_eq!(
+            ConcurrentCached::cache_get(&store, &1).unwrap(),
+            None,
+            "peeking must not have renewed the entry's expiry"
+        );
+        assert_eq!(
+            ConcurrentCacheBase::cache_hits(&store),
+            Some(0),
+            "peek and contains record no hits"
+        );
+    }
+
+    /// With expiry disabled at runtime (`unset_ttl`), a refreshing hit has no new deadline to
+    /// install, so it keeps the entry's original one rather than clearing it: the entry still
+    /// expires on schedule. The single-owner store is the oracle for this corner.
+    #[test]
+    fn refresh_after_unset_ttl_keeps_the_original_expiry() {
+        let sharded = ShardedLruTtlCache::<u32, u32>::builder()
+            .shards(1)
+            .per_shard_max_size(8)
+            .ttl(Duration::from_millis(150))
+            .refresh_on_hit(true)
+            .build()
+            .expect("build ShardedLruTtlCache");
+        let mut single = LruTtlCache::<u32, u32>::builder()
+            .max_size(8)
+            .ttl(Duration::from_millis(150))
+            .refresh_on_hit(true)
+            .build()
+            .expect("build LruTtlCache");
+
+        ConcurrentCached::cache_set(&sharded, 1, 10).unwrap();
+        single.cache_set(1, 10);
+        assert_eq!(
+            sharded.unset_ttl(),
+            Some(Duration::from_millis(150)),
+            "unset_ttl returns the previous ttl"
+        );
+        assert_eq!(single.unset_ttl(), Some(Duration::from_millis(150)));
+
+        // A refreshing hit while expiry is disabled leaves the stored deadline alone ...
+        assert_eq!(ConcurrentCached::cache_get(&sharded, &1).unwrap(), Some(10));
+        assert_eq!(single.cache_get(&1).copied(), Some(10));
+        std::thread::sleep(Duration::from_millis(300));
+        assert_eq!(
+            ConcurrentCached::cache_get(&sharded, &1).unwrap(),
+            None,
+            "the entry keeps the expiry it was written with"
+        );
+        assert_eq!(
+            single.cache_get(&1).copied(),
+            None,
+            "the single-owner store agrees"
+        );
+
+        // ... while an entry written *after* expiry was disabled never expires.
+        ConcurrentCached::cache_set(&sharded, 2, 20).unwrap();
+        single.cache_set(2, 20);
+        std::thread::sleep(Duration::from_millis(300));
+        assert_eq!(ConcurrentCached::cache_get(&sharded, &2).unwrap(), Some(20));
+        assert_eq!(single.cache_get(&2).copied(), Some(20));
+    }
+
+    /// A refreshing hit must promote recency exactly like a non-refreshing one -- the two use
+    /// different probes (`get_mut_if` vs `get_if`), so the promotion is asserted for both.
+    #[test]
+    fn a_refreshing_read_promotes_like_a_plain_read() {
+        for refresh in [false, true] {
+            let victims: Arc<Mutex<Vec<u32>>> = Arc::new(Mutex::new(Vec::new()));
+            let victims2 = Arc::clone(&victims);
+            let store = ShardedLruTtlCache::<u32, u32>::builder()
+                .shards(1)
+                .per_shard_max_size(3)
+                .ttl(Duration::from_secs(3600))
+                .refresh_on_hit(refresh)
+                .on_evict(move |k: &u32, _v: &u32| victims2.lock().unwrap().push(*k))
+                .build()
+                .expect("build ShardedLruTtlCache");
+            for i in 1..=3u32 {
+                ConcurrentCached::cache_set(&store, i, i * 10).unwrap();
+            }
+            // Read in an order that fully reverses the chain.
+            for i in 1..=3u32 {
+                assert_eq!(
+                    ConcurrentCached::cache_get(&store, &i).unwrap(),
+                    Some(i * 10)
+                );
+            }
+            // Now the chain is 3, 2, 1 (MRU -> LRU): the next three inserts evict 1, 2, 3.
+            for i in 10..13u32 {
+                ConcurrentCached::cache_set(&store, i, i).unwrap();
+            }
+            assert_eq!(
+                *victims.lock().unwrap(),
+                vec![1, 2, 3],
+                "refresh_on_hit={refresh}: reads must promote in the order they happened"
+            );
+        }
+    }
+}

--- a/tests/v3_cert_sharded_lru_semantics.rs
+++ b/tests/v3_cert_sharded_lru_semantics.rs
@@ -933,8 +933,13 @@ mod refresh_on_hit {
                 Some(10)
             );
         }
-        // Deliberately push well past the TTL now that the peeks are done.
-        std::thread::sleep(Duration::from_millis(1000));
+        // Land the final read strictly inside the window (original 1000 ms deadline,
+        // refreshed 1300 ms deadline): the last peek was at t~=300 ms, so sleeping 850 ms
+        // more reads at t~=1150 ms. A correctly non-refreshing entry (deadline 1000 ms) is
+        // expired; an entry that a buggy peek had refreshed (deadline 1300 ms) would still
+        // be live, flipping the assertion below. 700 <= 850 < 1000 keeps this true under
+        // scheduling jitter without false failures.
+        std::thread::sleep(Duration::from_millis(850));
         assert_eq!(
             ConcurrentCached::cache_get(&store, &1).unwrap(),
             None,

--- a/tests/v3_expiring_lru_on_evict_key.rs
+++ b/tests/v3_expiring_lru_on_evict_key.rs
@@ -47,8 +47,14 @@ impl Hash for IdTagKey {
 /// `tag`s so the test can distinguish which one the callback observed.
 #[test]
 fn id_tag_key_is_equal_but_distinct() {
-    let stored = IdTagKey { id: 1, tag: "first" };
-    let lookup = IdTagKey { id: 1, tag: "second" };
+    let stored = IdTagKey {
+        id: 1,
+        tag: "first",
+    };
+    let lookup = IdTagKey {
+        id: 1,
+        tag: "second",
+    };
     assert_eq!(stored, lookup, "keys with the same id must compare equal");
     assert_ne!(
         stored.tag, lookup.tag,

--- a/tests/v3_expiring_lru_on_evict_key.rs
+++ b/tests/v3_expiring_lru_on_evict_key.rs
@@ -1,0 +1,226 @@
+//! Regression test for the `ExpiringLruCache::cache_set` -> `cache_set_returning_entry`
+//! switch (perf shard, item 5).
+//!
+//! Before the switch, `cache_set` cloned the CALLER's key up front (`k.clone()`) and
+//! passed that clone to `on_evict` when the displaced entry was expired. After the
+//! switch to `LruCache::cache_set_returning_entry`, `on_evict` receives the entry's own
+//! STORED key instead -- matching the contract `cache_set_returning_entry` was written
+//! for and already used by `LruTtlCache::set_entry` (see src/stores/lru.rs ~:716-750
+//! and src/stores/lru_ttl.rs ~:366-384).
+//!
+//! This is only observable for key types whose `Eq`/`Hash` cover part of the payload:
+//! two keys that compare equal (and hash equal) but carry different data. Here that is
+//! an `id` field (covered by `Eq`/`Hash`) plus a `tag` field that is not. Insert under
+//! one tag, overwrite with a different tag while the first entry is expired, and assert
+//! the callback observes the FIRST-inserted (stored) tag, not the overwriting call's
+//! tag. `LruTtlCache` is exercised the same way and both stores must agree.
+//!
+//! Gated on `time_stores` because `LruTtlCache` lives behind that feature.
+#![cfg(feature = "time_stores")]
+
+use cached::time::Duration;
+use cached::{Cached, Expires, ExpiringLruCache, LruTtlCache};
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, Mutex};
+
+/// A key whose `Eq`/`Hash` cover only `id`; `tag` rides along uncompared, so two
+/// `IdTagKey`s with the same `id` but different `tag` are equal-but-distinct instances.
+#[derive(Debug, Clone)]
+struct IdTagKey {
+    id: u32,
+    tag: &'static str,
+}
+
+impl PartialEq for IdTagKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+impl Eq for IdTagKey {}
+impl Hash for IdTagKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
+
+/// Sanity: the two instances compare equal and hash identically, but carry different
+/// `tag`s so the test can distinguish which one the callback observed.
+#[test]
+fn id_tag_key_is_equal_but_distinct() {
+    let stored = IdTagKey { id: 1, tag: "first" };
+    let lookup = IdTagKey { id: 1, tag: "second" };
+    assert_eq!(stored, lookup, "keys with the same id must compare equal");
+    assert_ne!(
+        stored.tag, lookup.tag,
+        "tags must differ so the test can tell the two instances apart"
+    );
+}
+
+/// A value that decides its own staleness via a simple flag.
+#[derive(Debug, Clone)]
+struct Flag {
+    expired: bool,
+}
+impl Expires for Flag {
+    fn is_expired(&self) -> bool {
+        self.expired
+    }
+}
+
+/// `ExpiringLruCache::cache_set`, overwriting an expired entry, must fire `on_evict`
+/// with the STORED key ("first"), not the caller's overwriting key ("second").
+#[test]
+fn expiring_lru_cache_set_over_expired_on_evict_receives_stored_key() {
+    let seen: Arc<Mutex<Vec<&'static str>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&seen);
+
+    let mut cache: ExpiringLruCache<IdTagKey, Flag> = ExpiringLruCache::builder()
+        .max_size(8)
+        .on_evict(move |k: &IdTagKey, _v: &Flag| sink.lock().unwrap().push(k.tag))
+        .build()
+        .expect("build ExpiringLruCache");
+
+    // Store an already-expired value under the "first" tag.
+    let none = cache.cache_set(
+        IdTagKey {
+            id: 1,
+            tag: "first",
+        },
+        Flag { expired: true },
+    );
+    assert!(none.is_none(), "fresh insert returns None");
+
+    // Overwrite with the equal-but-distinct "second"-tagged key. The displaced entry
+    // was expired, so it is filtered from the return and on_evict fires once.
+    let displaced = cache.cache_set(
+        IdTagKey {
+            id: 1,
+            tag: "second",
+        },
+        Flag { expired: false },
+    );
+    assert!(
+        displaced.is_none(),
+        "an expired displaced value is filtered from cache_set's return"
+    );
+
+    let seen = seen.lock().unwrap();
+    assert_eq!(
+        &*seen,
+        &["first"],
+        "on_evict must receive the STORED key (tag \"first\"), not the overwriting \
+         call's key (tag \"second\")"
+    );
+}
+
+/// `LruTtlCache::cache_set`, overwriting an expired entry, must likewise fire
+/// `on_evict` with the STORED key -- the contract `cache_set_returning_entry` was
+/// written for, which `ExpiringLruCache::cache_set` now shares.
+#[test]
+fn lru_ttl_cache_set_over_expired_on_evict_receives_stored_key() {
+    let seen: Arc<Mutex<Vec<&'static str>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&seen);
+
+    let mut cache: LruTtlCache<IdTagKey, u32> = LruTtlCache::builder()
+        .max_size(8)
+        .ttl(Duration::from_millis(100))
+        .on_evict(move |k: &IdTagKey, _v: &u32| sink.lock().unwrap().push(k.tag))
+        .build()
+        .expect("build LruTtlCache");
+
+    cache.cache_set(
+        IdTagKey {
+            id: 1,
+            tag: "first",
+        },
+        10,
+    );
+    std::thread::sleep(std::time::Duration::from_millis(250));
+
+    let displaced = cache.cache_set(
+        IdTagKey {
+            id: 1,
+            tag: "second",
+        },
+        20,
+    );
+    assert!(
+        displaced.is_none(),
+        "an expired displaced value is filtered from cache_set's return"
+    );
+
+    let seen = seen.lock().unwrap();
+    assert_eq!(
+        &*seen,
+        &["first"],
+        "on_evict must receive the STORED key (tag \"first\"), not the overwriting \
+         call's key (tag \"second\")"
+    );
+}
+
+/// Both stores must agree: overwriting an expired entry under an equal-but-distinct
+/// key fires `on_evict` with the first-inserted (stored) key's tag in both cases.
+#[test]
+fn expiring_lru_and_lru_ttl_agree_on_stored_key_for_cache_set_over_expired() {
+    let expiring_seen: Arc<Mutex<Vec<&'static str>>> = Arc::new(Mutex::new(Vec::new()));
+    let expiring_sink = Arc::clone(&expiring_seen);
+    let mut expiring: ExpiringLruCache<IdTagKey, Flag> = ExpiringLruCache::builder()
+        .max_size(8)
+        .on_evict(move |k: &IdTagKey, _v: &Flag| expiring_sink.lock().unwrap().push(k.tag))
+        .build()
+        .expect("build ExpiringLruCache");
+    expiring.cache_set(
+        IdTagKey {
+            id: 1,
+            tag: "first",
+        },
+        Flag { expired: true },
+    );
+    expiring.cache_set(
+        IdTagKey {
+            id: 1,
+            tag: "second",
+        },
+        Flag { expired: false },
+    );
+
+    let ttl_seen: Arc<Mutex<Vec<&'static str>>> = Arc::new(Mutex::new(Vec::new()));
+    let ttl_sink = Arc::clone(&ttl_seen);
+    let mut ttl: LruTtlCache<IdTagKey, u32> = LruTtlCache::builder()
+        .max_size(8)
+        .ttl(Duration::from_millis(100))
+        .on_evict(move |k: &IdTagKey, _v: &u32| ttl_sink.lock().unwrap().push(k.tag))
+        .build()
+        .expect("build LruTtlCache");
+    ttl.cache_set(
+        IdTagKey {
+            id: 1,
+            tag: "first",
+        },
+        10,
+    );
+    std::thread::sleep(std::time::Duration::from_millis(250));
+    ttl.cache_set(
+        IdTagKey {
+            id: 1,
+            tag: "second",
+        },
+        20,
+    );
+
+    assert_eq!(
+        &*expiring_seen.lock().unwrap(),
+        &["first"],
+        "ExpiringLruCache must fire on_evict with the stored key"
+    );
+    assert_eq!(
+        &*ttl_seen.lock().unwrap(),
+        &["first"],
+        "LruTtlCache must fire on_evict with the stored key"
+    );
+    assert_eq!(
+        &*expiring_seen.lock().unwrap(),
+        &*ttl_seen.lock().unwrap(),
+        "ExpiringLruCache and LruTtlCache must agree on which key on_evict observes"
+    );
+}

--- a/tests/v3_retain_ttl_sorted.rs
+++ b/tests/v3_retain_ttl_sorted.rs
@@ -885,3 +885,214 @@ fn retain_matches_ttl_cache_and_lru_ttl_cache() {
     assert_eq!(ttl_outcome, expected, "TtlCache::retain");
     assert_eq!(lru_outcome, expected, "LruTtlCache::retain");
 }
+
+// ===========================================================================
+// Public-API coverage for the combined "size trim AND expiry sweep" path.
+//
+// `set_with(..).evict().set()` on a size-limited cache is the ONLY public route
+// that reaches the trim/sweep combination (an over-capacity insert that also
+// carries a cutoff). Everything else either trims with no cutoff (a plain `set`
+// over the cap, `set_max_size`, `retain_latest(n, false)`) or sweeps with no trim
+// (`evict()`, `retain_latest(n, true)` while under the cap).
+// ===========================================================================
+
+/// The expired prefix is larger than the size overflow: the insert must drop BOTH expired
+/// entries (not just the single entry needed to get back under the cap), fire `on_evict` for
+/// each in expiry order, and leave the cache below its cap.
+#[test]
+fn evicting_insert_over_the_cap_sweeps_the_whole_expired_prefix() {
+    let (mut cache, events) = events_cache_capped(Duration::from_secs(60), 3);
+    cache
+        .set_with(1u32, 11u32)
+        .ttl(Duration::from_millis(30))
+        .set();
+    cache
+        .set_with(2u32, 22u32)
+        .ttl(Duration::from_millis(30))
+        .set();
+    cache
+        .set_with(3u32, 33u32)
+        .ttl(Duration::from_secs(60))
+        .set();
+    std::thread::sleep(std::time::Duration::from_millis(60));
+    assert_eq!(cache.cache_size(), 3, "at the cap, nothing swept yet");
+
+    // Over the cap (4 > 3) with the sweep opted in: the trim needs 1 drop, the expiry sweep
+    // wants 2, and the combined pass must take the union.
+    cache
+        .set_with(4u32, 44u32)
+        .ttl(Duration::from_secs(60))
+        .evict()
+        .set();
+
+    assert_eq!(sorted_keys(&cache), vec![3u32, 4]);
+    assert_eq!(
+        cache.cache_size(),
+        2,
+        "the sweep goes past the size overflow"
+    );
+    assert_eq!(
+        fired(&events),
+        vec![(1u32, 11u32), (2, 22)],
+        "both expired entries are reported, in expiry order"
+    );
+    assert_eq!(cache.cache_evictions(), Some(2));
+    // Nothing stale is left behind for a later sweep to double-count.
+    assert_eq!(cache.evict(), 0);
+    assert_eq!(cache.retain_latest(2, true), 0);
+    assert_eq!(cache.cache_evictions(), Some(2));
+}
+
+/// The mirror case: the size overflow is larger than the expired prefix, so the trim must
+/// continue into LIVE entries (soonest-to-expire first) and then stop at the first live
+/// entry once the cap is satisfied.
+#[test]
+fn evicting_insert_over_the_cap_trims_past_the_expired_prefix_into_live_entries() {
+    let (mut cache, events) = events_cache_capped(Duration::from_secs(60), 2);
+    cache
+        .set_with(1u32, 11u32)
+        .ttl(Duration::from_millis(30))
+        .set();
+    cache
+        .set_with(2u32, 22u32)
+        .ttl(Duration::from_secs(10))
+        .set();
+    // `set` (no `.evict()`) over the cap still trims, so add the third with the cap already
+    // at 2: this drops the soonest-to-expire, which is the expired key 1.
+    std::thread::sleep(std::time::Duration::from_millis(60));
+    cache
+        .set_with(3u32, 33u32)
+        .ttl(Duration::from_secs(20))
+        .set();
+    assert_eq!(sorted_keys(&cache), vec![2u32, 3]);
+    assert_eq!(fired(&events), vec![(1u32, 11u32)]);
+
+    // Now an evicting insert over the cap with NOTHING expired: the cutoff contributes
+    // nothing and the trim alone picks the soonest-to-expire live entry.
+    cache
+        .set_with(4u32, 44u32)
+        .ttl(Duration::from_secs(30))
+        .evict()
+        .set();
+    assert_eq!(sorted_keys(&cache), vec![3u32, 4]);
+    assert_eq!(
+        fired(&events),
+        vec![(1u32, 11u32), (2, 22)],
+        "the live soonest-to-expire entry is the victim"
+    );
+    assert_eq!(cache.cache_evictions(), Some(2));
+    assert_eq!(cache.cache_size(), 2);
+}
+
+/// Never-expiring entries must be retained last by the combined pass: they sort after every
+/// finite expiry, so a trim only reaches them once every dated entry is gone.
+#[test]
+fn evicting_insert_over_the_cap_retains_never_expiring_entries_last() {
+    let (mut cache, events) = events_cache_capped(Duration::from_secs(60), 3);
+    cache.set_with(1u32, 11u32).ttl(Duration::ZERO).set();
+    cache.set_with(2u32, 22u32).ttl(Duration::ZERO).set();
+    cache
+        .set_with(3u32, 33u32)
+        .ttl(Duration::from_millis(30))
+        .set();
+    std::thread::sleep(std::time::Duration::from_millis(60));
+
+    // Over the cap with the sweep on: key 3 is expired AND is the only dated entry, so the
+    // single required drop and the sweep pick the same victim; the two never-expiring
+    // entries survive.
+    cache
+        .set_with(4u32, 44u32)
+        .ttl(Duration::from_secs(60))
+        .evict()
+        .set();
+    assert_eq!(sorted_keys(&cache), vec![1u32, 2, 4]);
+    assert_eq!(fired(&events), vec![(3u32, 33u32)]);
+    assert_eq!(cache.cache_evictions(), Some(1));
+
+    // Push past the cap again with everything live: the dated key 4 must go before either
+    // never-expiring entry.
+    cache
+        .set_with(5u32, 55u32)
+        .ttl(Duration::from_secs(120))
+        .evict()
+        .set();
+    assert_eq!(sorted_keys(&cache), vec![1u32, 2, 5]);
+    assert_eq!(fired(&events), vec![(3u32, 33u32), (4, 44)]);
+
+    // And only when no dated entry remains does a trim reach the never-expiring ones.
+    assert_eq!(cache.retain_latest(1, true), 2);
+    assert_eq!(sorted_keys(&cache), vec![2u32]);
+}
+
+/// An evicting insert that *replaces* an existing key while the cache is at its cap: the map
+/// length never exceeds the cap, so no trim runs, but the sweep still must not be reachable
+/// through this branch (the store only sweeps when it is over the cap). Pins the documented
+/// asymmetry that `.evict()` on a size-limited cache is a no-op unless the insert overflows.
+#[test]
+fn evicting_insert_at_the_cap_without_overflow_does_not_sweep() {
+    let (mut cache, events) = events_cache_capped(Duration::from_secs(60), 3);
+    cache
+        .set_with(1u32, 11u32)
+        .ttl(Duration::from_millis(30))
+        .set();
+    cache
+        .set_with(2u32, 22u32)
+        .ttl(Duration::from_secs(60))
+        .set();
+    std::thread::sleep(std::time::Duration::from_millis(60));
+
+    // Under the cap (2 -> 3) with `.evict()`: no overflow, so the expired key 1 stays.
+    cache
+        .set_with(3u32, 33u32)
+        .ttl(Duration::from_secs(60))
+        .evict()
+        .set();
+    assert_eq!(
+        cache.cache_size(),
+        3,
+        "a size-limited cache only sweeps when the insert overflows the cap"
+    );
+    assert_eq!(fired(&events), Vec::new());
+    assert_eq!(cache.cache_evictions(), Some(0));
+
+    // An explicit `evict()` still reaps it.
+    assert_eq!(cache.evict(), 1);
+    assert_eq!(fired(&events), vec![(1u32, 11u32)]);
+    assert_eq!(cache.cache_evictions(), Some(1));
+}
+
+/// The same combined pass reached through `set_max_size` on a cache holding expired entries:
+/// the shrink trims to the new bound (no cutoff), so expired entries are dropped only
+/// because they sort first, and the resulting count must still match the observable state.
+#[test]
+fn set_max_size_shrink_drops_the_soonest_to_expire_first() {
+    let (mut cache, events) = events_cache(Duration::from_secs(60));
+    cache
+        .set_with(1u32, 11u32)
+        .ttl(Duration::from_millis(30))
+        .set();
+    cache
+        .set_with(2u32, 22u32)
+        .ttl(Duration::from_secs(10))
+        .set();
+    cache
+        .set_with(3u32, 33u32)
+        .ttl(Duration::from_secs(20))
+        .set();
+    cache.set_with(4u32, 44u32).ttl(Duration::ZERO).set();
+    std::thread::sleep(std::time::Duration::from_millis(60));
+
+    assert_eq!(cache.set_max_size(2), None, "no previous bound was set");
+    assert_eq!(sorted_keys(&cache), vec![3u32, 4]);
+    assert_eq!(
+        fired(&events),
+        vec![(1u32, 11u32), (2, 22)],
+        "expiry order, expired first"
+    );
+    assert_eq!(cache.cache_evictions(), Some(2));
+    assert_eq!(
+        cache.evict(),
+        0,
+        "no stale index entries survive the shrink"
+    );
+}

--- a/tests/v3_sharded_concurrent_expiry.rs
+++ b/tests/v3_sharded_concurrent_expiry.rs
@@ -18,12 +18,20 @@ Covered:
 - A flip-stress that re-inserts a fresh value while readers race the expired one,
   exercising the write-upgrade recheck branch: the eviction counter and the
   `on_evict` callback stay in lockstep (never diverge) across many rounds.
+- The same expiry race with `refresh_on_hit = true`, which takes a different code
+  path entirely (an exclusive write lock and a single clock sample per call, with
+  no read-lock/write-lock upgrade): `on_evict` still fires exactly once.
+- A `refresh_on_hit = true` flip-stress across several shards with entries moving
+  between live and expired under contention. Besides the callback/counter lockstep
+  it asserts entry conservation: every entry ever inserted is either still stored,
+  counted as an eviction, or was returned to a `cache_set` caller as a displaced
+  live value -- so no removal can be lost or double-counted.
 
 All items are gated `#[cfg(feature = "time_stores")]`.
 */
 #![cfg(feature = "time_stores")]
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Barrier};
 use std::time::Duration;
 
@@ -185,4 +193,202 @@ fn sharded_ttl_flip_stress_evictions_and_callback_stay_in_lockstep() {
         evictions,
         "on_evict must fire exactly once per counted eviction across the race"
     );
+}
+
+// `refresh_on_hit = true` sends `cache_get` down a completely different branch: it takes
+// the shard's *write* lock up front, samples the clock once (and only when the key is
+// present), and decides absent / expired / live-and-refreshed from that one sample. There
+// is no read-lock-then-upgrade recheck on this path, so the "exactly one remover" property
+// has to come from `remove_entry` under the single write lock instead. The two tests below
+// stress that branch; the rest of this file only ever exercised the default (non-refresh)
+// path.
+#[test]
+fn sharded_ttl_refresh_on_hit_expiry_race_fires_on_evict_once() {
+    let fired = Arc::new(AtomicU64::new(0));
+    let fired2 = fired.clone();
+    let cache = Arc::new(
+        ShardedTtlCache::<u32, u32>::builder()
+            .shards(1)
+            .ttl(Duration::from_millis(30))
+            .refresh_on_hit(true)
+            .on_evict(move |_, _| {
+                fired2.fetch_add(1, Ordering::Relaxed);
+            })
+            .build()
+            .expect("build 1-shard refresh_on_hit ShardedTtlCache"),
+    );
+
+    ConcurrentCached::cache_set(&*cache, 1, 100).unwrap();
+    let before = ConcurrentCacheBase::cache_evictions(&*cache).unwrap();
+    std::thread::sleep(Duration::from_millis(80));
+
+    let gate = Arc::new(Barrier::new(RACERS));
+    let mut handles = Vec::new();
+    for _ in 0..RACERS {
+        let cache = cache.clone();
+        let gate = gate.clone();
+        handles.push(std::thread::spawn(move || {
+            gate.wait();
+            ConcurrentCached::cache_get(&*cache, &1).unwrap()
+        }));
+    }
+    for h in handles {
+        assert_eq!(h.join().unwrap(), None, "expired key must read as None");
+    }
+
+    assert_eq!(
+        fired.load(Ordering::Relaxed),
+        1,
+        "refresh_on_hit must still evict a raced expired entry exactly once"
+    );
+    assert_eq!(
+        ConcurrentCacheBase::cache_evictions(&*cache).unwrap(),
+        before + 1,
+        "exactly one eviction must be counted for the single expired entry"
+    );
+    assert_eq!(cache.len(), 0, "the expired entry must be physically gone");
+}
+
+#[test]
+fn sharded_ttl_refresh_on_hit_flip_stress_conserves_entries_and_evictions() {
+    const KEYS: u32 = 8;
+    const ROUNDS: u32 = 150;
+    const WRITERS: u32 = 2;
+
+    let fired = Arc::new(AtomicU64::new(0));
+    let fired2 = fired.clone();
+    let cache = Arc::new(
+        ShardedTtlCache::<u32, u32>::builder()
+            .shards(4)
+            .ttl(Duration::from_micros(200))
+            .refresh_on_hit(true)
+            .on_evict(move |_, _| {
+                fired2.fetch_add(1, Ordering::Relaxed);
+            })
+            .build()
+            .expect("build 4-shard refresh_on_hit ShardedTtlCache"),
+    );
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let gate = Arc::new(Barrier::new(RACERS + WRITERS as usize));
+
+    // Readers: hammer every key. With a 2ms TTL each key keeps flipping between live
+    // (refreshed in place under the write lock) and expired (removed, counted, callback).
+    let mut readers = Vec::new();
+    for _ in 0..RACERS {
+        let cache = cache.clone();
+        let gate = gate.clone();
+        let stop = stop.clone();
+        readers.push(std::thread::spawn(move || {
+            gate.wait();
+            let mut reads = 0u64;
+            while !stop.load(Ordering::Relaxed) {
+                for k in 0..KEYS {
+                    if let Some(v) = ConcurrentCached::cache_get(&*cache, &k).unwrap() {
+                        assert_eq!(
+                            v % 10,
+                            k,
+                            "a read for key {k} returned a value written for key {}",
+                            v % 10
+                        );
+                    }
+                    reads += 1;
+                }
+            }
+            reads
+        }));
+    }
+
+    // Writers: re-insert every key each round, counting the displaced *live* values they
+    // are handed back (those leave the map without being counted as evictions).
+    let mut writers = Vec::new();
+    for w in 0..WRITERS {
+        let cache = cache.clone();
+        let gate = gate.clone();
+        writers.push(std::thread::spawn(move || {
+            gate.wait();
+            let mut live_displacements = 0u64;
+            for r in 0..ROUNDS {
+                for k in 0..KEYS {
+                    let value = r * 100 + w * 10 + k;
+                    if ConcurrentCached::cache_set(&*cache, k, value)
+                        .unwrap()
+                        .is_some()
+                    {
+                        live_displacements += 1;
+                    }
+                }
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            live_displacements
+        }));
+    }
+
+    let mut live_displacements = 0u64;
+    for h in writers {
+        live_displacements += h.join().expect("writer thread must not panic");
+    }
+    stop.store(true, Ordering::Relaxed);
+    let mut reads = 0u64;
+    for h in readers {
+        reads += h.join().expect("reader thread must not panic");
+    }
+    assert!(reads > 0, "the readers must have run");
+
+    let inserts = u64::from(WRITERS * ROUNDS * KEYS);
+    let evictions = ConcurrentCacheBase::cache_evictions(&*cache).unwrap();
+    // Guard against a vacuous run: with a 200us TTL, a 1ms pause between writer rounds and
+    // readers refreshing hits in place, both kinds of displacement must actually occur.
+    assert!(
+        evictions > 0,
+        "no entry ever expired -- the refresh/expiry branch was never exercised"
+    );
+    assert!(
+        live_displacements > 0,
+        "no live entry was ever displaced -- the live-refresh branch was never exercised"
+    );
+    assert_eq!(
+        fired.load(Ordering::Relaxed),
+        evictions,
+        "on_evict must fire exactly once per counted eviction across the race"
+    );
+    let remaining = cache.len() as u64;
+    assert!(
+        remaining <= u64::from(KEYS),
+        "at most one entry per key can be stored, found {remaining}"
+    );
+    // Every entry ever inserted left the map as a counted eviction, was handed back to a
+    // `cache_set` caller as a displaced live value, or is still stored. A lost or
+    // double-counted eviction breaks this equality.
+    assert_eq!(
+        inserts,
+        remaining + evictions + live_displacements,
+        "inserts={inserts} remaining={remaining} evictions={evictions} \
+         live_displacements={live_displacements}"
+    );
+
+    // Final sweep: the counter advances by exactly the number of entries it removed, and
+    // conservation still holds afterwards.
+    let swept = cache.evict() as u64;
+    let evictions_after = ConcurrentCacheBase::cache_evictions(&*cache).unwrap();
+    assert_eq!(
+        evictions_after,
+        evictions + swept,
+        "the sweep must count exactly what it removed"
+    );
+    assert_eq!(
+        fired.load(Ordering::Relaxed),
+        evictions_after,
+        "the sweep must fire on_evict once per removed entry too"
+    );
+    assert_eq!(
+        inserts,
+        cache.len() as u64 + evictions_after + live_displacements,
+        "conservation must survive the sweep"
+    );
+    for k in 0..KEYS {
+        if let Some(v) = ConcurrentCached::cache_get(&*cache, &k).unwrap() {
+            assert_eq!(v % 10, k, "surviving entries must be self-consistent");
+        }
+    }
 }

--- a/tests/v3_sharded_concurrent_expiry.rs
+++ b/tests/v3_sharded_concurrent_expiry.rs
@@ -154,40 +154,62 @@ fn sharded_ttl_flip_stress_evictions_and_callback_stay_in_lockstep() {
     );
 
     const ROUNDS: u32 = 200;
+    let stop = Arc::new(AtomicBool::new(false));
     let gate = Arc::new(Barrier::new(RACERS + 1));
 
-    let mut handles = Vec::new();
-    // Reader threads: hammer cache_get across the whole run.
+    // Reader threads: hammer cache_get continuously until the writer signals done.
+    // Looping on the stop flag (rather than a fixed round count that finishes in
+    // microseconds) keeps readers contending while each freshly-written entry ages
+    // past the 2ms TTL, so they actually reach and evict expired entries.
+    let mut readers = Vec::new();
     for _ in 0..RACERS {
         let cache = cache.clone();
         let gate = gate.clone();
-        handles.push(std::thread::spawn(move || {
+        let stop = stop.clone();
+        readers.push(std::thread::spawn(move || {
             gate.wait();
-            for _ in 0..ROUNDS {
+            let mut reads = 0u64;
+            while !stop.load(Ordering::Relaxed) {
                 let _ = ConcurrentCached::cache_get(&*cache, &1).unwrap();
+                reads += 1;
             }
+            reads
         }));
     }
-    // Writer thread: re-insert a fresh value each round, letting the short TTL
-    // lapse in between so readers alternately hit and evict.
-    {
+    // Writer thread: re-insert a fresh value each round, sleeping LONGER than the
+    // TTL between rounds so the entry expires before the next overwrite. That lets
+    // the still-looping readers hit the expired entry and evict it, alternating the
+    // hit-and-evict path and driving the write-upgrade recheck branch.
+    let writer = {
         let cache = cache.clone();
         let gate = gate.clone();
-        handles.push(std::thread::spawn(move || {
+        std::thread::spawn(move || {
             gate.wait();
             for r in 0..ROUNDS {
                 ConcurrentCached::cache_set(&*cache, 1, r).unwrap();
-                std::thread::sleep(Duration::from_millis(1));
+                std::thread::sleep(Duration::from_millis(4));
             }
-        }));
+        })
+    };
+    writer.join().unwrap();
+    stop.store(true, Ordering::Relaxed);
+    let mut reads = 0u64;
+    for h in readers {
+        reads += h.join().unwrap();
     }
-    for h in handles {
-        h.join().unwrap();
-    }
+    assert!(reads > 0, "the readers must have run");
 
+    // Guard against a vacuous run: readers looping while entries age past the TTL
+    // must actually reach expired entries and evict them, so the eviction counter
+    // has to advance. Without this the lockstep check below could pass trivially as
+    // 0 == 0 while never exercising the expiry/recheck branch it claims to cover.
+    let evictions = ConcurrentCacheBase::cache_evictions(&*cache).unwrap();
+    assert!(
+        evictions > 0,
+        "no entry ever expired -- the write-upgrade recheck branch was never exercised"
+    );
     // The counter and the callback are bumped together on every removal, so they
     // must be equal regardless of how the race interleaved.
-    let evictions = ConcurrentCacheBase::cache_evictions(&*cache).unwrap();
     assert_eq!(
         fired.load(Ordering::Relaxed),
         evictions,
@@ -272,7 +294,7 @@ fn sharded_ttl_refresh_on_hit_flip_stress_conserves_entries_and_evictions() {
     let stop = Arc::new(AtomicBool::new(false));
     let gate = Arc::new(Barrier::new(RACERS + WRITERS as usize));
 
-    // Readers: hammer every key. With a 2ms TTL each key keeps flipping between live
+    // Readers: hammer every key. With a 200us TTL each key keeps flipping between live
     // (refreshed in place under the write lock) and expired (removed, counted, callback).
     let mut readers = Vec::new();
     for _ in 0..RACERS {

--- a/tests/v3_sharded_lru_read_path.rs
+++ b/tests/v3_sharded_lru_read_path.rs
@@ -1,0 +1,436 @@
+/*!
+Public-API contracts for the sharded LRU-family read/write fast paths.
+
+These pin, from outside the crate, the behavior that the internal single-lookup
+`cache_get` rewrite, the per-shard eviction counters, and the `drain_all`-based
+`cache_clear_with_on_evict` must preserve:
+
+- a live read returns the value, counts a hit, and **promotes** the entry (so the next
+  capacity eviction picks a different victim);
+- an absent read counts a miss and removes nothing;
+- an expired read counts a miss, removes the entry, fires `on_evict`, and counts exactly
+  one eviction;
+- `metrics().evictions` aggregates capacity and non-capacity evictions across *many*
+  shards without double counting, and survives `deep_clone`;
+- `cache_clear_with_on_evict` fires most-recently-used first;
+- overwriting an entry through the `on_evict` path keeps it most-recently-used.
+
+No Redis server required.
+*/
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use cached::{
+    ConcurrentCacheBase, ConcurrentCacheEvict, ConcurrentCached, Expires, ShardedExpiringLruCache,
+    ShardedLruCache,
+};
+
+#[derive(Clone, Debug, PartialEq)]
+struct Val {
+    v: u32,
+    expired: bool,
+}
+
+impl Expires for Val {
+    fn is_expired(&self) -> bool {
+        self.expired
+    }
+}
+
+fn live(v: u32) -> Val {
+    Val { v, expired: false }
+}
+
+fn dead(v: u32) -> Val {
+    Val { v, expired: true }
+}
+
+// --- ShardedExpiringLruCache ------------------------------------------------------------
+
+#[test]
+fn expiring_lru_read_path_hit_miss_expired_and_promotion() {
+    let evicted: Arc<Mutex<Vec<(u32, u32)>>> = Arc::new(Mutex::new(Vec::new()));
+    let evicted2 = Arc::clone(&evicted);
+    let store = ShardedExpiringLruCache::<u32, Val>::builder()
+        .shards(1)
+        .per_shard_max_size(2)
+        .on_evict(move |k: &u32, v: &Val| evicted2.lock().unwrap().push((*k, v.v)))
+        .build()
+        .expect("build ShardedExpiringLruCache");
+
+    ConcurrentCached::cache_set(&store, 1, live(10)).unwrap();
+    ConcurrentCached::cache_set(&store, 2, live(20)).unwrap();
+
+    // Live read: value, one hit, nothing removed.
+    assert_eq!(
+        ConcurrentCached::cache_get(&store, &1).unwrap(),
+        Some(live(10))
+    );
+    assert_eq!(ConcurrentCacheBase::cache_hits(&store), Some(1));
+    assert_eq!(ConcurrentCacheBase::cache_misses(&store), Some(0));
+    assert_eq!(ConcurrentCacheBase::cache_size(&store).unwrap(), Some(2));
+
+    // Absent read: one miss, nothing removed, no callback.
+    assert_eq!(ConcurrentCached::cache_get(&store, &404).unwrap(), None);
+    assert_eq!(ConcurrentCacheBase::cache_misses(&store), Some(1));
+    assert_eq!(ConcurrentCacheBase::cache_size(&store).unwrap(), Some(2));
+    assert!(evicted.lock().unwrap().is_empty());
+
+    // The live read promoted key 1, so the capacity eviction must claim key 2.
+    ConcurrentCached::cache_set(&store, 3, live(30)).unwrap();
+    assert!(ConcurrentCached::cache_contains(&store, &1).unwrap());
+    assert!(!ConcurrentCached::cache_contains(&store, &2).unwrap());
+    assert_eq!(*evicted.lock().unwrap(), vec![(2, 20)]);
+
+    // Expired read: miss, removed, callback, exactly one more eviction. (The insert below
+    // is at capacity and evicts on its own, so the baseline is taken after it.)
+    ConcurrentCached::cache_set(&store, 4, dead(40)).unwrap();
+    let before = store.metrics().evictions.expect("evictions tracked");
+    assert_eq!(ConcurrentCached::cache_get(&store, &4).unwrap(), None);
+    assert!(!ConcurrentCached::cache_contains(&store, &4).unwrap());
+    assert_eq!(
+        store.metrics().evictions.expect("evictions tracked") - before,
+        1,
+        "an expired read must count exactly one eviction"
+    );
+    assert_eq!(evicted.lock().unwrap().last(), Some(&(4, 40)));
+
+    // Reading the now-absent key again is a plain miss with no further eviction.
+    let after_expiry = store.metrics().evictions.expect("evictions tracked");
+    assert_eq!(ConcurrentCached::cache_get(&store, &4).unwrap(), None);
+    assert_eq!(
+        store.metrics().evictions.expect("evictions tracked"),
+        after_expiry
+    );
+}
+
+#[test]
+fn expiring_lru_evictions_aggregate_across_shards_and_survive_deep_clone() {
+    let store = ShardedExpiringLruCache::<u32, Val>::builder()
+        .shards(8)
+        .per_shard_max_size(4)
+        .build()
+        .expect("build ShardedExpiringLruCache");
+
+    // Capacity evictions: 200 keys spread over 8 shards of 4 entries each.
+    for i in 0..200u32 {
+        ConcurrentCached::cache_set(&store, i, live(i)).unwrap();
+    }
+    let capacity_evictions = store.metrics().evictions.expect("evictions tracked");
+    assert_eq!(
+        capacity_evictions,
+        200 - ConcurrentCacheBase::cache_size(&store).unwrap().unwrap() as u64,
+        "every insert beyond what is still stored must have been evicted exactly once"
+    );
+
+    // Non-capacity evictions from more than one shard: a sweep of expired entries.
+    ConcurrentCached::cache_clear(&store).unwrap();
+    for i in 1000..1016u32 {
+        ConcurrentCached::cache_set(&store, i, dead(i)).unwrap();
+    }
+    let stored = ConcurrentCacheBase::cache_size(&store).unwrap().unwrap();
+    assert!(
+        stored >= 8,
+        "the expired entries must be spread over several shards; got {stored}"
+    );
+    let before_sweep = store.metrics().evictions.expect("evictions tracked");
+    let swept = ConcurrentCacheEvict::evict(&store);
+    assert_eq!(swept, stored, "every stored entry is expired");
+    assert_eq!(
+        store.metrics().evictions.expect("evictions tracked") - before_sweep,
+        swept as u64,
+        "the sweep must add exactly one eviction per removed entry"
+    );
+    assert_eq!(
+        ConcurrentCacheBase::cache_evictions(&store),
+        store.metrics().evictions,
+        "the trait method and metrics() must agree"
+    );
+
+    // deep_clone carries the eviction total across (the counters are per-shard now).
+    let total = store.metrics().evictions.expect("evictions tracked");
+    let cloned = store.deep_clone();
+    assert_eq!(cloned.metrics().evictions, Some(total));
+    assert_eq!(ConcurrentCacheBase::cache_evictions(&cloned), Some(total));
+
+    // ... and the clone is independent.
+    ConcurrentCached::cache_set(&cloned, 5000, dead(1)).unwrap();
+    assert_eq!(ConcurrentCached::cache_get(&cloned, &5000).unwrap(), None);
+    assert_eq!(cloned.metrics().evictions, Some(total + 1));
+    assert_eq!(store.metrics().evictions, Some(total));
+
+    // Resetting metrics zeroes every family of counters.
+    ConcurrentCached::cache_reset_metrics(&store).unwrap();
+    assert_eq!(store.metrics().evictions, Some(0));
+    assert_eq!(ConcurrentCacheBase::cache_evictions(&store), Some(0));
+}
+
+#[test]
+fn expiring_lru_overwrite_with_on_evict_keeps_entry_most_recently_used() {
+    let store = ShardedExpiringLruCache::<u32, Val>::builder()
+        .shards(1)
+        .per_shard_max_size(2)
+        .on_evict(|_, _| {})
+        .build()
+        .expect("build ShardedExpiringLruCache");
+    ConcurrentCached::cache_set(&store, 1, live(10)).unwrap();
+    ConcurrentCached::cache_set(&store, 2, live(20)).unwrap();
+
+    // Overwrite the least-recently-used entry; it must become most-recently-used.
+    assert_eq!(
+        ConcurrentCached::cache_set(&store, 1, live(11)).unwrap(),
+        Some(live(10))
+    );
+    ConcurrentCached::cache_set(&store, 3, live(30)).unwrap();
+    assert_eq!(
+        ConcurrentCached::cache_get(&store, &1).unwrap(),
+        Some(live(11)),
+        "the overwritten entry must have been promoted and so must survive"
+    );
+    assert!(!ConcurrentCached::cache_contains(&store, &2).unwrap());
+}
+
+// --- ShardedLruCache --------------------------------------------------------------------
+
+#[test]
+fn sharded_lru_clear_with_on_evict_fires_most_recently_used_first() {
+    let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let seen2 = Arc::clone(&seen);
+    let store = ShardedLruCache::<String, u64>::builder()
+        .shards(1)
+        .per_shard_max_size(16)
+        .on_evict(move |k: &String, _v: &u64| seen2.lock().unwrap().push(k.clone()))
+        .build()
+        .expect("build ShardedLruCache");
+
+    for i in 0..5u64 {
+        ConcurrentCached::cache_set(&store, i.to_string(), i).unwrap();
+    }
+    // Re-read "1" so the chain is not merely reverse insertion order.
+    assert_eq!(
+        ConcurrentCached::cache_get(&store, &"1".to_string()).unwrap(),
+        Some(1)
+    );
+    let before = store.metrics().evictions.expect("evictions tracked");
+
+    store.cache_clear_with_on_evict();
+
+    assert_eq!(
+        *seen.lock().unwrap(),
+        vec![
+            "1".to_string(),
+            "4".to_string(),
+            "3".to_string(),
+            "2".to_string(),
+            "0".to_string(),
+        ],
+        "on_evict must fire most-recently-used first"
+    );
+    assert!(store.is_empty());
+    assert_eq!(
+        store.metrics().evictions.expect("evictions tracked") - before,
+        5,
+        "every cleared entry must be counted once"
+    );
+
+    // The cleared store keeps working.
+    ConcurrentCached::cache_set(&store, "x".to_string(), 42).unwrap();
+    assert_eq!(
+        ConcurrentCached::cache_get(&store, &"x".to_string()).unwrap(),
+        Some(42)
+    );
+}
+
+#[test]
+fn sharded_lru_clear_with_on_evict_clears_every_shard() {
+    let count = Arc::new(AtomicU64::new(0));
+    let count2 = Arc::clone(&count);
+    let store = ShardedLruCache::<String, u64>::builder()
+        .shards(8)
+        .per_shard_max_size(64)
+        .on_evict(move |_k: &String, _v: &u64| {
+            count2.fetch_add(1, Ordering::Relaxed);
+        })
+        .build()
+        .expect("build ShardedLruCache");
+    for i in 0..200u64 {
+        ConcurrentCached::cache_set(&store, i.to_string(), i).unwrap();
+    }
+    assert_eq!(
+        ConcurrentCacheBase::cache_size(&store).unwrap(),
+        Some(200),
+        "no capacity eviction should have happened yet"
+    );
+    store.cache_clear_with_on_evict();
+    assert_eq!(count.load(Ordering::Relaxed), 200);
+    assert!(store.is_empty());
+}
+
+// --- ShardedLruTtlCache -----------------------------------------------------------------
+
+#[cfg(feature = "time_stores")]
+mod lru_ttl {
+    use super::*;
+    use cached::ShardedLruTtlCache;
+    use std::time::Duration;
+
+    #[test]
+    fn read_path_hit_miss_expired_and_promotion() {
+        let evicted: Arc<Mutex<Vec<(u32, u32)>>> = Arc::new(Mutex::new(Vec::new()));
+        let evicted2 = Arc::clone(&evicted);
+        let store = ShardedLruTtlCache::<u32, u32>::builder()
+            .shards(1)
+            .per_shard_max_size(2)
+            .ttl(Duration::from_millis(40))
+            .on_evict(move |k: &u32, v: &u32| evicted2.lock().unwrap().push((*k, *v)))
+            .build()
+            .expect("build ShardedLruTtlCache");
+
+        ConcurrentCached::cache_set(&store, 1, 10).unwrap();
+        ConcurrentCached::cache_set(&store, 2, 20).unwrap();
+
+        // Live read: value, one hit, nothing removed, and the entry is promoted.
+        assert_eq!(ConcurrentCached::cache_get(&store, &1).unwrap(), Some(10));
+        assert_eq!(ConcurrentCacheBase::cache_hits(&store), Some(1));
+        assert_eq!(ConcurrentCached::cache_get(&store, &404).unwrap(), None);
+        assert_eq!(ConcurrentCacheBase::cache_misses(&store), Some(1));
+        assert_eq!(ConcurrentCacheBase::cache_size(&store).unwrap(), Some(2));
+
+        ConcurrentCached::cache_set(&store, 3, 30).unwrap();
+        assert!(ConcurrentCached::cache_contains(&store, &1).unwrap());
+        assert!(!ConcurrentCached::cache_contains(&store, &2).unwrap());
+        assert_eq!(*evicted.lock().unwrap(), vec![(2, 20)]);
+
+        // Expired read: miss, removed, callback, exactly one more eviction.
+        let before = store.metrics().evictions.expect("evictions tracked");
+        std::thread::sleep(Duration::from_millis(120));
+        assert_eq!(ConcurrentCached::cache_get(&store, &1).unwrap(), None);
+        assert!(!ConcurrentCached::cache_contains(&store, &1).unwrap());
+        assert_eq!(
+            store.metrics().evictions.expect("evictions tracked") - before,
+            1,
+            "an expired read must count exactly one eviction"
+        );
+        assert_eq!(evicted.lock().unwrap().last(), Some(&(1, 10)));
+    }
+
+    #[test]
+    fn evictions_aggregate_across_shards_and_survive_deep_clone() {
+        let store = ShardedLruTtlCache::<u32, u32>::builder()
+            .shards(8)
+            .per_shard_max_size(4)
+            .ttl(Duration::from_millis(40))
+            .build()
+            .expect("build ShardedLruTtlCache");
+
+        for i in 0..200u32 {
+            ConcurrentCached::cache_set(&store, i, i).unwrap();
+        }
+        let stored = ConcurrentCacheBase::cache_size(&store).unwrap().unwrap() as u64;
+        assert_eq!(
+            store.metrics().evictions.expect("evictions tracked"),
+            200 - stored,
+            "every insert beyond what is still stored must have been evicted exactly once"
+        );
+
+        // Non-capacity evictions from many shards at once: a TTL sweep.
+        std::thread::sleep(Duration::from_millis(120));
+        let before_sweep = store.metrics().evictions.expect("evictions tracked");
+        let swept = ConcurrentCacheEvict::evict(&store) as u64;
+        assert_eq!(swept, stored, "every stored entry is expired by now");
+        assert_eq!(
+            store.metrics().evictions.expect("evictions tracked") - before_sweep,
+            swept,
+            "the sweep must add exactly one eviction per removed entry"
+        );
+        assert_eq!(
+            ConcurrentCacheBase::cache_evictions(&store),
+            store.metrics().evictions,
+            "the trait method and metrics() must agree"
+        );
+
+        let total = store.metrics().evictions.expect("evictions tracked");
+        let cloned = store.deep_clone();
+        assert_eq!(cloned.metrics().evictions, Some(total));
+        assert_eq!(ConcurrentCacheBase::cache_evictions(&cloned), Some(total));
+
+        // The clone is independent.
+        ConcurrentCached::cache_set(&cloned, 5000, 1).unwrap();
+        assert_eq!(
+            ConcurrentCached::cache_remove(&cloned, &5000).unwrap(),
+            Some(1)
+        );
+        assert_eq!(cloned.metrics().evictions, Some(total + 1));
+        assert_eq!(store.metrics().evictions, Some(total));
+
+        ConcurrentCached::cache_reset_metrics(&store).unwrap();
+        assert_eq!(store.metrics().evictions, Some(0));
+        assert_eq!(ConcurrentCacheBase::cache_evictions(&store), Some(0));
+    }
+
+    #[test]
+    fn overwrite_with_on_evict_keeps_entry_most_recently_used() {
+        let store = ShardedLruTtlCache::<u32, u32>::builder()
+            .shards(1)
+            .per_shard_max_size(2)
+            .ttl(Duration::from_secs(3600))
+            .on_evict(|_, _| {})
+            .build()
+            .expect("build ShardedLruTtlCache");
+        ConcurrentCached::cache_set(&store, 1, 10).unwrap();
+        ConcurrentCached::cache_set(&store, 2, 20).unwrap();
+
+        assert_eq!(
+            ConcurrentCached::cache_set(&store, 1, 11).unwrap(),
+            Some(10)
+        );
+        ConcurrentCached::cache_set(&store, 3, 30).unwrap();
+        assert_eq!(
+            ConcurrentCached::cache_get(&store, &1).unwrap(),
+            Some(11),
+            "the overwritten entry must have been promoted and so must survive"
+        );
+        assert!(!ConcurrentCached::cache_contains(&store, &2).unwrap());
+    }
+
+    #[test]
+    fn clear_with_on_evict_fires_most_recently_used_first() {
+        let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen2 = Arc::clone(&seen);
+        let store = ShardedLruTtlCache::<String, u64>::builder()
+            .shards(1)
+            .per_shard_max_size(16)
+            .ttl(Duration::from_secs(3600))
+            .on_evict(move |k: &String, _v: &u64| seen2.lock().unwrap().push(k.clone()))
+            .build()
+            .expect("build ShardedLruTtlCache");
+        for i in 0..5u64 {
+            ConcurrentCached::cache_set(&store, i.to_string(), i).unwrap();
+        }
+        assert_eq!(
+            ConcurrentCached::cache_get(&store, &"1".to_string()).unwrap(),
+            Some(1)
+        );
+        let before = store.metrics().evictions.expect("evictions tracked");
+
+        store.cache_clear_with_on_evict();
+
+        assert_eq!(
+            *seen.lock().unwrap(),
+            vec![
+                "1".to_string(),
+                "4".to_string(),
+                "3".to_string(),
+                "2".to_string(),
+                "0".to_string(),
+            ],
+            "on_evict must fire most-recently-used first"
+        );
+        assert!(store.is_empty());
+        assert_eq!(
+            store.metrics().evictions.expect("evictions tracked") - before,
+            5
+        );
+    }
+}


### PR DESCRIPTION
Performance work across the in-memory and sharded stores, plus a behavior change to `cache_set` recency.

## Breaking

- `cache_set` (and `cache_set_returning_entry`) over an existing key now promote that key to most-recently-used instead of replacing it in place. Affects `LruCache`, `LruTtlCache`, `ExpiringLruCache`, `ShardedLruCache`, `ShardedLruTtlCache`, and `ShardedExpiringLruCache`, and changes which entry a capacity eviction selects in overwrite-heavy workloads. `cache_peek` / `cache_peek_with_expiry_status` / `cache_contains` stay non-promoting. See `specs/design/0038-cache-set-promotes-on-overwrite.md`.
- Resolves an `on_evict` divergence on the sharded LRU-TTL and expiring-LRU stores: the callback and no-callback write branches now share one promoting primitive, so configuring an observational `on_evict` no longer changes eviction order.

## Changed

- Sharded stores resolve a read hit in one hash lookup instead of two, count evictions per shard instead of through a shared striped counter, and cache the host CPU topology instead of probing it per construction.
- LRU-family and expiry-aware stores sweep in one pass instead of collecting keys first; TTL stores sample the clock once per operation instead of once per entry examined.
- `ExpiringLruCache::cache_set` fires `on_evict` with the stored key, matching `LruTtlCache`, and drops an unconditional key clone from every set.
- `TtlSortedCache` reuses the stored key on overwrite, its `get_or_set` family no longer removes an expired entry before running the initializer, and `retain_latest` counts an eviction before firing `on_evict`.

## Tests

- New certification tests for promotion and the eviction-victim shift, head and sole-entry `move_to_front` ring integrity, sharded semantics and concurrency, stored-key lifecycle, and the LRU-TTL / expiring-LRU parity.

Redis tests require a live server (`CACHED_REDIS_CONNECTION_STRING`); CI runs `--all-features`.