### PR TITLE
feat: derive default shard count from `max_size`, make `cache_contains` dyn-callable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,21 @@
   caller queues for the lock is judged live: `cache_set` returns `Some(old)` with no eviction
   and no `on_evict`, where previously the clock was re-read under the lock. This stays within
   the documented lazy-expiry contract, which makes no promise of prompt removal.
+- The default shard count of the LRU-bounded sharded stores (`ShardedLruCache`,
+  `ShardedLruTtlCache`, `ShardedExpiringLruCache`) is now capped by the requested `max_size`
+  instead of derived solely from `available_parallelism()`. On the default path (no explicit
+  `.shards(n)`) with a total `max_size`, the count is
+  `next_power_of_two(max_size / 16).clamp(1, default_shard_count())`. This changes the observable
+  `capacity()`, `shards()`, and `shard_sizes()` for small caches on high-core-count hosts
+  (`ShardedLruCache::new(100)` resolves to 8 shards / capacity 128, where a 64-core box previously
+  produced 256 shards / capacity 4096), and makes per-shard LRU eviction coarser-grained since
+  each shard holds a larger fraction of the entries. An explicit `.shards(n)` is authoritative and
+  unaffected; the `per_shard_max_size` path and the unbounded stores (`ShardedUnboundCache`, and
+  `ShardedTtlCache` / `ShardedExpiringCache` without a `max_size`) keep `default_shard_count()`.
+- `ConcurrentCached::cache_contains` drops its `where Self: Sized` bound and is now part of the
+  vtable, so it is callable through `dyn ConcurrentCached<K, V, Error = E>`. Breaking only for rc
+  adopters whose out-of-crate `ConcurrentCached` impls repeated the `where Self: Sized` clause on
+  their `cache_contains`: drop it to match the trait.
 
 ### Added
 
@@ -100,18 +115,19 @@
   beyond the behavior changes listed under Breaking Changes above. The sharded stores resolve
   a read hit in one hash lookup instead of two, count evictions per shard rather than through a
   shared striped counter, and cache the host's CPU topology instead of probing it on every
-  construction. The LRU-family and expiry-aware stores sweep in one pass instead of collecting
-  keys first, and the TTL stores sample the clock once per operation instead of once per entry
-  examined. `ExpiringCache` is 48 bytes plus two heap buffers smaller per instance.
+  construction. The topology is sampled once per process (memoized in a `OnceLock`), so a later
+  CPU-quota or cgroup change does not affect the shard count of subsequently built caches. The
+  LRU-family and expiry-aware stores sweep in one pass instead of collecting keys first, and the
+  TTL stores sample the clock once per operation instead of once per entry examined.
+  `ExpiringCache` is smaller per instance (one flattened map and two fewer heap buffers).
 
 ### Fixed
 
 - docs.rs feature annotation (`doc(cfg)`) on `AsyncRedisCacheBuilder::client_side_caching`,
   which previously rendered as unconditionally available.
 - `ConcurrentCached::cache_contains` docs no longer list `AsyncRedisCache` as an implementor
-  (it implements the async counterpart) and note the `dyn` limitation of the
-  `where Self: Sized` bound; the rc.9 changelog entry and `specs/traits-concurrent.md` are
-  corrected to match.
+  (it implements the async counterpart); the rc.9 changelog entry and
+  `specs/traits-concurrent.md` are corrected to match.
 - Macro docs note the `Arc<T>` return pattern for expensive-to-clone values ([#64]): the
   cache stores the `Arc`, hits clone only the pointer.
 - docs.rs feature badges on the `async_core`-gated `CachedGetOrSetAsync` and

--- a/cached_proc_macro/src/cached.rs
+++ b/cached_proc_macro/src/cached.rs
@@ -604,8 +604,9 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
     // The generated cache internals `.clone()` the value on `cache_set` and
     // `.to_owned()` it on a cache hit; without a `Clone` bound on the cached
     // value type those calls fail deep inside macro-generated code with an
-    // opaque trait-bound error. Emit a clear, precisely-spanned assertion
-    // instead (see `clone_return_assertion`).
+    // opaque trait-bound error. Emit a clear, precisely-spanned assertion ahead
+    // of those internals so it appears first (see `clone_return_assertion`);
+    // the opaque errors below still follow it.
     let clone_type_assertion = clone_return_assertion(&cache_value_ty, output_span);
 
     // make the cache identifier

--- a/cached_proc_macro/src/helpers.rs
+++ b/cached_proc_macro/src/helpers.rs
@@ -380,8 +380,9 @@ pub(super) fn find_value_type(
 /// Without this, a non-`Clone` return type only fails deep inside the
 /// generated cache internals (the `.clone()` call in the `cache_set` block, or
 /// the `.to_owned()` call on a cache hit), producing a trait-bound error that
-/// points at macro-generated code rather than at the user's return type -
-/// confusing and hard to act on.
+/// points at macro-generated code rather than at the user's return type. This
+/// assertion is emitted ahead of those internals, so its clear,
+/// precisely-spanned error appears first; the opaque ones still follow it.
 ///
 /// The assertion is a local, non-generic-over-`value_ty` helper fn plus a
 /// call that names `value_ty` as its turbofish argument, e.g.

--- a/docs/migrations/2.0-to-3.0-human.md
+++ b/docs/migrations/2.0-to-3.0-human.md
@@ -162,6 +162,12 @@ let cache: LruCache<String, u32> = LruCache::new(100);
 let cache: TtlCache<String, u32> = TtlCache::new(Duration::from_secs(60));
 ```
 
+The default shard count of the LRU-bounded sharded stores (`ShardedLruCache`, `ShardedLruTtlCache`,
+`ShardedExpiringLruCache`) is now scaled down for small `max_size` (roughly `max_size / 16` shards,
+capped by the CPU-derived default), so `ShardedLruCache::new(100)` reports 8 shards and a
+`capacity()` of 128 rather than the much larger shard count and capacity a high-core-count host
+produced before. An explicit `.shards(n)` still overrides this.
+
 ### 5. Trait imports
 
 The short method aliases (`get`, `set`, `remove`, `len`, `is_empty`, ...) moved off the `Cached` /
@@ -351,6 +357,10 @@ Note that the trait declares `async_cache_contains` in RPIT form
 (`impl Future<Output = ...> + Send` with `where Self: Sized + Sync, K: Sync`); the
 `async fn` above desugars to it, so either spelling works in an impl. The machine guide
 shows the full RPIT form.
+
+The sync `cache_contains` has no `Self: Sized` bound, so it is now callable through
+`dyn ConcurrentCached<K, V, Error = E>`. If your rc-era impl copied a `where Self: Sized` onto its
+`cache_contains`, drop it to match the trait.
 
 If you only use the built-in sharded, redis, or redb stores, no change is needed.
 

--- a/docs/migrations/2.0-to-3.0.md
+++ b/docs/migrations/2.0-to-3.0.md
@@ -1678,6 +1678,48 @@ Action: none required for correctness. There is no public API that writes a valu
 touching recency; `cache_peek`, `cache_peek_with_expiry_status`, and `cache_contains` remain
 non-promoting reads.
 
+### 77. Default shard count of the LRU-bounded sharded stores is capped by `max_size`
+
+The DEFAULT shard count of `ShardedLruCache`, `ShardedLruTtlCache`, and `ShardedExpiringLruCache`
+(no explicit `.shards(n)` on the builder, and a total `max_size` rather than `per_shard_max_size`)
+is now `next_power_of_two(max_size / 16).clamp(1, default_shard_count())` instead of the raw
+`default_shard_count()` (`available_parallelism() * 4`, clamped to `[8, 1024]`). Small caches on
+high-core-count hosts get fewer, larger shards: `ShardedLruCache::new(100)` resolves to 8 shards
+with an effective `capacity()` of 128, where a 64-core box previously built 256 shards with a
+capacity of 4096. `shards()`, `shard_sizes()`, and `capacity()` change accordingly, and per-shard
+LRU eviction is coarser-grained since each shard holds a larger fraction of the entries.
+
+An explicit `.shards(n)` is authoritative and unaffected. The `per_shard_max_size` path and the
+unbounded stores (`ShardedUnboundCache`, and `ShardedTtlCache` / `ShardedExpiringCache` without a
+`max_size`) keep `default_shard_count()`.
+
+Detection: a test or invariant that asserts on `shards()`, `shard_sizes()`, or `capacity()` of a
+default-constructed LRU-bounded sharded cache with a small `max_size`.
+
+Action: pin the count with `.shards(n)` if you depend on a specific shard count. Otherwise none;
+reads and writes are unchanged.
+
+### 78. `ConcurrentCached::cache_contains` is dyn-callable (`where Self: Sized` dropped)
+
+`cache_contains` no longer carries a `where Self: Sized` bound, so it is part of the vtable and
+callable through `dyn ConcurrentCached<K, V, Error = E>`. This only affects out-of-crate
+`ConcurrentCached` implementations written against a 3.0.0 rc that copied the `where Self: Sized`
+clause onto their `cache_contains`: the override no longer matches the trait signature.
+
+Detection: `E0053` (method `cache_contains` has an incompatible type / where-clause) on a custom
+`impl ConcurrentCached` that repeated `where Self: Sized`.
+
+Action: drop the `where Self: Sized` clause from your `cache_contains` implementation.
+```rust
+// Before
+fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
+where
+    Self: Sized,
+{ /* ... */ }
+// After
+fn cache_contains(&self, k: &K) -> Result<bool, Self::Error> { /* ... */ }
+```
+
 ## Required Cargo.toml change
 
 ```toml

--- a/specs/design/0037-sharded-lru-default-shard-cap.md
+++ b/specs/design/0037-sharded-lru-default-shard-cap.md
@@ -1,6 +1,6 @@
 # 0037 - sharded LRU default shard count bounded by max_size
 
-Status: Not implemented
+Status: Implemented
 
 ## Current state
 
@@ -22,69 +22,74 @@ more capacity than requested for a bounded cache on a high-core-count machine:
 4096 effective capacity: 256 hash tables and 256 `Vec`s eagerly allocated for a cache asked to
 hold only 100 entries.
 
-## The rule (proposed)
+## The rule
 
 When a builder has a total `max_size` (as opposed to an explicit `per_shard_max_size`), the
-DEFAULT shard count would become:
+DEFAULT shard count is:
 
 ```text
 next_power_of_two(max_size / 16).clamp(1, default_shard_count())
 ```
 
-to be implemented by `default_shard_count_for_capacity(Option<usize>)` in
-`src/stores/sharded/mod.rs`. Passing `None` (the unbounded stores' path) would reproduce
-`default_shard_count()` exactly, unchanged. This would keep each shard at roughly its 16-entry
-floor by construction instead of relying on the floor to silently inflate a shard count picked
-without regard to capacity.
+implemented by `default_shard_count_for_capacity(Option<usize>)` in
+`src/stores/sharded/mod.rs`. Passing `None` (the unbounded stores' path, and the
+`per_shard_max_size` path, which has no total to scale against) reproduces `default_shard_count()`
+exactly, unchanged. This keeps each shard at roughly its 16-entry floor by construction instead of
+relying on the floor to silently inflate a shard count picked without regard to capacity.
 
-**An explicit `.shards(n)` on a builder would remain authoritative.** `default_shard_count_for_capacity`
-would be consulted only on the default (unconfigured) shard-count path; a caller who sets
-`.shards(n)` would still get exactly `n` shards regardless of `max_size`.
+Each LRU-family builder consults `default_shard_count_for_capacity(self.max_size)` on the default
+path via a `resolve_shard_count` helper: when `self.shards` is `None` it derives the count from
+capacity, and when `.shards(n)` is set it defers to `checked_shard_count` unchanged.
+
+An explicit `.shards(n)` on a builder remains authoritative. `default_shard_count_for_capacity` is
+consulted only on the default (unconfigured) shard-count path; a caller who sets `.shards(n)` gets
+exactly `n` shards (rounded up to a power of two) regardless of `max_size`, preserving the
+`Some(0)` rejection and the rounding-overflow guard in `checked_shard_count`.
 
 ## Why this is default tuning, not a bug fix
 
-The over-capacity outcome is currently *documented*, not merely an accident of the formula:
-`src/stores/sharded/lru.rs` around lines 738-745 (the `max_size` builder doc) and around lines
-86-91 (`ShardedLruCache::new` doc) both state that "the effective total capacity can exceed
-`max_size` for small values" and point at `capacity()` to read the actual figure. A caller could
-be relying on the current default shard count for its own reasons (e.g. deliberately
-over-provisioning to reduce shard contention). Changing the default is a considered tuning
-decision (trading some of that headroom for allocation cost proportional to the requested size),
-not a correctness fix for behavior that violated its own contract.
+The over-capacity outcome was already *documented*, not merely an accident of the formula: the
+`max_size` builder doc and the `ShardedLruCache::new` doc in `src/stores/sharded/lru.rs` both
+state that the effective total capacity can exceed `max_size` for small values and point at
+`capacity()` to read the actual figure. A caller could be relying on the old default shard count
+for its own reasons (e.g. deliberately over-provisioning to reduce shard contention). Changing the
+default is a considered tuning decision (trading some of that headroom for allocation cost
+proportional to the requested size), not a correctness fix for behavior that violated its own
+contract. The docs are updated to describe the capped default (the overshoot is now roughly
+`max_size` rounded up to the 16-per-shard floor rather than a fixed CPU-derived shard count times
+16).
 
-## Observable surface that would change
+## Observable surface that changed
 
-For caches built through the default (no explicit `.shards(n)`) path with a `max_size`, once this
-lands:
+For caches built through the default (no explicit `.shards(n)`) path with a `max_size`:
 
-- `capacity()`: the effective total capacity would be smaller for small `max_size` values on
-  high-core-count machines, though it could still exceed `max_size` when the 16-per-shard floor
-  applies (e.g. `max_size = 100` would yield 8 shards x 16 = 128, versus 256 shards x 16 = 4096
-  today).
-- `shards()`: would report the capped default shard count, not the raw
-  `available_parallelism() * 4` figure.
-- `shard_sizes()`: fewer, larger shards under the new default.
-- Eviction distribution: with fewer shards, each shard would hold a larger fraction of the total
-  entries, so LRU eviction (which is per-shard) would be coarser-grained under concurrent load.
+- `capacity()`: the effective total capacity is smaller for small `max_size` values on
+  high-core-count machines, though it can still exceed `max_size` when the 16-per-shard floor
+  applies (e.g. `max_size = 100` yields 8 shards x 16 = 128, versus 256 shards x 16 = 4096 under
+  the old default on a 64-core box).
+- `shards()`: reports the capped default shard count, not the raw `available_parallelism() * 4`
+  figure.
+- `shard_sizes()`: fewer, larger shards under the default.
+- Eviction distribution: with fewer shards, each shard holds a larger fraction of the total
+  entries, so LRU eviction (which is per-shard) is coarser-grained under concurrent load.
 
-Existing tests that construct sharded LRU caches with an explicit `.shards(n)` would be
-unaffected, since `.shards(n)` overrides the default path entirely. Only default-shard-count
-construction (`::new(max_size)` or `.max_size(n).build()` with no `.shards()` call) would observe
-the new sizing.
+Caches built with an explicit `.shards(n)` are unaffected, since `.shards(n)` overrides the
+default path entirely. The unbounded sharded stores (`ShardedUnboundCache`, and the non-LRU
+`ShardedTtlCache` / `ShardedExpiringCache` without a `max_size`) are unaffected: their default
+path passes `None` and keeps `default_shard_count()`. The `per_shard_max_size` path is also
+unaffected. Only default-shard-count construction with a total `max_size` (`::new(max_size)` or
+`.max_size(n).build()` with no `.shards()` call) observes the new sizing.
 
-This must land before the 3.0.0 final release: it changes an observable default (not just an
+This landed before the 3.0.0 final release: it changes an observable default (not just an
 internal allocation detail), and 3.0 is the last point where a default like this can move without
 a deprecation cycle.
 
 ## Notes
 
-- `default_shard_count_for_capacity` and its test suite already exist in
-  `src/stores/sharded/mod.rs`; the LRU-family builders (`ShardedLruCacheBuilder`,
-  `ShardedLruTtlCacheBuilder`, `ShardedExpiringLruCacheBuilder`) need to call it on their default
-  shard-count path in place of the bare `default_shard_count()`. See
-  `checked_shard_count` in `src/stores/sharded/mod.rs`, which is the current unconditional
-  `shards.unwrap_or_else(default_shard_count)` call site each builder's `build()` goes through.
+- `default_shard_count_for_capacity` lives in `src/stores/sharded/mod.rs`. The LRU-family
+  builders (`ShardedLruCacheBuilder`, `ShardedLruTtlCacheBuilder`, `ShardedExpiringLruCacheBuilder`)
+  call it on their default shard-count path through a `resolve_shard_count` helper; the explicit
+  `.shards(n)` path still goes through `checked_shard_count`.
 - The 16-per-shard floor itself (`per_shard_cap_from_total`) is unchanged; this record only
   changes how many shards the default path asks for.
-- See [store-sharded.md](../store-sharded.md) SHARD-7 for the current (not-yet-changed) behavior
-  and the same planned cap described here.
+- See [store-sharded.md](../store-sharded.md) SHARD-7 for the live behavior.

--- a/specs/store-sharded.md
+++ b/specs/store-sharded.md
@@ -71,23 +71,24 @@ no `K: Clone` bound and is inherent-only, not a trait method; see
 
 ## SHARD-7
 
-**Current behavior:** for the LRU-bounded variants (`ShardedLruCache`, `ShardedLruTtlCache`,
-`ShardedExpiringLruCache`), the DEFAULT shard count (no explicit `.shards(n)` on the builder)
-ignores `max_size` entirely; it is derived only from `available_parallelism()`. Combined with the
-16-entries-per-shard floor (`per_shard_cap_from_total`), this means the effective capacity can
-exceed the requested `max_size` by a wide margin on a high-core-count host: `ShardedLruCache::new(100)`
-on a 64-core box preallocates 256 shards and yields an effective capacity of 4096, not 100. Read
-`capacity()` after construction to see the actual figure a given host resolves to; an explicit
-`.shards(n)` on the builder is the only way to control this today.
-
-**Planned, not yet in effect.** The DEFAULT shard count is intended to be capped by the requested
-`max_size` instead: the helper `default_shard_count_for_capacity` would yield
+For the LRU-bounded variants (`ShardedLruCache`, `ShardedLruTtlCache`, `ShardedExpiringLruCache`),
+the DEFAULT shard count (no explicit `.shards(n)` on the builder) is capped by the requested
+`max_size`. The helper `default_shard_count_for_capacity(Some(max_size))` yields
 `next_power_of_two(max_size / 16).clamp(1, default_shard_count())`, where `default_shard_count()`
-is `available_parallelism() * 4` clamped to `[8, 1024]` and rounded to a power of two. This helper
-exists (`#[allow(dead_code)]`) but no builder's default path calls it yet. Once wired in, building
-without a `max_size` (the unbounded sharded stores) would be unaffected and would keep using
-`default_shard_count()` directly, and `.shards(n)` on the builder would always override this
-default and remain authoritative regardless of `max_size`. See
+is `available_parallelism() * 4` clamped to `[8, 1024]` and rounded to a power of two. Each
+LRU-family builder calls it on the default path via `resolve_shard_count`.
+
+Combined with the 16-entries-per-shard floor (`per_shard_cap_from_total`), the effective capacity
+can still exceed the requested `max_size`, but only modestly: `ShardedLruCache::new(100)` resolves
+to 8 shards and an effective capacity of 128 (8 x 16), not the old 256 shards / 4096 capacity a
+64-core box produced. Read `capacity()` after construction for the exact figure.
+
+Building without a `max_size` (the unbounded sharded stores `ShardedUnboundCache`, and the non-LRU
+`ShardedTtlCache` / `ShardedExpiringCache`) passes `None` and keeps `default_shard_count()`
+directly, unaffected. The `per_shard_max_size` path (no total) likewise keeps
+`default_shard_count()`. An explicit `.shards(n)` always overrides the default and remains
+authoritative regardless of `max_size` (routed through `checked_shard_count`, which preserves the
+`Some(0)` rejection and the rounding-overflow guard). See
 [design/0037-sharded-lru-default-shard-cap.md](design/0037-sharded-lru-default-shard-cap.md).
 
 ## SHARD-8

--- a/specs/traits-concurrent.md
+++ b/specs/traits-concurrent.md
@@ -37,9 +37,10 @@ the ext-trait aliases, consistent with the other inherent shims (`get`, `set`, `
 They likewise expose inherent `retain<F: FnMut(&K, &V) -> bool>(&self, keep: F)` (see
 [store-sharded.md](store-sharded.md) SHARD-6). It is deliberately not a `ConcurrentCached*` trait
 method: it is generic over `F`, so a trait method would need `where Self: Sized` to stay object
-safe (the crate already carries that wart on `cache_contains`), and adding a required method to
-`ConcurrentCached*` pre-3.0-final would break external implementors, with no sensible default to
-provide instead. Revisit as a trait method post-3.0 if a generic consumer needs it.
+safe, which would keep it off the vtable and out of reach through `dyn ConcurrentCached`. Adding a
+required method to `ConcurrentCached*` pre-3.0-final would also break external implementors, with
+no sensible default to provide instead. Revisit as a trait method post-3.0 if a generic consumer
+needs it.
 
 ## CTRAIT-3
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2333,16 +2333,16 @@ pub trait ConcurrentCached<K, V>: ConcurrentCacheBase {
     /// (`AsyncRedisCache` implements the async counterpart,
     /// [`async_cache_contains`](ConcurrentCachedAsync::async_cache_contains).)
     ///
-    /// The `where Self: Sized` bound keeps this generic method out of the vtable, so it is
-    /// not callable through `dyn ConcurrentCached`; use the concrete type, the inherent
-    /// `contains` on the sharded stores, or a generic bound instead.
+    /// This method is object-safe: it takes no generic parameters and does not require
+    /// `Self: Sized`, so it is part of the vtable and callable through
+    /// `dyn ConcurrentCached` (e.g. `Box<dyn ConcurrentCached<K, V, Error = _>>`), not only on
+    /// the concrete type. The inherent `contains` on the sharded stores remains available for
+    /// the same check without a trait import.
     ///
     /// # Errors
     ///
     /// Should return `Self::Error` if the operation fails.
-    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
-    where
-        Self: Sized;
+    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>;
 
     /// Remove all cached entries while preserving capacity allocation and metrics.
     ///

--- a/src/stores/expiring_lru.rs
+++ b/src/stores/expiring_lru.rs
@@ -971,6 +971,56 @@ mod tests {
         );
     }
 
+    // B1 regression: on_evict must receive the STORED key, not the caller's lookup key.
+    // Key types can have fields not covered by Eq/Hash; the stored key and the new key may
+    // differ in those extra fields even though they compare equal.
+    #[test]
+    fn on_evict_receives_stored_key_not_callers_key() {
+        use std::sync::{Arc, Mutex};
+
+        // A key whose Hash/PartialEq use only `id`; `tag` is transparent to equality.
+        #[derive(Clone, Debug)]
+        struct TaggedKey {
+            id: u32,
+            tag: &'static str,
+        }
+        impl PartialEq for TaggedKey {
+            fn eq(&self, other: &Self) -> bool {
+                self.id == other.id
+            }
+        }
+        impl Eq for TaggedKey {}
+        impl std::hash::Hash for TaggedKey {
+            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+                self.id.hash(state);
+            }
+        }
+
+        let evicted_tags: Arc<Mutex<Vec<&'static str>>> = Arc::new(Mutex::new(Vec::new()));
+        let evicted_tags2 = evicted_tags.clone();
+
+        let mut cache: ExpiringLruCache<TaggedKey, ExpiredU8> = ExpiringLruCache::builder()
+            .max_size(4)
+            .on_evict(move |k: &TaggedKey, _v: &ExpiredU8| {
+                evicted_tags2.lock().unwrap().push(k.tag);
+            })
+            .build()
+            .unwrap();
+
+        // Insert with tag "a"; value 15 is expired (>10).
+        cache.cache_set(TaggedKey { id: 1, tag: "a" }, 15);
+        // Overwrite with an equal key (same id) but different tag "b".
+        // The displaced entry was stored with tag "a"; on_evict must report "a".
+        cache.cache_set(TaggedKey { id: 1, tag: "b" }, 3);
+
+        let tags = evicted_tags.lock().unwrap();
+        assert_eq!(
+            tags.as_slice(),
+            &["a"],
+            "on_evict must receive the stored key (tag='a'), not the caller's key (tag='b')"
+        );
+    }
+
     #[test]
     fn cache_set_overwrite_promotes_to_mru() {
         // `cache_set` goes through `LruCache::cache_set_returning_entry`, which promotes an

--- a/src/stores/lru_ttl.rs
+++ b/src/stores/lru_ttl.rs
@@ -1272,6 +1272,27 @@ mod tests {
     }
 
     #[test]
+    fn cache_set_with_ttl_overflow_stores_never_expiring_entry() {
+        // A TTL that would overflow Instant bounds (compute_expires_at's
+        // now.checked_add(ttl) -> None) stores the entry with no expiry: it never
+        // expires, matching TtlSortedCache's set_with(..).ttl(..) overflow behavior.
+        use crate::CacheTtl;
+        let mut c: LruTtlCache<u32, u32> = LruTtlCache::builder()
+            .max_size(4)
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        c.set_ttl(Duration::MAX);
+        assert_eq!(c.cache_set(1, 42), None);
+        assert_eq!(c.cache_get(&1), Some(&42));
+        // Never-expiring: CacheValue's expires_at() metadata must be None.
+        let ordered = c.iter_order();
+        assert_eq!(ordered.len(), 1);
+        assert_eq!(*ordered[0].1, 42);
+        assert_eq!(ordered[0].1.expires_at(), None);
+    }
+
+    #[test]
     fn cache_set_over_existing_key_promotes_to_mru() {
         let mut c: LruTtlCache<u32, u32> = LruTtlCache::builder()
             .max_size(3)

--- a/src/stores/redb.rs
+++ b/src/stores/redb.rs
@@ -1415,10 +1415,7 @@ where
     ///
     /// Delegates to [`cache_get`](ConcurrentCached::cache_get): the value is
     /// fetched and deserialized to determine presence.
-    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
-    where
-        Self: Sized,
-    {
+    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error> {
         self.cache_get(k).map(|v| v.is_some())
     }
 }

--- a/src/stores/redis.rs
+++ b/src/stores/redis.rs
@@ -1718,10 +1718,7 @@ where
     /// This delegates to [`cache_get`](ConcurrentCached::cache_get): the value is
     /// fetched and deserialized to determine presence. There is no separate Redis
     /// EXISTS round-trip in this implementation.
-    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
-    where
-        Self: Sized,
-    {
+    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error> {
         self.cache_get(k).map(|v| v.is_some())
     }
 }

--- a/src/stores/sharded/expiring.rs
+++ b/src/stores/sharded/expiring.rs
@@ -204,7 +204,10 @@ where
 
     /// Insert a key-value pair and return the previous value, if any.
     ///
-    /// This is the infallible ergonomic API for the concrete type.
+    /// This is the infallible ergonomic API for the concrete type. Unlike the trait's
+    /// [`cache_set`](ConcurrentCached::cache_set) (which returns `Result<Option<V>, _>`), this
+    /// inherent form returns the displaced `Option<V>` directly, so `.set(k, v).unwrap()` panics
+    /// on a fresh insert -- there is no prior value to unwrap.
     pub fn set(&self, k: K, v: V) -> Option<V> {
         ConcurrentCached::cache_set(self, k, v).unwrap()
     }
@@ -654,10 +657,7 @@ where
 
     /// Efficient peek-based contains: acquires a read lock, does not clone the value,
     /// and does not record hit/miss metrics. Returns `true` only for live (not expired) entries.
-    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
-    where
-        Self: Sized,
-    {
+    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error> {
         let shard = self.shard_of(k);
         Ok(shard.lock.read().get(k).is_some_and(|v| !v.is_expired()))
     }

--- a/src/stores/sharded/expiring_lru.rs
+++ b/src/stores/sharded/expiring_lru.rs
@@ -13,7 +13,7 @@ use core::future::Future;
 
 use super::{
     CachePadded, DefaultShardHasher, Shard, ShardHasher, checked_shard_count,
-    per_shard_cap_from_total, shard_index,
+    default_shard_count_for_capacity, per_shard_cap_from_total, shard_index,
 };
 use crate::Cached;
 use crate::ConcurrentCacheEvict;
@@ -116,10 +116,13 @@ where
     /// Construct a ready-to-use [`ShardedExpiringLruCache`] holding up to roughly `max_size`
     /// entries total, with the [`DefaultShardHasher`] and a default shard count.
     ///
-    /// Note that the effective total capacity can exceed `max_size` for small values
+    /// Note that the effective total capacity can still exceed `max_size` for small values
     /// because each shard reserves a minimum capacity (see
-    /// [`max_size`](ShardedExpiringLruCacheBuilder::max_size)). For a custom hasher, shard
-    /// count, per-shard cap, or `on_evict`, use [`builder`](Self::builder).
+    /// [`max_size`](ShardedExpiringLruCacheBuilder::max_size)). The default shard count is now
+    /// scaled down for small `max_size` (roughly `max_size / 16` shards, capped by the
+    /// CPU-derived default), so the overshoot is modest -- `max_size = 100` yields 8 shards x 16
+    /// = 128 effective capacity. For a custom hasher, shard count, per-shard cap, or `on_evict`,
+    /// use [`builder`](Self::builder).
     ///
     /// # Panics
     ///
@@ -223,7 +226,10 @@ where
 
     /// Insert a key-value pair and return the previous value, if any.
     ///
-    /// This is the infallible ergonomic API for the concrete type.
+    /// This is the infallible ergonomic API for the concrete type. Unlike the trait's
+    /// [`cache_set`](ConcurrentCached::cache_set) (which returns `Result<Option<V>, _>`), this
+    /// inherent form returns the displaced `Option<V>` directly, so `.set(k, v).unwrap()` panics
+    /// on a fresh insert -- there is no prior value to unwrap.
     pub fn set(&self, k: K, v: V) -> Option<V> {
         ConcurrentCached::cache_set(self, k, v).unwrap()
     }
@@ -767,10 +773,7 @@ where
     /// Efficient peek-based contains: acquires a read lock, does not clone the value, does not
     /// update LRU recency, and does not record hit/miss metrics. Returns `true` only for live
     /// (not expired) entries.
-    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
-    where
-        Self: Sized,
-    {
+    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error> {
         use crate::CachedPeek;
         let shard = self.shard_of(k);
         Ok(shard
@@ -947,7 +950,12 @@ impl<K, V, H> ShardedExpiringLruCacheBuilder<K, V, H> {
     ///
     /// Because each shard reserves a minimum of **16** entries when `shards > 1`, the effective
     /// total capacity is at least `shards * 16` and may **exceed** the requested `max_size` for
-    /// small values (e.g. `max_size = 10` with 8 shards yields an effective capacity of 128).
+    /// small values. On the default shard-count path the shard count itself is scaled down for
+    /// small `max_size` (roughly `max_size / 16`, capped by the CPU-derived default), so the
+    /// overshoot stays modest: `max_size = 100` builds 8 shards x 16 = 128 effective capacity.
+    /// An explicit [`shards`](Self::shards) count opts out of that scaling, so a large explicit
+    /// count with a small `max_size` still overshoots by `shards * 16` (e.g. `max_size = 10`
+    /// with an explicit 8 shards yields 128).
     /// [`metrics()`](ShardedExpiringLruCacheBase::metrics)'s `capacity` and `entry_count` reflect
     /// the actual (possibly larger) amount. Use [`per_shard_max_size`](Self::per_shard_max_size)
     /// or `shards = 1` if you need a strict small cap.
@@ -1076,6 +1084,24 @@ impl<K, V, H> ShardedExpiringLruCacheBuilder<K, V, H> {
             })
     }
 
+    /// Resolve the shard count for this build.
+    ///
+    /// An explicit `.shards(n)` is authoritative: it goes through
+    /// [`checked_shard_count`], which rounds up to a power of two, rejects `Some(0)`, and
+    /// guards against the rounding overflowing `usize`.
+    ///
+    /// On the default path (no explicit shard count) the count is derived from capacity via
+    /// [`default_shard_count_for_capacity`]: a configured total `max_size` scales the default
+    /// shard count down toward `max_size / 16` so a small cache does not preallocate an
+    /// oversized shard array. The `per_shard_max_size` path has no total to scale against, so
+    /// `self.max_size` is `None` there and the plain `default_shard_count()` is kept.
+    fn resolve_shard_count(&self) -> Result<usize, BuildError> {
+        match self.shards {
+            Some(_) => checked_shard_count(self.shards),
+            None => Ok(default_shard_count_for_capacity(self.max_size)),
+        }
+    }
+
     /// Build the new cache and copy every non-expired entry from `existing` into it,
     /// preserving LRU ordering (least-recently-used entries inserted first so that
     /// most-recently-used entries end up at the head of the new cache).
@@ -1138,7 +1164,7 @@ impl<K, V, H> ShardedExpiringLruCacheBuilder<K, V, H> {
         K: Hash + Eq + Clone,
         H: ShardHasher<K>,
     {
-        let n = checked_shard_count(self.shards)?;
+        let n = self.resolve_shard_count()?;
         let mask = n - 1;
         let per_shard_cap = self.resolve_per_shard_cap(n)?;
         let total_cap = self.total_capacity(n, per_shard_cap)?;
@@ -1235,6 +1261,55 @@ mod tests {
         fn is_expired(&self) -> bool {
             self.expired
         }
+    }
+
+    #[test]
+    fn default_shard_count_scales_with_max_size() {
+        use crate::stores::sharded::{default_shard_count, default_shard_count_for_capacity};
+        let c = ShardedExpiringLruCacheBase::<u32, Val>::builder()
+            .max_size(100)
+            .build()
+            .unwrap();
+        let expected = default_shard_count_for_capacity(Some(100));
+        assert_eq!(c.shards(), expected);
+        // 100/16 == 6, next_power_of_two(6) == 8, clamped into [1, default_shard_count()].
+        assert_eq!(expected, 8usize.clamp(1, default_shard_count()));
+        assert_eq!(c.capacity(), c.shards() * 16);
+    }
+
+    #[test]
+    fn explicit_shards_override_capacity_default() {
+        let c = ShardedExpiringLruCacheBase::<u32, Val>::builder()
+            .shards(64)
+            .max_size(100)
+            .build()
+            .unwrap();
+        assert_eq!(c.shards(), 64);
+        assert_eq!(c.capacity(), 64 * 16);
+    }
+
+    #[test]
+    fn default_shard_count_clamps_at_upper_bound_end_to_end() {
+        // This builder has its own resolve_shard_count copy; verify the large-max_size clamp
+        // reaches default_shard_count() through it, with the expectation computed at runtime.
+        use crate::stores::sharded::default_shard_count;
+        let d = default_shard_count();
+        let big = d.checked_mul(16).unwrap().checked_mul(4).unwrap();
+        let c = ShardedExpiringLruCacheBase::<u32, Val>::builder()
+            .max_size(big)
+            .build()
+            .unwrap();
+        assert_eq!(c.shards(), d);
+    }
+
+    #[test]
+    fn per_shard_max_size_keeps_plain_default_shard_count() {
+        use crate::stores::sharded::default_shard_count;
+        let c = ShardedExpiringLruCacheBase::<u32, Val>::builder()
+            .per_shard_max_size(4)
+            .build()
+            .unwrap();
+        assert_eq!(c.shards(), default_shard_count());
     }
 
     #[test]

--- a/src/stores/sharded/lru.rs
+++ b/src/stores/sharded/lru.rs
@@ -10,7 +10,7 @@ use core::future::Future;
 
 use super::{
     CachePadded, DefaultShardHasher, Shard, ShardHasher, checked_shard_count,
-    per_shard_cap_from_total, shard_index,
+    default_shard_count_for_capacity, per_shard_cap_from_total, shard_index,
 };
 use crate::stores::{BuildError, LruCache};
 
@@ -86,10 +86,13 @@ where
     /// Construct a ready-to-use [`ShardedLruCache`] holding up to roughly `max_size`
     /// entries total, with the [`DefaultShardHasher`] and a default shard count.
     ///
-    /// Note that the effective total capacity can exceed `max_size` for small values
+    /// Note that the effective total capacity can still exceed `max_size` for small values
     /// because each shard reserves a minimum capacity (see
-    /// [`max_size`](ShardedLruCacheBuilder::max_size)). For a custom hasher, shard count,
-    /// per-shard cap, or `on_evict`, use [`builder`](Self::builder).
+    /// [`max_size`](ShardedLruCacheBuilder::max_size)). The default shard count is now scaled
+    /// down for small `max_size` (roughly `max_size / 16` shards, capped by the CPU-derived
+    /// default), so the overshoot is modest -- `max_size = 100` yields 8 shards x 16 = 128
+    /// effective capacity rather than the full default shard count times 16. For a custom
+    /// hasher, shard count, per-shard cap, or `on_evict`, use [`builder`](Self::builder).
     ///
     /// # Panics
     ///
@@ -183,7 +186,10 @@ where
 
     /// Insert a key-value pair and return the previous value, if any.
     ///
-    /// This is the infallible ergonomic API for the concrete type.
+    /// This is the infallible ergonomic API for the concrete type. Unlike the trait's
+    /// [`cache_set`](ConcurrentCached::cache_set) (which returns `Result<Option<V>, _>`), this
+    /// inherent form returns the displaced `Option<V>` directly, so `.set(k, v).unwrap()` panics
+    /// on a fresh insert -- there is no prior value to unwrap.
     pub fn set(&self, k: K, v: V) -> Option<V> {
         ConcurrentCached::cache_set(self, k, v).unwrap()
     }
@@ -625,10 +631,7 @@ where
 
     /// Efficient peek-based contains: acquires a read lock, does not clone the value,
     /// does not update LRU recency, and does not record hit/miss metrics.
-    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
-    where
-        Self: Sized,
-    {
+    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error> {
         use crate::CachedPeek;
         let shard = self.shard_of(k);
         Ok(shard.lock.read().cache_peek(k).is_some())
@@ -738,7 +741,12 @@ impl<K, V, H> ShardedLruCacheBuilder<K, V, H> {
     ///
     /// Because each shard reserves a minimum of **16** entries when `shards > 1`, the effective
     /// total capacity is at least `shards * 16` and may **exceed** the requested `max_size` for
-    /// small values (e.g. `max_size = 10` with 8 shards yields an effective capacity of 128).
+    /// small values. On the default shard-count path the shard count itself is scaled down for
+    /// small `max_size` (roughly `max_size / 16`, capped by the CPU-derived default), so the
+    /// overshoot stays modest: `max_size = 100` builds 8 shards x 16 = 128 effective capacity.
+    /// An explicit [`shards`](Self::shards) count opts out of that scaling, so a large explicit
+    /// count with a small `max_size` still overshoots by `shards * 16` (e.g. `max_size = 10`
+    /// with an explicit 8 shards yields 128).
     /// [`metrics()`](ShardedLruCacheBase::metrics)'s `capacity` and `entry_count` reflect the
     /// actual (possibly larger) amount. Use [`per_shard_max_size`](Self::per_shard_max_size) or
     /// `shards = 1` if you need a strict small cap.
@@ -859,6 +867,24 @@ impl<K, V, H> ShardedLruCacheBuilder<K, V, H> {
             })
     }
 
+    /// Resolve the shard count for this build.
+    ///
+    /// An explicit `.shards(n)` is authoritative: it goes through
+    /// [`checked_shard_count`], which rounds up to a power of two, rejects `Some(0)`, and
+    /// guards against the rounding overflowing `usize`.
+    ///
+    /// On the default path (no explicit shard count) the count is derived from capacity via
+    /// [`default_shard_count_for_capacity`]: a configured total `max_size` scales the default
+    /// shard count down toward `max_size / 16` so a small cache does not preallocate an
+    /// oversized shard array. The `per_shard_max_size` path has no total to scale against, so
+    /// `self.max_size` is `None` there and the plain `default_shard_count()` is kept.
+    fn resolve_shard_count(&self) -> Result<usize, BuildError> {
+        match self.shards {
+            Some(_) => checked_shard_count(self.shards),
+            None => Ok(default_shard_count_for_capacity(self.max_size)),
+        }
+    }
+
     /// Build the cache, returning an error if required fields are missing or invalid.
     ///
     /// Use [`ShardedLruCache::builder()`] (or [`ShardedLruCacheBase::builder()`]) to obtain
@@ -876,7 +902,7 @@ impl<K, V, H> ShardedLruCacheBuilder<K, V, H> {
         K: Hash + Eq + Clone,
         H: ShardHasher<K>,
     {
-        let n = checked_shard_count(self.shards)?;
+        let n = self.resolve_shard_count()?;
         let mask = n - 1;
         let per_shard_cap = self.resolve_per_shard_cap(n)?;
         let total_cap = self.total_capacity(n, per_shard_cap)?;
@@ -982,6 +1008,142 @@ mod tests {
                 .unwrap()
                 .capacity()
         );
+    }
+
+    #[test]
+    fn default_shard_count_scales_with_max_size() {
+        use crate::stores::sharded::{default_shard_count, default_shard_count_for_capacity};
+        // On the default path (no explicit .shards), a total max_size caps the shard count.
+        let c = ShardedLruCache::<u32, u32>::builder()
+            .max_size(100)
+            .build()
+            .unwrap();
+        let expected = default_shard_count_for_capacity(Some(100));
+        assert_eq!(c.shards(), expected);
+        // 100/16 == 6, next_power_of_two(6) == 8, clamped into [1, default_shard_count()].
+        // default_shard_count()'s documented minimum is 8, so this resolves to 8 on any host.
+        assert_eq!(expected, 8usize.clamp(1, default_shard_count()));
+        // capacity() reflects the capped count times the 16-per-shard floor.
+        assert_eq!(c.capacity(), c.shards() * 16);
+        // `new(max_size)` goes through the same default path.
+        assert_eq!(ShardedLruCache::<u32, u32>::new(100).shards(), expected);
+    }
+
+    #[test]
+    fn explicit_shards_override_capacity_default() {
+        // An explicit .shards(n) is authoritative regardless of max_size: rounded up to a power
+        // of two, never scaled down by the capacity helper.
+        let c = ShardedLruCache::<u32, u32>::builder()
+            .shards(64)
+            .max_size(100)
+            .build()
+            .unwrap();
+        assert_eq!(c.shards(), 64);
+        // A tiny max_size with a large explicit shard count still overshoots by shards * 16.
+        assert_eq!(c.capacity(), 64 * 16);
+    }
+
+    #[test]
+    fn per_shard_max_size_keeps_plain_default_shard_count() {
+        use crate::stores::sharded::default_shard_count;
+        // The per_shard_max_size path has no total to scale against, so it keeps the plain
+        // default_shard_count().
+        let c = ShardedLruCache::<u32, u32>::builder()
+            .per_shard_max_size(4)
+            .build()
+            .unwrap();
+        assert_eq!(c.shards(), default_shard_count());
+    }
+
+    #[test]
+    fn spec_0037_formula_holds_end_to_end() {
+        // Independent re-derivation of the spec 0037 contract: a bounded default-path store's
+        // shards() must equal next_power_of_two(max_size / 16).clamp(1, default_shard_count()).
+        // Computed here from first principles (not via default_shard_count_for_capacity) so a
+        // regression in the helper cannot mask a regression in the builder and vice versa.
+        use crate::stores::sharded::default_shard_count;
+        let d = default_shard_count();
+        // Include a size that forces the upper clamp: 64 * d makes max_size/16 == 4*d, whose
+        // next_power_of_two is 4*d (d is already a power of two) -- well above the clamp ceiling.
+        for &n in &[1usize, 16, 100, d * 16, d * 64] {
+            let c = ShardedLruCache::<u32, u32>::builder()
+                .max_size(n)
+                .build()
+                .unwrap();
+            let expected = (n / 16).next_power_of_two().clamp(1, d);
+            assert_eq!(c.shards(), expected, "max_size={n}");
+            // `new(n)` must route through the identical default path.
+            assert_eq!(ShardedLruCache::<u32, u32>::new(n).shards(), expected);
+        }
+    }
+
+    #[test]
+    fn default_shard_count_clamps_at_upper_bound_end_to_end() {
+        // The high-core-host interaction the builder tests otherwise never reach: a max_size large
+        // enough that the capacity-derived count would exceed the CPU-derived ceiling must clamp
+        // back to exactly default_shard_count(). Expectation is computed at runtime, so this holds
+        // on an 8-core box and a 256-core box alike.
+        use crate::stores::sharded::default_shard_count;
+        let d = default_shard_count();
+        let big = d.checked_mul(16).unwrap().checked_mul(4).unwrap();
+        let c = ShardedLruCache::<u32, u32>::builder()
+            .max_size(big)
+            .build()
+            .unwrap();
+        assert_eq!(
+            c.shards(),
+            d,
+            "derived count must clamp down to default_shard_count()"
+        );
+    }
+
+    #[test]
+    fn deep_clone_preserves_capacity_derived_shard_count() {
+        // deep_clone copies the source's actual shard array length; it must NOT re-derive the
+        // count from capacity. A source built on the scaled-down default path (8 shards for
+        // max_size 100) must clone to 8 shards, not back up to the plain default.
+        let src = ShardedLruCache::<u32, u32>::builder()
+            .max_size(100)
+            .build()
+            .unwrap();
+        let derived = src.shards();
+        let clone = src.deep_clone();
+        assert_eq!(clone.shards(), derived);
+        assert_eq!(clone.capacity(), src.capacity());
+    }
+
+    #[test]
+    fn copy_from_derives_shard_count_from_new_builder_not_source() {
+        // copy_from builds a fresh cache from the NEW builder, so the destination shard count
+        // follows the new builder's own default/explicit resolution -- never inherited from the
+        // source. Entries survive the re-sharding.
+        use crate::stores::sharded::default_shard_count_for_capacity;
+        let src = ShardedLruCache::<u32, u32>::builder()
+            .shards(64)
+            .max_size(4096)
+            .build()
+            .unwrap();
+        assert_eq!(src.shards(), 64);
+        src.set(1, 10);
+        src.set(2, 20);
+
+        // Default-path destination with a small max_size derives a scaled-down count (8), not 64.
+        let dst = ShardedLruCache::<u32, u32>::builder()
+            .max_size(100)
+            .copy_from(&src)
+            .unwrap();
+        assert_eq!(dst.shards(), default_shard_count_for_capacity(Some(100)));
+        assert_eq!(dst.get(&1), Some(10));
+        assert_eq!(dst.get(&2), Some(20));
+
+        // Explicit shards on the destination stay authoritative through copy_from.
+        let dst2 = ShardedLruCache::<u32, u32>::builder()
+            .shards(32)
+            .max_size(4096)
+            .copy_from(&src)
+            .unwrap();
+        assert_eq!(dst2.shards(), 32);
+        assert_eq!(dst2.get(&1), Some(10));
     }
 
     #[test]

--- a/src/stores/sharded/lru_ttl.rs
+++ b/src/stores/sharded/lru_ttl.rs
@@ -15,7 +15,7 @@ use core::future::Future;
 
 use super::{
     CachePadded, DefaultShardHasher, Shard, ShardHasher, checked_shard_count, decode_ttl,
-    encode_ttl, per_shard_cap_from_total, shard_index,
+    default_shard_count_for_capacity, encode_ttl, per_shard_cap_from_total, shard_index,
 };
 use crate::stores::{BuildError, HasEvict, LruCache, NoEvict, TimedEntry};
 use crate::{Cached, CachedIter, CachedPeek};
@@ -142,10 +142,13 @@ where
     /// entries total with the given `ttl`, the [`DefaultShardHasher`], and a default shard
     /// count.
     ///
-    /// Note that the effective total capacity can exceed `max_size` for small values
+    /// Note that the effective total capacity can still exceed `max_size` for small values
     /// because each shard reserves a minimum capacity (see
-    /// [`max_size`](ShardedLruTtlCacheBuilder::max_size)). For a custom hasher, shard count,
-    /// per-shard cap, `refresh_on_hit`, or `on_evict`, use [`builder`](Self::builder).
+    /// [`max_size`](ShardedLruTtlCacheBuilder::max_size)). The default shard count is now scaled
+    /// down for small `max_size` (roughly `max_size / 16` shards, capped by the CPU-derived
+    /// default), so the overshoot is modest -- `max_size = 100` yields 8 shards x 16 = 128
+    /// effective capacity. For a custom hasher, shard count, per-shard cap, `refresh_on_hit`, or
+    /// `on_evict`, use [`builder`](Self::builder).
     ///
     /// # Panics
     ///
@@ -267,7 +270,10 @@ where
 
     /// Insert a key-value pair and return the previous value, if any.
     ///
-    /// This is the infallible ergonomic API for the concrete type.
+    /// This is the infallible ergonomic API for the concrete type. Unlike the trait's
+    /// [`cache_set`](ConcurrentCached::cache_set) (which returns `Result<Option<V>, _>`), this
+    /// inherent form returns the displaced `Option<V>` directly, so `.set(k, v).unwrap()` panics
+    /// on a fresh insert -- there is no prior value to unwrap.
     pub fn set(&self, k: K, v: V) -> Option<V> {
         ConcurrentCached::cache_set(self, k, v).unwrap()
     }
@@ -889,10 +895,7 @@ where
     /// Efficient peek-based contains: acquires a read lock, does not clone the value, does not
     /// update LRU recency, and does not record hit/miss metrics. Returns `true` only for live
     /// (not expired) entries.
-    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
-    where
-        Self: Sized,
-    {
+    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error> {
         let shard = self.shard_of(k);
         let guard = shard.lock.read();
         Ok(guard
@@ -1016,7 +1019,12 @@ impl<K, V, E, H> ShardedLruTtlCacheBuilder<K, V, E, H> {
     ///
     /// Because each shard reserves a minimum of **16** entries when `shards > 1`, the effective
     /// total capacity is at least `shards * 16` and may **exceed** the requested `max_size` for
-    /// small values (e.g. `max_size = 10` with 8 shards yields an effective capacity of 128).
+    /// small values. On the default shard-count path the shard count itself is scaled down for
+    /// small `max_size` (roughly `max_size / 16`, capped by the CPU-derived default), so the
+    /// overshoot stays modest: `max_size = 100` builds 8 shards x 16 = 128 effective capacity.
+    /// An explicit [`shards`](Self::shards) count opts out of that scaling, so a large explicit
+    /// count with a small `max_size` still overshoots by `shards * 16` (e.g. `max_size = 10`
+    /// with an explicit 8 shards yields 128).
     /// [`metrics()`](ShardedLruTtlCacheBase::metrics)'s `capacity` and `entry_count` reflect the
     /// actual (possibly larger) amount. Use [`per_shard_max_size`](Self::per_shard_max_size) or
     /// `shards = 1` if you need a strict small cap.
@@ -1152,10 +1160,28 @@ impl<K, V, E, H> ShardedLruTtlCacheBuilder<K, V, E, H> {
             })
     }
 
+    /// Resolve the shard count for this build.
+    ///
+    /// An explicit `.shards(n)` is authoritative: it goes through
+    /// [`checked_shard_count`], which rounds up to a power of two, rejects `Some(0)`, and
+    /// guards against the rounding overflowing `usize`.
+    ///
+    /// On the default path (no explicit shard count) the count is derived from capacity via
+    /// [`default_shard_count_for_capacity`]: a configured total `max_size` scales the default
+    /// shard count down toward `max_size / 16` so a small cache does not preallocate an
+    /// oversized shard array. The `per_shard_max_size` path has no total to scale against, so
+    /// `self.max_size` is `None` there and the plain `default_shard_count()` is kept.
+    fn resolve_shard_count(&self) -> Result<usize, BuildError> {
+        match self.shards {
+            Some(_) => checked_shard_count(self.shards),
+            None => Ok(default_shard_count_for_capacity(self.max_size)),
+        }
+    }
+
     fn validated_parts(&self) -> Result<(Duration, usize, usize, usize), BuildError> {
         let ttl = self.ttl.ok_or(BuildError::MissingRequired("ttl"))?;
         crate::stores::validate_ttl(ttl)?;
-        let n = checked_shard_count(self.shards)?;
+        let n = self.resolve_shard_count()?;
         let mask = n - 1;
         let per_shard_cap = self.resolve_per_shard_cap(n)?;
         let total_cap = self.total_capacity(n, per_shard_cap)?;
@@ -1476,6 +1502,59 @@ mod tests {
     use crate::ConcurrentCached;
     use crate::ConcurrentCached as SyncConcurrentCached;
     use crate::ConcurrentCloneCached;
+
+    #[test]
+    fn default_shard_count_scales_with_max_size() {
+        use crate::stores::sharded::{default_shard_count, default_shard_count_for_capacity};
+        let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
+            .max_size(100)
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        let expected = default_shard_count_for_capacity(Some(100));
+        assert_eq!(c.shards(), expected);
+        // 100/16 == 6, next_power_of_two(6) == 8, clamped into [1, default_shard_count()].
+        assert_eq!(expected, 8usize.clamp(1, default_shard_count()));
+        assert_eq!(c.capacity(), c.shards() * 16);
+    }
+
+    #[test]
+    fn explicit_shards_override_capacity_default() {
+        let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
+            .shards(64)
+            .max_size(100)
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        assert_eq!(c.shards(), 64);
+        assert_eq!(c.capacity(), 64 * 16);
+    }
+
+    #[test]
+    fn per_shard_max_size_keeps_plain_default_shard_count() {
+        use crate::stores::sharded::default_shard_count;
+        let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
+            .per_shard_max_size(4)
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        assert_eq!(c.shards(), default_shard_count());
+    }
+
+    #[test]
+    fn default_shard_count_clamps_at_upper_bound_end_to_end() {
+        // This builder has its own resolve_shard_count copy; verify the large-max_size clamp
+        // reaches default_shard_count() through it, with the expectation computed at runtime.
+        use crate::stores::sharded::default_shard_count;
+        let d = default_shard_count();
+        let big = d.checked_mul(16).unwrap().checked_mul(4).unwrap();
+        let c = ShardedLruTtlCacheBase::<u32, u32>::builder()
+            .max_size(big)
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        assert_eq!(c.shards(), d);
+    }
 
     #[test]
     fn cache_set_over_expired_returns_none_fires_on_evict_and_counts() {

--- a/src/stores/sharded/mod.rs
+++ b/src/stores/sharded/mod.rs
@@ -44,10 +44,15 @@ pub(crate) struct Shard<S> {
     pub misses: AtomicU64,
     /// Per-shard eviction count. Co-located with `hits`/`misses` for the same reason:
     /// a thread bumping this has just taken `lock`, so it already owns this cache line
-    /// exclusively. Consuming stores that currently keep a single process-wide
-    /// `evictions: AtomicU64` in `Arc<Inner>` (contended from every core, and sharing a
-    /// cache line with fields read on every op) should migrate to summing this field
-    /// across shards instead.
+    /// exclusively.
+    ///
+    /// Not every consuming store uses this field. The ttl/expiring family (sharded ttl,
+    /// expiring, lru_ttl, expiring_lru) counts shard-level evictions here and sums the
+    /// field across shards for its metrics. Sharded lru instead counts evictions via the
+    /// inner `LruCache`'s own per-store counter (read back through `cache_evictions()`),
+    /// and sharded unbound has no eviction concept at all; for those two the field is
+    /// intentionally left unused. Keeping one shared field (rather than a type-level split
+    /// of `Shard`) is a deliberate simplification.
     pub evictions: AtomicU64,
 }
 
@@ -62,6 +67,14 @@ impl<S> Shard<S> {
     }
 }
 
+/// The default shard count: `available_parallelism() * 4`, clamped to `[8, 1024]` and rounded
+/// up to a power of two.
+///
+/// The host CPU topology is sampled exactly once per process (memoized in a `OnceLock`) on the
+/// first call, then reused for every cache built afterward. A later change to the effective CPU
+/// count -- for example a cgroup/container CPU-quota adjustment made after the first sample --
+/// does not affect the shard count of subsequently built caches; they all see the value latched
+/// at first call.
 pub(crate) fn default_shard_count() -> usize {
     static DEFAULT_SHARD_COUNT: OnceLock<usize> = OnceLock::new();
     *DEFAULT_SHARD_COUNT.get_or_init(|| {
@@ -92,7 +105,6 @@ pub(crate) fn default_shard_count() -> usize {
 ///
 /// An explicit `.shards(n)` on a builder remains authoritative; this helper is only consulted
 /// on the *default* (no explicit shard count given) path.
-#[allow(dead_code)] // consumed by sibling shards migrating their builders' default path
 pub(crate) fn default_shard_count_for_capacity(max_size: Option<usize>) -> usize {
     match max_size {
         Some(n) => (n / 16).next_power_of_two().clamp(1, default_shard_count()),

--- a/src/stores/sharded/ttl.rs
+++ b/src/stores/sharded/ttl.rs
@@ -243,7 +243,10 @@ where
 
     /// Insert a key-value pair and return the previous value, if any.
     ///
-    /// This is the infallible ergonomic API for the concrete type.
+    /// This is the infallible ergonomic API for the concrete type. Unlike the trait's
+    /// [`cache_set`](ConcurrentCached::cache_set) (which returns `Result<Option<V>, _>`), this
+    /// inherent form returns the displaced `Option<V>` directly, so `.set(k, v).unwrap()` panics
+    /// on a fresh insert -- there is no prior value to unwrap.
     pub fn set(&self, k: K, v: V) -> Option<V> {
         ConcurrentCached::cache_set(self, k, v).unwrap()
     }
@@ -801,10 +804,7 @@ where
 
     /// Efficient peek-based contains: acquires a read lock, does not clone the value,
     /// and does not record hit/miss metrics. Returns `true` only for live (not expired) entries.
-    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
-    where
-        Self: Sized,
-    {
+    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error> {
         let shard = self.shard_of(k);
         let guard = shard.lock.read();
         Ok(guard.get(k).is_some_and(|entry| !self.is_expired(entry)))

--- a/src/stores/sharded/unbound.rs
+++ b/src/stores/sharded/unbound.rs
@@ -195,7 +195,10 @@ where
 
     /// Insert a key-value pair and return the previous value, if any.
     ///
-    /// This is the infallible ergonomic API for the concrete type.
+    /// This is the infallible ergonomic API for the concrete type. Unlike the trait's
+    /// [`cache_set`](ConcurrentCached::cache_set) (which returns `Result<Option<V>, _>`), this
+    /// inherent form returns the displaced `Option<V>` directly, so `.set(k, v).unwrap()` panics
+    /// on a fresh insert -- there is no prior value to unwrap.
     pub fn set(&self, k: K, v: V) -> Option<V> {
         ConcurrentCached::cache_set(self, k, v).unwrap()
     }
@@ -483,10 +486,7 @@ where
 
     /// Efficient peek-based contains: acquires a read lock, does not clone the value,
     /// and does not record hit/miss metrics.
-    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error>
-    where
-        Self: Sized,
-    {
+    fn cache_contains(&self, k: &K) -> Result<bool, Self::Error> {
         let shard = self.shard_of(k);
         Ok(shard.lock.read().contains_key(k))
     }
@@ -740,6 +740,21 @@ mod tests {
         assert_eq!(SyncConcurrentCached::cache_set(&c, 1, 100).unwrap(), None);
         assert_eq!(SyncConcurrentCached::cache_get(&c, &1).unwrap(), Some(100));
         assert_eq!(c.len(), 1);
+    }
+
+    #[test]
+    fn default_shard_count_is_plain_default_no_capacity_scaling() {
+        use crate::stores::sharded::default_shard_count;
+        // The unbounded store has no max_size to scale against, so the capacity-derived cap
+        // never applies: the default path keeps the plain default_shard_count().
+        let c = ShardedUnboundCache::<u32, u32>::builder().build().unwrap();
+        assert_eq!(c.shards(), default_shard_count());
+        // An explicit .shards(n) still rounds up to a power of two and is authoritative.
+        let c2 = ShardedUnboundCache::<u32, u32>::builder()
+            .shards(10)
+            .build()
+            .unwrap();
+        assert_eq!(c2.shards(), 16);
     }
 
     #[test]

--- a/src/stores/ttl.rs
+++ b/src/stores/ttl.rs
@@ -964,6 +964,23 @@ mod tests {
         assert_eq!(c.cache_evictions(), Some(1));
     }
 
+    #[test]
+    fn cache_set_with_ttl_overflow_stores_never_expiring_entry() {
+        // A TTL that would overflow Instant bounds (compute_expires_at's
+        // now.checked_add(ttl) -> None) stores the entry with no expiry: it never
+        // expires, matching TtlSortedCache's set_with(..).ttl(..) overflow behavior.
+        use crate::CacheTtl;
+        let mut c: TtlCache<u32, u32> = TtlCache::builder()
+            .ttl(crate::time::Duration::from_secs(60))
+            .build()
+            .unwrap();
+        c.set_ttl(crate::time::Duration::MAX);
+        assert_eq!(c.cache_set(1, 42), None);
+        assert_eq!(c.cache_get(&1), Some(&42));
+        // Never-expiring: cache_peek_with_expiry_status must not report it as expired.
+        assert_eq!(c.cache_peek_with_expiry_status(&1), (Some(42), false));
+    }
+
     // BUG-1 regression (sync): a panicking factory on the infallible get-or-set
     // path must not fire on_evict or increment evictions; the expired entry must
     // remain in place for the next access to evict it exactly once.

--- a/src/stores/ttl_sorted.rs
+++ b/src/stores/ttl_sorted.rs
@@ -1899,6 +1899,37 @@ mod test {
     }
 
     #[test]
+    fn capacity_returns_bound_not_live_size() {
+        let cache: TtlSortedCache<u32, u32> = TtlSortedCache::builder()
+            .ttl(Duration::from_secs(60))
+            .build()
+            .unwrap();
+        assert_eq!(cache.capacity(), None);
+        assert_eq!(cache.capacity(), cache.cache_capacity());
+
+        let mut cache = TtlSortedCache::builder()
+            .ttl(Duration::from_secs(60))
+            .max_size(3)
+            .build()
+            .unwrap();
+        assert_eq!(cache.capacity(), Some(3));
+        assert_eq!(cache.capacity(), cache.cache_capacity());
+
+        cache.cache_set(1, 10);
+        cache.cache_set(2, 20);
+        assert_eq!(
+            cache.capacity(),
+            Some(3),
+            "capacity tracks the bound, not live entries"
+        );
+        assert_eq!(cache.len(), 2);
+
+        cache.set_max_size(5);
+        assert_eq!(cache.capacity(), Some(5));
+        assert_eq!(cache.capacity(), cache.cache_capacity());
+    }
+
+    #[test]
     fn updating_existing_key_at_size_limit_does_not_evict_another_key() {
         let mut cache = TtlSortedCache::builder()
             .ttl(Duration::from_millis(1_000))

--- a/tests/ui/cached_return_type_requires_clone.rs
+++ b/tests/ui/cached_return_type_requires_clone.rs
@@ -2,9 +2,9 @@ use cached::macros::cached;
 
 // `#[cached]` clones the cached value on every cache hit (`.to_owned()`) and
 // on insert (`.clone()` into the store), so the return type must implement
-// `Clone`. Without the dedicated assertion this only fails deep inside
-// macro-generated internals; it should instead produce a clear diagnostic
-// spanned at the function's return type.
+// `Clone`. The dedicated assertion emits a clear diagnostic spanned at the
+// return type ahead of the opaque errors that still follow from deep inside
+// macro-generated internals.
 struct NotClone {
     _value: u32,
 }

--- a/tests/v3_builder_new_parity.rs
+++ b/tests/v3_builder_new_parity.rs
@@ -1,0 +1,630 @@
+//! Equivalence tests for `Builder::new()` on the 13 in-memory/sharded builders
+//! (see CHANGELOG [Unreleased] Added: "Builder::new() on the in-memory and
+//! sharded builders (all 13)").
+//!
+//! `tests/v3_additive_parity.rs::builders_construct_via_new` already proves bare
+//! construction works for a subset of these builders. This file goes further:
+//! for each of the 13 builders it configures a store via `XxxBuilder::new()`
+//! and an equivalently-configured store via `Xxx::builder()`, then asserts the
+//! two agree on observable configuration (capacity/cache_capacity, ttl where
+//! applicable, shards() for sharded stores) and on basic set/get behavior.
+//!
+//! Sharded LRU-family stores built with `max_size` and no explicit `.shards(n)`
+//! have a default shard count that is being changed (capacity-derived) by a
+//! concurrent shard of work; to stay correct regardless of that change, every
+//! sharded assertion below sets `.shards(n)` explicitly rather than relying on
+//! (or hardcoding) the default.
+
+#[cfg(feature = "time_stores")]
+use cached::time::Duration;
+
+// ── in-memory (non-sharded) ────────────────────────────────────────────────
+
+#[test]
+fn unbound_cache_new_matches_builder() {
+    use cached::{Cached, UnboundCache, UnboundCacheBuilder};
+
+    let mut a: UnboundCache<u32, u32> = UnboundCacheBuilder::new()
+        .initial_capacity(4)
+        .build()
+        .unwrap();
+    let mut b: UnboundCache<u32, u32> =
+        UnboundCache::builder().initial_capacity(4).build().unwrap();
+
+    assert_eq!(a.cache_capacity(), b.cache_capacity());
+
+    a.cache_set(1, 10);
+    b.cache_set(1, 10);
+    assert_eq!(a.cache_get(&1), b.cache_get(&1));
+    assert_eq!(a.cache_size(), b.cache_size());
+}
+
+#[test]
+fn lru_cache_new_matches_builder() {
+    use cached::{Cached, LruCache, LruCacheBuilder};
+
+    let mut a: LruCache<u32, u32> = LruCacheBuilder::new().max_size(2).build().unwrap();
+    let mut b: LruCache<u32, u32> = LruCache::builder().max_size(2).build().unwrap();
+
+    assert_eq!(a.capacity(), b.capacity());
+    assert_eq!(a.capacity(), 2);
+
+    a.cache_set(1, 10);
+    a.cache_set(2, 20);
+    a.cache_set(3, 30); // evicts key 1 (LRU, max_size = 2)
+    b.cache_set(1, 10);
+    b.cache_set(2, 20);
+    b.cache_set(3, 30);
+
+    assert_eq!(a.cache_get(&1), b.cache_get(&1));
+    assert_eq!(a.cache_get(&1), None);
+    assert_eq!(a.cache_get(&2), b.cache_get(&2));
+    assert_eq!(a.cache_get(&3), b.cache_get(&3));
+    assert_eq!(a.cache_size(), b.cache_size());
+}
+
+#[cfg(feature = "time_stores")]
+#[test]
+fn ttl_cache_new_matches_builder() {
+    use cached::{CacheTtl, Cached, TtlCache, TtlCacheBuilder};
+
+    let ttl = Duration::from_secs(60);
+    let mut a: TtlCache<u32, u32> = TtlCacheBuilder::new()
+        .ttl(ttl)
+        .refresh_on_hit(true)
+        .build()
+        .unwrap();
+    let mut b: TtlCache<u32, u32> = TtlCache::builder()
+        .ttl(ttl)
+        .refresh_on_hit(true)
+        .build()
+        .unwrap();
+
+    assert_eq!(CacheTtl::ttl(&a), CacheTtl::ttl(&b));
+    assert_eq!(CacheTtl::ttl(&a), Some(ttl));
+    assert_eq!(CacheTtl::refresh_on_hit(&a), CacheTtl::refresh_on_hit(&b));
+    assert!(
+        CacheTtl::refresh_on_hit(&a),
+        "refresh_on_hit(true) set via new() must be wired through to the store"
+    );
+
+    a.cache_set(1, 10);
+    b.cache_set(1, 10);
+    assert_eq!(a.cache_get(&1), b.cache_get(&1));
+}
+
+#[cfg(feature = "time_stores")]
+#[test]
+fn lru_ttl_cache_new_matches_builder() {
+    use cached::{CacheTtl, Cached, LruTtlCache, LruTtlCacheBuilder};
+
+    let ttl = Duration::from_secs(60);
+    let mut a: LruTtlCache<u32, u32> = LruTtlCacheBuilder::new()
+        .max_size(2)
+        .ttl(ttl)
+        .refresh_on_hit(true)
+        .build()
+        .unwrap();
+    let mut b: LruTtlCache<u32, u32> = LruTtlCache::builder()
+        .max_size(2)
+        .ttl(ttl)
+        .refresh_on_hit(true)
+        .build()
+        .unwrap();
+
+    assert_eq!(a.capacity(), b.capacity());
+    assert_eq!(a.capacity(), 2);
+    assert_eq!(CacheTtl::ttl(&a), CacheTtl::ttl(&b));
+    assert_eq!(CacheTtl::ttl(&a), Some(ttl));
+    assert_eq!(CacheTtl::refresh_on_hit(&a), CacheTtl::refresh_on_hit(&b));
+    assert!(
+        CacheTtl::refresh_on_hit(&a),
+        "refresh_on_hit(true) set via new() must be wired through to the store"
+    );
+
+    a.cache_set(1, 10);
+    a.cache_set(2, 20);
+    a.cache_set(3, 30); // evicts key 1 (LRU, max_size = 2)
+    b.cache_set(1, 10);
+    b.cache_set(2, 20);
+    b.cache_set(3, 30);
+
+    assert_eq!(a.cache_get(&1), b.cache_get(&1));
+    assert_eq!(a.cache_get(&1), None);
+    assert_eq!(a.cache_get(&2), b.cache_get(&2));
+    assert_eq!(a.cache_get(&3), b.cache_get(&3));
+}
+
+#[cfg(feature = "time_stores")]
+#[test]
+fn ttl_sorted_cache_new_matches_builder() {
+    use cached::{CacheTtl, Cached, TtlSortedCache, TtlSortedCacheBuilder};
+
+    let ttl = Duration::from_secs(60);
+    let mut a: TtlSortedCache<u32, u32> = TtlSortedCacheBuilder::new()
+        .ttl(ttl)
+        .max_size(2)
+        .build()
+        .unwrap();
+    let mut b: TtlSortedCache<u32, u32> = TtlSortedCache::builder()
+        .ttl(ttl)
+        .max_size(2)
+        .build()
+        .unwrap();
+
+    assert_eq!(a.capacity(), b.capacity());
+    assert_eq!(a.capacity(), Some(2));
+    assert_eq!(CacheTtl::ttl(&a), CacheTtl::ttl(&b));
+    assert_eq!(CacheTtl::ttl(&a), Some(ttl));
+
+    a.cache_set(1, 10);
+    b.cache_set(1, 10);
+    assert_eq!(a.cache_get(&1), b.cache_get(&1));
+}
+
+#[cfg(feature = "time_stores")]
+#[test]
+fn ttl_sorted_cache_new_initial_capacity_matches_builder() {
+    use cached::{Cached, TtlSortedCache, TtlSortedCacheBuilder};
+
+    // `initial_capacity` is a preallocation hint with no public getter (its only
+    // externally-observable effect is via `cache_reset`, which shrinks the
+    // backing map back to this hint rather than to zero). We cannot compare
+    // the raw allocated capacity from outside the crate, but we can prove the
+    // option is accepted and wired through identically on both construction
+    // paths across a set/reset/refill cycle.
+    let ttl = Duration::from_secs(60);
+    let mut a: TtlSortedCache<u32, u32> = TtlSortedCacheBuilder::new()
+        .ttl(ttl)
+        .initial_capacity(64)
+        .build()
+        .unwrap();
+    let mut b: TtlSortedCache<u32, u32> = TtlSortedCache::builder()
+        .ttl(ttl)
+        .initial_capacity(64)
+        .build()
+        .unwrap();
+
+    for i in 0..32u32 {
+        a.cache_set(i, i * 10);
+        b.cache_set(i, i * 10);
+    }
+    assert_eq!(a.cache_size(), b.cache_size());
+
+    a.cache_reset();
+    b.cache_reset();
+    assert_eq!(a.cache_size(), b.cache_size());
+    assert_eq!(a.cache_size(), 0);
+
+    a.cache_set(1, 100);
+    b.cache_set(1, 100);
+    assert_eq!(a.cache_get(&1), b.cache_get(&1));
+}
+
+// ── Expiring stores (not time_stores-gated) ─────────────────────────────────
+
+#[test]
+fn expiring_cache_new_matches_builder() {
+    use cached::{Cached, Expires, ExpiringCache, ExpiringCacheBuilder};
+
+    #[derive(Clone, PartialEq, Debug)]
+    struct Val(u32);
+    impl Expires for Val {
+        fn is_expired(&self) -> bool {
+            false
+        }
+    }
+
+    let mut a: ExpiringCache<u32, Val> = ExpiringCacheBuilder::new()
+        .initial_capacity(4)
+        .build()
+        .unwrap();
+    let mut b: ExpiringCache<u32, Val> = ExpiringCache::builder()
+        .initial_capacity(4)
+        .build()
+        .unwrap();
+
+    assert_eq!(a.cache_capacity(), b.cache_capacity());
+
+    a.cache_set(1, Val(10));
+    b.cache_set(1, Val(10));
+    assert_eq!(a.cache_get(&1), b.cache_get(&1));
+}
+
+#[test]
+fn expiring_lru_cache_new_matches_builder() {
+    use cached::{Cached, Expires, ExpiringLruCache, ExpiringLruCacheBuilder};
+
+    #[derive(Clone, PartialEq, Debug)]
+    struct Val(u32);
+    impl Expires for Val {
+        fn is_expired(&self) -> bool {
+            false
+        }
+    }
+
+    let mut a: ExpiringLruCache<u32, Val> =
+        ExpiringLruCacheBuilder::new().max_size(2).build().unwrap();
+    let mut b: ExpiringLruCache<u32, Val> =
+        ExpiringLruCache::builder().max_size(2).build().unwrap();
+
+    assert_eq!(a.capacity(), b.capacity());
+    assert_eq!(a.capacity(), 2);
+
+    a.cache_set(1, Val(10));
+    a.cache_set(2, Val(20));
+    a.cache_set(3, Val(30)); // evicts key 1 (LRU, max_size = 2)
+    b.cache_set(1, Val(10));
+    b.cache_set(2, Val(20));
+    b.cache_set(3, Val(30));
+
+    assert_eq!(a.cache_get(&1), b.cache_get(&1));
+    assert_eq!(a.cache_get(&1), None);
+    assert_eq!(a.cache_get(&2), b.cache_get(&2));
+    assert_eq!(a.cache_get(&3), b.cache_get(&3));
+}
+
+// ── sharded ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn sharded_unbound_cache_new_matches_builder() {
+    use cached::{ShardedUnboundCache, ShardedUnboundCacheBuilder};
+
+    let a: ShardedUnboundCache<u32, u32> =
+        ShardedUnboundCacheBuilder::new().shards(4).build().unwrap();
+    let b: ShardedUnboundCache<u32, u32> =
+        ShardedUnboundCache::builder().shards(4).build().unwrap();
+
+    assert_eq!(a.shards(), b.shards());
+    assert_eq!(a.shards(), 4);
+
+    a.set(1, 10);
+    b.set(1, 10);
+    assert_eq!(a.get(&1), b.get(&1));
+}
+
+#[test]
+fn sharded_lru_cache_new_matches_builder() {
+    use cached::{ShardedLruCache, ShardedLruCacheBuilder};
+
+    let a: ShardedLruCache<u32, u32> = ShardedLruCacheBuilder::new()
+        .max_size(2)
+        .shards(1)
+        .build()
+        .unwrap();
+    let b: ShardedLruCache<u32, u32> = ShardedLruCache::builder()
+        .max_size(2)
+        .shards(1)
+        .build()
+        .unwrap();
+
+    assert_eq!(a.shards(), b.shards());
+    assert_eq!(a.shards(), 1);
+    assert_eq!(a.capacity(), b.capacity());
+
+    a.set(1, 10);
+    a.set(2, 20);
+    a.set(3, 30); // evicts key 1 (LRU, shards = 1, max_size = 2)
+    b.set(1, 10);
+    b.set(2, 20);
+    b.set(3, 30);
+
+    assert_eq!(a.get(&1), b.get(&1));
+    assert_eq!(a.get(&1), None);
+    assert_eq!(a.get(&2), b.get(&2));
+    assert_eq!(a.get(&3), b.get(&3));
+}
+
+#[cfg(feature = "time_stores")]
+#[test]
+fn sharded_ttl_cache_new_matches_builder() {
+    use cached::{ConcurrentCacheTtl, ShardedTtlCache, ShardedTtlCacheBuilder};
+
+    let ttl = Duration::from_secs(60);
+    let a: ShardedTtlCache<u32, u32> = ShardedTtlCacheBuilder::new()
+        .ttl(ttl)
+        .refresh_on_hit(true)
+        .shards(4)
+        .build()
+        .unwrap();
+    let b: ShardedTtlCache<u32, u32> = ShardedTtlCache::builder()
+        .ttl(ttl)
+        .refresh_on_hit(true)
+        .shards(4)
+        .build()
+        .unwrap();
+
+    assert_eq!(a.shards(), b.shards());
+    assert_eq!(a.shards(), 4);
+    assert_eq!(ConcurrentCacheTtl::ttl(&a), ConcurrentCacheTtl::ttl(&b));
+    assert_eq!(ConcurrentCacheTtl::ttl(&a), Some(ttl));
+    assert_eq!(
+        ConcurrentCacheTtl::refresh_on_hit(&a),
+        ConcurrentCacheTtl::refresh_on_hit(&b)
+    );
+    assert!(
+        ConcurrentCacheTtl::refresh_on_hit(&a),
+        "refresh_on_hit(true) set via new() must be wired through to the store"
+    );
+
+    a.set(1, 10);
+    b.set(1, 10);
+    assert_eq!(a.get(&1), b.get(&1));
+}
+
+#[cfg(feature = "time_stores")]
+#[test]
+fn sharded_lru_ttl_cache_new_matches_builder() {
+    use cached::{ConcurrentCacheTtl, ShardedLruTtlCache, ShardedLruTtlCacheBuilder};
+
+    let ttl = Duration::from_secs(60);
+    let a: ShardedLruTtlCache<u32, u32> = ShardedLruTtlCacheBuilder::new()
+        .max_size(2)
+        .ttl(ttl)
+        .refresh_on_hit(true)
+        .shards(1)
+        .build()
+        .unwrap();
+    let b: ShardedLruTtlCache<u32, u32> = ShardedLruTtlCache::builder()
+        .max_size(2)
+        .ttl(ttl)
+        .refresh_on_hit(true)
+        .shards(1)
+        .build()
+        .unwrap();
+
+    assert_eq!(a.shards(), b.shards());
+    assert_eq!(a.shards(), 1);
+    assert_eq!(a.capacity(), b.capacity());
+    assert_eq!(ConcurrentCacheTtl::ttl(&a), ConcurrentCacheTtl::ttl(&b));
+    assert_eq!(ConcurrentCacheTtl::ttl(&a), Some(ttl));
+    assert_eq!(
+        ConcurrentCacheTtl::refresh_on_hit(&a),
+        ConcurrentCacheTtl::refresh_on_hit(&b)
+    );
+    assert!(
+        ConcurrentCacheTtl::refresh_on_hit(&a),
+        "refresh_on_hit(true) set via new() must be wired through to the store"
+    );
+
+    a.set(1, 10);
+    a.set(2, 20);
+    a.set(3, 30); // evicts key 1 (LRU, shards = 1, max_size = 2)
+    b.set(1, 10);
+    b.set(2, 20);
+    b.set(3, 30);
+
+    assert_eq!(a.get(&1), b.get(&1));
+    assert_eq!(a.get(&1), None);
+    assert_eq!(a.get(&2), b.get(&2));
+    assert_eq!(a.get(&3), b.get(&3));
+}
+
+#[test]
+fn sharded_expiring_cache_new_matches_builder() {
+    use cached::{Expires, ShardedExpiringCache, ShardedExpiringCacheBuilder};
+
+    #[derive(Clone, PartialEq, Debug)]
+    struct Val(u32);
+    impl Expires for Val {
+        fn is_expired(&self) -> bool {
+            false
+        }
+    }
+
+    let a: ShardedExpiringCache<u32, Val> = ShardedExpiringCacheBuilder::new()
+        .shards(4)
+        .build()
+        .unwrap();
+    let b: ShardedExpiringCache<u32, Val> =
+        ShardedExpiringCache::builder().shards(4).build().unwrap();
+
+    assert_eq!(a.shards(), b.shards());
+    assert_eq!(a.shards(), 4);
+
+    a.set(1, Val(10));
+    b.set(1, Val(10));
+    assert_eq!(a.get(&1), b.get(&1));
+}
+
+#[test]
+fn sharded_expiring_lru_cache_new_matches_builder() {
+    use cached::{Expires, ShardedExpiringLruCache, ShardedExpiringLruCacheBuilder};
+
+    #[derive(Clone, PartialEq, Debug)]
+    struct Val(u32);
+    impl Expires for Val {
+        fn is_expired(&self) -> bool {
+            false
+        }
+    }
+
+    let a: ShardedExpiringLruCache<u32, Val> = ShardedExpiringLruCacheBuilder::new()
+        .max_size(2)
+        .shards(1)
+        .build()
+        .unwrap();
+    let b: ShardedExpiringLruCache<u32, Val> = ShardedExpiringLruCache::builder()
+        .max_size(2)
+        .shards(1)
+        .build()
+        .unwrap();
+
+    assert_eq!(a.shards(), b.shards());
+    assert_eq!(a.shards(), 1);
+    assert_eq!(a.capacity(), b.capacity());
+
+    a.set(1, Val(10));
+    a.set(2, Val(20));
+    a.set(3, Val(30)); // evicts key 1 (LRU, shards = 1, max_size = 2)
+    b.set(1, Val(10));
+    b.set(2, Val(20));
+    b.set(3, Val(30));
+
+    assert_eq!(a.get(&1), b.get(&1));
+    assert_eq!(a.get(&1), None);
+    assert_eq!(a.get(&2), b.get(&2));
+    assert_eq!(a.get(&3), b.get(&3));
+}
+
+// ── on_evict / hasher wiring ─────────────────────────────────────────────────
+//
+// `on_evict` and `hasher` are configurable on every one of the 13 builders but
+// aren't exercised by the equivalence tests above (whose stores are built
+// without either). A closure or a `BuildHasher`/`ShardHasher` instance can't be
+// compared for equality, so these are checked by wiring *effect* instead:
+// - `on_evict`: fire an eviction on both construction paths and assert the
+//   recorded (k, v) callback events are identical.
+// - `hasher` (sharded only): a custom `ShardHasher`'s effect on shard
+//   placement *is* externally observable via `shard_sizes()`, so a
+//   deterministic router proves the swapped hasher actually took effect on
+//   both paths, not just that the type parameter compiled. For the
+//   non-sharded (`BuildHasher`) case, hash choice has no externally-observable
+//   effect on a correct `HashMap` beyond performance, so we only prove the
+//   `.hasher()` call chains onto a `new()`-built builder and yields a working
+//   store, matching the pattern in every `hasher()` doc example.
+
+#[test]
+fn lru_cache_new_on_evict_matches_builder() {
+    use cached::{Cached, LruCache, LruCacheBuilder};
+    use std::sync::{Arc, Mutex};
+
+    let events_a = Arc::new(Mutex::new(Vec::<(u32, u32)>::new()));
+    let events_a2 = events_a.clone();
+    let mut a: LruCache<u32, u32> = LruCacheBuilder::new()
+        .max_size(2)
+        .on_evict(move |k: &u32, v: &u32| events_a2.lock().unwrap().push((*k, *v)))
+        .build()
+        .unwrap();
+
+    let events_b = Arc::new(Mutex::new(Vec::<(u32, u32)>::new()));
+    let events_b2 = events_b.clone();
+    let mut b: LruCache<u32, u32> = LruCache::builder()
+        .max_size(2)
+        .on_evict(move |k: &u32, v: &u32| events_b2.lock().unwrap().push((*k, *v)))
+        .build()
+        .unwrap();
+
+    a.cache_set(1, 10);
+    a.cache_set(2, 20);
+    a.cache_set(3, 30); // evicts key 1 (LRU, max_size = 2), firing on_evict
+    b.cache_set(1, 10);
+    b.cache_set(2, 20);
+    b.cache_set(3, 30);
+
+    let events_a = events_a.lock().unwrap().clone();
+    let events_b = events_b.lock().unwrap().clone();
+    assert_eq!(
+        events_a, events_b,
+        "on_evict wired via new() must fire identically to on_evict wired via builder()"
+    );
+    assert_eq!(events_a, vec![(1, 10)]);
+}
+
+#[test]
+fn sharded_lru_cache_new_on_evict_matches_builder() {
+    use cached::{ShardedLruCache, ShardedLruCacheBuilder};
+    use std::sync::{Arc, Mutex};
+
+    // shards = 1 so all keys share one LRU order and eviction is deterministic.
+    let events_a = Arc::new(Mutex::new(Vec::<(u32, u32)>::new()));
+    let events_a2 = events_a.clone();
+    let a: ShardedLruCache<u32, u32> = ShardedLruCacheBuilder::new()
+        .max_size(2)
+        .shards(1)
+        .on_evict(move |k: &u32, v: &u32| events_a2.lock().unwrap().push((*k, *v)))
+        .build()
+        .unwrap();
+
+    let events_b = Arc::new(Mutex::new(Vec::<(u32, u32)>::new()));
+    let events_b2 = events_b.clone();
+    let b: ShardedLruCache<u32, u32> = ShardedLruCache::builder()
+        .max_size(2)
+        .shards(1)
+        .on_evict(move |k: &u32, v: &u32| events_b2.lock().unwrap().push((*k, *v)))
+        .build()
+        .unwrap();
+
+    a.set(1, 10);
+    a.set(2, 20);
+    a.set(3, 30); // evicts key 1, firing on_evict
+    b.set(1, 10);
+    b.set(2, 20);
+    b.set(3, 30);
+
+    let events_a = events_a.lock().unwrap().clone();
+    let events_b = events_b.lock().unwrap().clone();
+    assert_eq!(
+        events_a, events_b,
+        "on_evict wired via new() must fire identically to on_evict wired via builder()"
+    );
+    assert_eq!(events_a, vec![(1, 10)]);
+}
+
+#[test]
+fn unbound_cache_new_hasher_matches_builder() {
+    use cached::{Cached, UnboundCache, UnboundCacheBuilder};
+    use std::collections::hash_map::RandomState;
+
+    // `.hasher()` changes the builder's type parameter; this proves it's
+    // reachable and functional when chained onto a `new()`-built builder,
+    // exactly as it is when chained onto a `builder()`-built one.
+    let mut a: UnboundCache<u32, u32, RandomState> = UnboundCacheBuilder::<u32, u32>::new()
+        .hasher(RandomState::new())
+        .build()
+        .unwrap();
+    let mut b: UnboundCache<u32, u32, RandomState> = UnboundCache::<u32, u32>::builder()
+        .hasher(RandomState::new())
+        .build()
+        .unwrap();
+
+    a.cache_set(1, 10);
+    b.cache_set(1, 10);
+    assert_eq!(a.cache_get(&1), b.cache_get(&1));
+    assert_eq!(a.cache_get(&1), Some(&10));
+}
+
+/// Deterministic shard router for `u32` keys: shard selection reads the upper 32
+/// bits of the hash (`(hash >> 32) & mask`), so left-shifting the key by 32
+/// makes `shard == key & mask` -- i.e. `key % shard_count` for a power-of-two
+/// shard count. Lets the test below pin keys to specific shards instead of
+/// relying on (and being unable to observe) `DefaultShardHasher`'s distribution.
+#[derive(Clone)]
+struct KeyIsShardHasher;
+
+impl cached::ShardHasher<u32> for KeyIsShardHasher {
+    fn shard_hash(&self, key: &u32) -> u64 {
+        (u64::from(*key)) << 32
+    }
+}
+
+#[test]
+fn sharded_unbound_cache_new_hasher_matches_builder() {
+    use cached::{ShardedUnboundCache, ShardedUnboundCacheBase, ShardedUnboundCacheBuilder};
+
+    let a: ShardedUnboundCacheBase<u32, u32, KeyIsShardHasher> = ShardedUnboundCacheBuilder::new()
+        .shards(4)
+        .hasher(KeyIsShardHasher)
+        .build()
+        .unwrap();
+    let b: ShardedUnboundCacheBase<u32, u32, KeyIsShardHasher> = ShardedUnboundCache::builder()
+        .shards(4)
+        .hasher(KeyIsShardHasher)
+        .build()
+        .unwrap();
+
+    for k in 0..16u32 {
+        a.set(k, k * 10);
+        b.set(k, k * 10);
+    }
+
+    // `key % 4` sends exactly 4 of the 16 keys to each of the 4 shards; a
+    // mismatch here (or with `DefaultShardHasher`'s distribution) would prove
+    // the custom hasher set via `new()` didn't actually take effect.
+    assert_eq!(a.shard_sizes(), b.shard_sizes());
+    assert_eq!(a.shard_sizes(), vec![4, 4, 4, 4]);
+
+    for k in 0..16u32 {
+        assert_eq!(a.get(&k), b.get(&k));
+    }
+}

--- a/tests/v3_contains_dyn_dispatch.rs
+++ b/tests/v3_contains_dyn_dispatch.rs
@@ -1,0 +1,86 @@
+//! `ConcurrentCached::cache_contains` dropped its `where Self: Sized` bound, so it is part of the
+//! vtable and callable through `dyn ConcurrentCached`. Backed by `ShardedUnboundCache`, which is
+//! unconditional (no feature gate needed).
+
+use cached::{ConcurrentCached, ShardedUnboundCache};
+use std::convert::Infallible;
+
+#[test]
+fn cache_contains_through_trait_object() {
+    let cache = ShardedUnboundCache::<u32, String>::new();
+    let boxed: Box<dyn ConcurrentCached<u32, String, Error = Infallible>> = Box::new(cache);
+
+    // Absent key reads false through the trait object.
+    assert!(!boxed.cache_contains(&1).unwrap());
+
+    // Insert through the same trait object (cache_set is object-safe too), then observe presence.
+    assert_eq!(boxed.cache_set(1, "one".to_string()).unwrap(), None);
+    assert!(boxed.cache_contains(&1).unwrap());
+    assert!(!boxed.cache_contains(&2).unwrap());
+
+    // Removing the entry flips contains back to false, still through the trait object.
+    assert_eq!(boxed.cache_remove(&1).unwrap(), Some("one".to_string()));
+    assert!(!boxed.cache_contains(&1).unwrap());
+}
+
+/// A monomorphic function that only ever sees the erased trait object proves `cache_contains`
+/// resolves through the vtable rather than a `Sized` concrete type.
+fn contains_via_dyn(
+    store: &dyn ConcurrentCached<u32, String, Error = Infallible>,
+    key: u32,
+) -> bool {
+    store.cache_contains(&key).unwrap()
+}
+
+#[test]
+fn cache_contains_via_borrowed_trait_object() {
+    let cache = ShardedUnboundCache::<u32, String>::new();
+    assert!(!contains_via_dyn(&cache, 7));
+    cache.cache_set(7, "seven".to_string()).unwrap();
+    assert!(contains_via_dyn(&cache, 7));
+}
+
+// A second, structurally different implementor exercised through the vtable. The TTL family's
+// `cache_contains` has a non-trivial body (peek-based, expiry-aware) distinct from the unbound
+// store's plain map lookup, so dispatching it through `dyn` guards against an impl regressing to
+// `where Self: Sized` (which would drop it from the vtable and fail to compile here).
+#[cfg(feature = "time_stores")]
+#[test]
+fn cache_contains_through_trait_object_ttl_family() {
+    use cached::ShardedTtlCache;
+    use std::time::Duration;
+
+    let cache = ShardedTtlCache::<u32, String>::builder()
+        .ttl(Duration::from_secs(60))
+        .build()
+        .unwrap();
+    let boxed: Box<dyn ConcurrentCached<u32, String, Error = Infallible>> = Box::new(cache);
+
+    assert!(!boxed.cache_contains(&1).unwrap());
+    assert_eq!(boxed.cache_set(1, "one".to_string()).unwrap(), None);
+    assert!(boxed.cache_contains(&1).unwrap());
+    assert!(!boxed.cache_contains(&2).unwrap());
+    assert_eq!(boxed.cache_remove(&1).unwrap(), Some("one".to_string()));
+    assert!(!boxed.cache_contains(&1).unwrap());
+}
+
+// Compile-only object-safety guard covering the IO implementors, which need live services to run.
+// If `cache_contains` (or any method the erased handle uses) regained a `Self: Sized` bound, or an
+// IO impl reintroduced one, coercing the concrete store to `&dyn ConcurrentCached` would stop
+// compiling and fail the build -- no Redis/redb server required. Kept monomorphic over concrete
+// `u64`/`String` so the guard needs no `serde` in the test crate's extern prelude. Never called.
+#[cfg(feature = "redis_store")]
+#[allow(dead_code)]
+fn _redis_cache_is_object_safe(
+    c: &cached::RedisCache<u64, String>,
+) -> &dyn ConcurrentCached<u64, String, Error = cached::RedisCacheError> {
+    c
+}
+
+#[cfg(feature = "redb_store")]
+#[allow(dead_code)]
+fn _redb_cache_is_object_safe(
+    c: &cached::RedbCache<u64, String>,
+) -> &dyn ConcurrentCached<u64, String, Error = cached::RedbCacheError> {
+    c
+}


### PR DESCRIPTION
- Derive the default shard count for the sharded LRU-family builders from `max_size`: `next_power_of_two(max_size / 16).clamp(1, default_shard_count())`. `ShardedLruCache::new(100)` no longer allocates `available_parallelism() * 4` shards; explicit `.shards(n)` and `per_shard_max_size` are unchanged. See `specs/design/0037-sharded-lru-default-shard-cap.md`.
- Remove `where Self: Sized` from `ConcurrentCached::cache_contains` and its impls, making it callable through `dyn ConcurrentCached` (tests/v3_contains_dyn_dispatch.rs). Note that this breaks rc implementors that repeat the where clause verbatim; dropping the clause is the fix.
- Document once-per-process `available_parallelism` sampling, the inherent sharded `set` returning `Option<V>` (so `.set(k, v).unwrap()` panics on a fresh insert), and which store families use `Shard::evictions`.
- Correct the proc-macro comments claiming the `Clone` assertion replaces the generated internals' errors (it is emitted ahead of them); drop the hard-coded byte count from the `ExpiringCache` changelog entry.
- Add tests: `Builder::new()` vs `::builder()` parity across the 13 in-memory/sharded builders, `ExpiringLruCache` stored-key `on_evict`, `Duration::MAX` ttl overflow on `TtlCache`/`LruTtlCache`, `TtlSortedCache::capacity`.
- Update CHANGELOG, both 2.0-to-3.0 migration guides, `specs/store-sharded.md` SHARD-7, and `specs/traits-concurrent.md` for the two breaking changes.