### PR TITLE
feat: count evictions before `on_evict`, clear `Clone` error for `#[once]`, no-callback `retain` fast path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,14 @@
 - `ExpiringLruCache::cache_set` fires `on_evict` with the stored key rather than the caller's
   key, matching `LruTtlCache`. Observable only for key types whose `Eq` ignores part of the
   payload; it also removes an unconditional key clone from every set.
-- `TtlSortedCache::retain_latest` counts an eviction before firing `on_evict`, so a panicking
-  callback can no longer remove an entry without counting it. Matches `evict` and `retain`.
+- Every in-memory store now counts an eviction before firing `on_evict`, on every removal path
+  (`evict`, `retain`, `cache_remove` / `cache_remove_entry`, lazy expiry sweeps in `cache_get`,
+  `cache_set` over an expired entry, capacity evictions, and the `get_or_set` families), so a
+  panicking callback can no longer remove an entry without counting it. Previously `LruCache`,
+  `TtlCache`, `LruTtlCache`, `ExpiringCache`, and `ExpiringLruCache` counted after the callback
+  returned on most of these paths, and a few `TtlSortedCache` / sharded-store paths did too.
+  Observable only when `on_evict` panics (or, on the sharded stores, when a callback reads
+  metrics concurrently). `TtlSortedCache::retain_latest` already counted before firing.
 - `ShardedTtlCache` and `ShardedLruTtlCache` decide expiry against a clock sample taken before
   the shard lock is acquired. Under contention, an entry that crosses its expiry while the
   caller queues for the lock is judged live: `cache_set` returns `Some(old)` with no eviction
@@ -133,8 +139,8 @@
 - docs.rs feature badges on the `async_core`-gated `CachedGetOrSetAsync` and
   `ConcurrentCachedAsync` impls for the in-memory and sharded stores (and `HashMap`), which
   previously rendered as unconditionally available.
-- `#[cached]` on a function whose return type does not implement `Clone` now emits a clear
-  `Clone`-bound error spanned at the return type, ahead of the opaque errors from the
+- `#[cached]` and `#[once]` on a function whose return type does not implement `Clone` now emit
+  a clear `Clone`-bound error spanned at the return type, ahead of the opaque errors from the
   generated internals.
 
 [#64]: https://github.com/jaemk/cached/issues/64

--- a/cached_proc_macro/src/once.rs
+++ b/cached_proc_macro/src/once.rs
@@ -454,6 +454,15 @@ pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
         Err(e) => return e.to_compile_error().into(),
     };
 
+    // The generated cache internals `.clone()` the value on every cache-set
+    // (`set_cache_block` above) and on a cache hit (`return_cache_block`);
+    // without a `Clone` bound on the cached value type those calls fail deep
+    // inside macro-generated code with an opaque trait-bound error. Emit a
+    // clear, precisely-spanned assertion ahead of those internals so it
+    // appears first (see `clone_return_assertion`); the opaque errors below
+    // still follow it.
+    let clone_type_assertion = clone_return_assertion(&cache_value_ty, output_span);
+
     // G1: Reject a generic `#[once]` whose cache value type names one of the
     // function's own type or const parameters. The cache static is
     // monomorphic, so it cannot contain a bare type/const param in its type.
@@ -969,6 +978,7 @@ pub fn once(args: TokenStream, input: TokenStream) -> TokenStream {
         #(#attributes)*
         #visibility #signature_no_muts {
             #body_static
+            #clone_type_assertion
             #now_block
             #do_set_return_block
         }

--- a/docs/migrations/2.0-to-3.0-human.md
+++ b/docs/migrations/2.0-to-3.0-human.md
@@ -455,6 +455,13 @@ the overwritten key survives longer, and `iter_order` / `value_order` after an o
 accordingly. There is no API that writes a value without touching recency; `cache_peek` and
 `cache_contains` remain non-promoting.
 
+### `evictions` counts before `on_evict` fires
+
+Every in-memory store increments the `evictions` counter before invoking `on_evict` for a
+removed entry, on every removal path. Observable only if a callback panics (the eviction is
+still counted) or reads `metrics().evictions` concurrently on a sharded store. No action
+needed unless a test asserts the counter under a panicking callback.
+
 ---
 
 ## Cargo.toml

--- a/docs/migrations/2.0-to-3.0.md
+++ b/docs/migrations/2.0-to-3.0.md
@@ -1720,6 +1720,22 @@ where
 fn cache_contains(&self, k: &K) -> Result<bool, Self::Error> { /* ... */ }
 ```
 
+### 79. `evictions` counter increments before `on_evict` fires
+
+Every in-memory store now increments the `evictions` counter before invoking `on_evict` for a
+removed entry, on every removal path (evict/retain sweeps, `cache_remove` / `cache_remove_entry`,
+lazy expiry removal in `cache_get`, `cache_set` over an expired entry, capacity eviction, the
+`get_or_set` families). Previously `LruCache`, `TtlCache`, `LruTtlCache`, `ExpiringCache`, and
+`ExpiringLruCache` counted after the callback returned on most paths, so a panicking callback
+left the removal uncounted.
+
+Detection: not grep-detectable. Observable only if an `on_evict` callback panics (the eviction
+is now counted) or, on the sharded stores, if a callback reads `metrics().evictions`
+concurrently (the count now includes the eviction the callback is observing).
+
+Action: none required. Tests that assert an eviction count under a panicking `on_evict` must
+expect the removed entry to be counted.
+
 ## Required Cargo.toml change
 
 ```toml

--- a/specs/design/README.md
+++ b/specs/design/README.md
@@ -55,5 +55,5 @@ the item stays here for history.
 | [0034](0034-prime-companion-body-before-lock.md) | Prime companion runs body before lock | Implemented |
 | [0035](0035-seeded-per-key-lock-bucket-hasher.md) | Seeded per-key lock-bucket hasher | Implemented |
 | [0036](0036-in-impl-static-placement.md) | `in_impl` static placement | Implemented |
-| [0037](0037-sharded-lru-default-shard-cap.md) | Sharded LRU default shard count bounded by `max_size` | Not implemented |
+| [0037](0037-sharded-lru-default-shard-cap.md) | Sharded LRU default shard count bounded by `max_size` | Implemented |
 | [0038](0038-cache-set-promotes-on-overwrite.md) | `cache_set` over an existing key promotes to MRU | Implemented |

--- a/specs/metrics.md
+++ b/specs/metrics.md
@@ -22,3 +22,12 @@ Per-metric accessors on `Cached` (`cache_hits`, `cache_misses`, `cache_evictions
 `cache_capacity`) mirror the snapshot fields. `cache_reset_metrics` clears the counters without
 touching entries. A peek (`cache_peek`) does not record a hit or miss; see
 [traits-core.md](traits-core.md).
+
+## METRIC-4
+
+On every removal path that fires `on_evict` (evict/retain sweeps, `cache_remove` /
+`cache_remove_entry`, lazy expiry removal in `cache_get`, `cache_set` over an expired entry,
+capacity eviction, the `get_or_set` families), the `evictions` counter is incremented before the
+callback is invoked, so a panicking callback cannot remove an entry without counting it. This
+holds across the single-owner in-memory stores and the sharded stores (which additionally
+publish counter updates under the shard lock and fire callbacks after the lock is released).

--- a/specs/store-ttl.md
+++ b/specs/store-ttl.md
@@ -57,6 +57,7 @@ For a key type whose `Eq` ignores part of its payload, `set` / `set_with` report
 **first-inserted** key to `on_evict` and the displaced value's key in `cache_remove_entry`, not
 the most recently inserted key: the occupied-entry insert path reuses the existing entry's stored
 key `Arc` rather than replacing it with the caller's new key. This matches `HashMap::insert`'s own
-rule for keys that compare equal. `retain_latest` counts an eviction (increments the `evictions`
-counter) before invoking `on_evict` for that entry, so a panicking `on_evict` callback still
-leaves the eviction counted.
+rule for keys that compare equal. Every removal path counts an eviction (increments the
+`evictions` counter) before invoking `on_evict` for that entry, so a panicking `on_evict`
+callback still leaves the eviction counted; this is the crate-wide ordering, see
+[metrics.md](metrics.md) METRIC-4.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1313,6 +1313,11 @@ pub trait CachedExt<K, V>: Cached<K, V> {
 
     /// Return the cache's capacity bound, if it has one. Delegates to
     /// [`cache_capacity`](Cached::cache_capacity).
+    ///
+    /// Note: the always-bounded LRU-family stores (`LruCache`, `LruTtlCache`,
+    /// `ExpiringLruCache`) also expose an inherent `capacity` returning a plain
+    /// `usize`, which takes call-site priority over this alias on those concrete
+    /// types; the alias applies in generic `Cached`-bounded code.
     #[must_use]
     fn capacity(&self) -> Option<usize>;
 
@@ -2552,6 +2557,12 @@ pub trait ConcurrentCachedExt<K, V>: ConcurrentCached<K, V> {
 
     /// Return the cache's capacity bound, if it has one. Delegates to
     /// [`cache_capacity`](ConcurrentCacheBase::cache_capacity).
+    ///
+    /// Note: the always-bounded sharded LRU-family stores (`ShardedLruCache`,
+    /// `ShardedLruTtlCache`, `ShardedExpiringLruCache`) also expose an inherent
+    /// `capacity` returning a plain `usize`, which takes call-site priority over
+    /// this alias on those concrete types; the alias applies in generic
+    /// `ConcurrentCached`-bounded code.
     #[must_use]
     fn capacity(&self) -> Option<usize>;
 

--- a/src/stores/expiring.rs
+++ b/src/stores/expiring.rs
@@ -260,10 +260,12 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> ExpiringCache<K, V, S> {
         let mut removed = 0;
         self.store.retain(|key, value| {
             if value.is_expired() {
+                // Count BEFORE notifying: a panicking callback must never leave
+                // an entry removed-but-uncounted.
+                evictions.fetch_add(1, Ordering::Relaxed);
                 if let Some(on_evict) = on_evict {
                     on_evict(key, value);
                 }
-                evictions.fetch_add(1, Ordering::Relaxed);
                 removed += 1;
                 false
             } else {
@@ -311,10 +313,12 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> ExpiringCache<K, V, S> {
         let evictions = &self.evictions;
         self.store.retain(|key, value| {
             if value.is_expired() || !keep(key, value) {
+                // Count BEFORE notifying: a panicking callback must never leave
+                // an entry removed-but-uncounted.
+                evictions.fetch_add(1, Ordering::Relaxed);
                 if let Some(on_evict) = on_evict {
                     on_evict(key, value);
                 }
-                evictions.fetch_add(1, Ordering::Relaxed);
                 false
             } else {
                 true
@@ -353,10 +357,12 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> Cached<K, V> for ExpiringCache<K,
             Some(true) => {
                 self.misses.fetch_add(1, Ordering::Relaxed);
                 if let Some((key, old)) = self.store.remove_entry(k) {
+                    // Count BEFORE notifying: a panicking callback must never leave
+                    // an entry removed-but-uncounted.
+                    self.evictions.fetch_add(1, Ordering::Relaxed);
                     if let Some(on_evict) = &self.on_evict {
                         on_evict(&key, &old);
                     }
-                    self.evictions.fetch_add(1, Ordering::Relaxed);
                 }
                 None
             }
@@ -381,10 +387,12 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> Cached<K, V> for ExpiringCache<K,
             Some(true) => {
                 self.misses.fetch_add(1, Ordering::Relaxed);
                 if let Some((key, old)) = self.store.remove_entry(k) {
+                    // Count BEFORE notifying: a panicking callback must never leave
+                    // an entry removed-but-uncounted.
+                    self.evictions.fetch_add(1, Ordering::Relaxed);
                     if let Some(on_evict) = &self.on_evict {
                         on_evict(&key, &old);
                     }
-                    self.evictions.fetch_add(1, Ordering::Relaxed);
                 }
                 None
             }
@@ -412,10 +420,12 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> Cached<K, V> for ExpiringCache<K,
                     // slot, matching TtlCache ordering (compute value, fire callback,
                     // then insert). A callback that peeks the cache sees the old value.
                     let new_val = f();
+                    // Count BEFORE notifying: a panicking callback must never leave
+                    // an entry removed-but-uncounted.
+                    self.evictions.fetch_add(1, Ordering::Relaxed);
                     if let Some(on_evict) = &self.on_evict {
                         on_evict(occupied.key(), occupied.get());
                     }
-                    self.evictions.fetch_add(1, Ordering::Relaxed);
                     occupied.insert(new_val);
                     occupied.into_mut()
                 }
@@ -442,10 +452,12 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> Cached<K, V> for ExpiringCache<K,
                     // Same ordering fix as cache_get_or_set_with_mut: compute,
                     // fire on_evict while old entry is still in the map, then insert.
                     let new_val = f()?;
+                    // Count BEFORE notifying: a panicking callback must never leave
+                    // an entry removed-but-uncounted.
+                    self.evictions.fetch_add(1, Ordering::Relaxed);
                     if let Some(on_evict) = &self.on_evict {
                         on_evict(occupied.key(), occupied.get());
                     }
-                    self.evictions.fetch_add(1, Ordering::Relaxed);
                     occupied.insert(new_val);
                     Ok(occupied.into_mut())
                 }
@@ -466,10 +478,12 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> Cached<K, V> for ExpiringCache<K,
                     // The previous value had expired, so it is filtered from the return
                     // (matching `cache_remove`); fire `on_evict` and count an eviction so the
                     // silently-dropped value is cleaned up like every other removal path.
+                    // Count BEFORE notifying: a panicking callback must never leave
+                    // an entry removed-but-uncounted.
+                    self.evictions.fetch_add(1, Ordering::Relaxed);
                     if let Some(on_evict) = &self.on_evict {
                         on_evict(occupied.key(), &old);
                     }
-                    self.evictions.fetch_add(1, Ordering::Relaxed);
                     None
                 } else {
                     Some(old)
@@ -503,10 +517,12 @@ impl<K: Hash + Eq, V: Expires, S: BuildHasher> Cached<K, V> for ExpiringCache<K,
         Q: std::hash::Hash + Eq + ?Sized,
     {
         if let Some((stored_k, v)) = self.store.remove_entry(k) {
+            // Count BEFORE notifying: a panicking callback must never leave an
+            // entry removed-but-uncounted.
+            self.evictions.fetch_add(1, Ordering::Relaxed);
             if let Some(on_evict) = &self.on_evict {
                 on_evict(&stored_k, &v);
             }
-            self.evictions.fetch_add(1, Ordering::Relaxed);
             Some((stored_k, v))
         } else {
             None
@@ -618,10 +634,12 @@ where
                         // Same ordering fix: compute, fire on_evict while old entry
                         // is still in the map slot, then insert.
                         let new_val = f().await;
+                        // Count BEFORE notifying: a panicking callback must never
+                        // leave an entry removed-but-uncounted.
+                        self.evictions.fetch_add(1, Ordering::Relaxed);
                         if let Some(on_evict) = &self.on_evict {
                             on_evict(occupied.key(), occupied.get());
                         }
-                        self.evictions.fetch_add(1, Ordering::Relaxed);
                         occupied.insert(new_val);
                         occupied.into_mut()
                     }
@@ -657,10 +675,12 @@ where
                         // Same ordering fix: compute, fire on_evict while old entry
                         // is still in the map slot, then insert.
                         let new_val = f().await?;
+                        // Count BEFORE notifying: a panicking callback must never
+                        // leave an entry removed-but-uncounted.
+                        self.evictions.fetch_add(1, Ordering::Relaxed);
                         if let Some(on_evict) = &self.on_evict {
                             on_evict(occupied.key(), occupied.get());
                         }
-                        self.evictions.fetch_add(1, Ordering::Relaxed);
                         occupied.insert(new_val);
                         occupied.into_mut()
                     }
@@ -1197,6 +1217,94 @@ mod tests {
 
         let _ = c.cache_remove_entry(&99u8);
         assert_eq!(count.load(Ordering::Relaxed), 1, "no fire for absent key");
+    }
+
+    #[test]
+    fn cache_remove_entry_with_panicking_on_evict_still_counts_eviction() {
+        // The entry is popped and counted BEFORE `on_evict` runs, so a panicking
+        // callback must not leave the removed entry uncounted.
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        let mut c: ExpiringCache<u8, ExpiredU8> = ExpiringCache::builder()
+            .on_evict(|_k: &u8, _v: &ExpiredU8| panic!("boom"))
+            .build()
+            .unwrap();
+        c.cache_set(1u8, ExpiredU8(1)); // live
+        let r = catch_unwind(AssertUnwindSafe(|| c.cache_remove_entry(&1u8)));
+        assert!(r.is_err(), "on_evict should have panicked");
+        assert_eq!(
+            c.cache_size(),
+            0,
+            "entry must still be removed from the store"
+        );
+        assert_eq!(
+            c.cache_evictions(),
+            Some(1),
+            "eviction must be counted even though on_evict panicked"
+        );
+    }
+
+    #[test]
+    fn retain_with_panicking_on_evict_still_counts_eviction() {
+        // Same invariant on the `retain` path: the predicate closure counts BEFORE
+        // notifying, so a panicking callback still leaves the eviction counted.
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        let mut c: ExpiringCache<u8, ExpiredU8> = ExpiringCache::builder()
+            .on_evict(|_k: &u8, _v: &ExpiredU8| panic!("boom"))
+            .build()
+            .unwrap();
+        c.cache_set(1u8, ExpiredU8(1)); // live
+        let r = catch_unwind(AssertUnwindSafe(|| c.retain(|_, _| false)));
+        assert!(r.is_err(), "on_evict should have panicked");
+        assert_eq!(
+            c.cache_evictions(),
+            Some(1),
+            "eviction must be counted even though on_evict panicked"
+        );
+    }
+
+    #[test]
+    fn cache_get_lazy_sweep_with_panicking_on_evict_still_counts_eviction() {
+        // `cache_get` on an expired entry removes it and counts the eviction BEFORE
+        // `on_evict` runs, so a panicking callback must not leave it uncounted.
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        let mut c: ExpiringCache<u8, ExpiredU8> = ExpiringCache::builder()
+            .on_evict(|_k: &u8, _v: &ExpiredU8| panic!("boom"))
+            .build()
+            .unwrap();
+        c.cache_set(1u8, ExpiredU8(15)); // already expired (>10)
+        let r = catch_unwind(AssertUnwindSafe(|| {
+            let _ = c.cache_get(&1u8);
+        }));
+        assert!(r.is_err(), "on_evict should have panicked");
+        assert_eq!(
+            c.cache_size(),
+            0,
+            "the expired entry must still be swept from the store"
+        );
+        assert_eq!(
+            c.cache_evictions(),
+            Some(1),
+            "eviction must be counted even though on_evict panicked"
+        );
+    }
+
+    #[test]
+    fn cache_set_over_expired_with_panicking_on_evict_still_counts_eviction() {
+        // Overwriting an expired entry fires `on_evict` for the displaced value;
+        // `cache_set` counts the eviction BEFORE notifying.
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        let mut c: ExpiringCache<u8, ExpiredU8> = ExpiringCache::builder()
+            .on_evict(|_k: &u8, _v: &ExpiredU8| panic!("boom"))
+            .build()
+            .unwrap();
+        c.cache_set(1u8, ExpiredU8(15)); // already expired (>10)
+        let r = catch_unwind(AssertUnwindSafe(|| c.cache_set(1u8, ExpiredU8(1))));
+        assert!(r.is_err(), "on_evict should have panicked");
+        assert_eq!(
+            c.cache_evictions(),
+            Some(1),
+            "eviction must be counted even though on_evict panicked"
+        );
     }
 
     #[test]

--- a/src/stores/expiring_lru.rs
+++ b/src/stores/expiring_lru.rs
@@ -352,10 +352,12 @@ impl<K: Clone + Hash + Eq, V: Expires, S: BuildHasher> ExpiringLruCache<K, V, S>
         let mut removed = 0;
         self.store.retain_silent(|key, value| {
             if value.is_expired() {
+                // Count BEFORE notifying: a panicking callback must never leave
+                // an entry removed-but-uncounted.
+                evictions.fetch_add(1, Ordering::Relaxed);
                 if let Some(on_evict) = on_evict {
                     on_evict(key, value);
                 }
-                evictions.fetch_add(1, Ordering::Relaxed);
                 removed += 1;
                 false
             } else {
@@ -382,10 +384,12 @@ impl<K: Clone + Hash + Eq, V: Expires, S: BuildHasher> ExpiringLruCache<K, V, S>
         let evictions = &self.evictions;
         self.store.retain_silent(|key, value| {
             if value.is_expired() || !keep(key, value) {
+                // Count BEFORE notifying: a panicking callback must never leave
+                // an entry removed-but-uncounted.
+                evictions.fetch_add(1, Ordering::Relaxed);
                 if let Some(on_evict) = on_evict {
                     on_evict(key, value);
                 }
-                evictions.fetch_add(1, Ordering::Relaxed);
                 false
             } else {
                 true
@@ -499,10 +503,12 @@ impl<K: Hash + Eq + Clone, V: Expires, S: BuildHasher> Cached<K, V> for Expiring
                 // `hash` was already computed above for `get_index`; reuse it instead of
                 // letting `pop_raw` re-hash the same key.
                 if let Some((key, old)) = self.store.pop_raw_with_hash(hash, k) {
+                    // Count BEFORE notifying: a panicking callback must never leave
+                    // an entry removed-but-uncounted.
+                    self.evictions.fetch_add(1, Ordering::Relaxed);
                     if let Some(on_evict) = &self.on_evict {
                         on_evict(&key, &old);
                     }
-                    self.evictions.fetch_add(1, Ordering::Relaxed);
                 }
                 None
             }
@@ -529,10 +535,12 @@ impl<K: Hash + Eq + Clone, V: Expires, S: BuildHasher> Cached<K, V> for Expiring
                 // `hash` was already computed above for `get_index`; reuse it instead of
                 // letting `pop_raw` re-hash the same key.
                 if let Some((k, old)) = self.store.pop_raw_with_hash(hash, key) {
+                    // Count BEFORE notifying: a panicking callback must never leave
+                    // an entry removed-but-uncounted.
+                    self.evictions.fetch_add(1, Ordering::Relaxed);
                     if let Some(on_evict) = &self.on_evict {
                         on_evict(&k, &old);
                     }
-                    self.evictions.fetch_add(1, Ordering::Relaxed);
                 }
                 None
             }
@@ -564,10 +572,12 @@ impl<K: Hash + Eq + Clone, V: Expires, S: BuildHasher> Cached<K, V> for Expiring
         if was_present && was_valid {
             self.hits.fetch_add(1, Ordering::Relaxed);
         } else if let Some((old_key, old)) = old_val {
+            // Count BEFORE notifying: a panicking callback must never leave an
+            // entry removed-but-uncounted.
+            self.evictions.fetch_add(1, Ordering::Relaxed);
             if let Some(on_evict) = &self.on_evict {
                 on_evict(&old_key, &old);
             }
-            self.evictions.fetch_add(1, Ordering::Relaxed);
         }
         v
     }
@@ -594,10 +604,12 @@ impl<K: Hash + Eq + Clone, V: Expires, S: BuildHasher> Cached<K, V> for Expiring
         if was_present && was_valid {
             self.hits.fetch_add(1, Ordering::Relaxed);
         } else if let Some((old_key, old)) = old_val {
+            // Count BEFORE notifying: a panicking callback must never leave an
+            // entry removed-but-uncounted.
+            self.evictions.fetch_add(1, Ordering::Relaxed);
             if let Some(on_evict) = &self.on_evict {
                 on_evict(&old_key, &old);
             }
-            self.evictions.fetch_add(1, Ordering::Relaxed);
         }
         Ok(v)
     }
@@ -612,10 +624,12 @@ impl<K: Hash + Eq + Clone, V: Expires, S: BuildHasher> Cached<K, V> for Expiring
         // `LruTtlCache::set_entry`.
         match self.store.cache_set_returning_entry(k, v) {
             Some((stored_key, old)) if old.is_expired() => {
+                // Count BEFORE notifying: a panicking callback must never leave an
+                // entry removed-but-uncounted.
+                self.evictions.fetch_add(1, Ordering::Relaxed);
                 if let Some(on_evict) = &self.on_evict {
                     on_evict(&stored_key, &old);
                 }
-                self.evictions.fetch_add(1, Ordering::Relaxed);
                 None
             }
             Some((_, old)) => Some(old),
@@ -643,10 +657,12 @@ impl<K: Hash + Eq + Clone, V: Expires, S: BuildHasher> Cached<K, V> for Expiring
         Q: std::hash::Hash + Eq + ?Sized,
     {
         if let Some((stored_k, v)) = self.store.pop_raw(k) {
+            // Count BEFORE notifying: a panicking callback must never leave an
+            // entry removed-but-uncounted.
+            self.evictions.fetch_add(1, Ordering::Relaxed);
             if let Some(on_evict) = &self.on_evict {
                 on_evict(&stored_k, &v);
             }
-            self.evictions.fetch_add(1, Ordering::Relaxed);
             Some((stored_k, v))
         } else {
             None
@@ -773,10 +789,12 @@ where
             if was_present && was_valid {
                 self.hits.fetch_add(1, Ordering::Relaxed);
             } else if let Some((old_key, old)) = old_val {
+                // Count BEFORE notifying: a panicking callback must never leave an
+                // entry removed-but-uncounted.
+                self.evictions.fetch_add(1, Ordering::Relaxed);
                 if let Some(on_evict) = &self.on_evict {
                     on_evict(&old_key, &old);
                 }
-                self.evictions.fetch_add(1, Ordering::Relaxed);
             }
             v
         }
@@ -813,10 +831,12 @@ where
             if was_present && was_valid {
                 self.hits.fetch_add(1, Ordering::Relaxed);
             } else if let Some((old_key, old)) = old_val {
+                // Count BEFORE notifying: a panicking callback must never leave an
+                // entry removed-but-uncounted.
+                self.evictions.fetch_add(1, Ordering::Relaxed);
                 if let Some(on_evict) = &self.on_evict {
                     on_evict(&old_key, &old);
                 }
-                self.evictions.fetch_add(1, Ordering::Relaxed);
             }
             Ok(v)
         }
@@ -1730,6 +1750,98 @@ mod tests {
 
         let _ = c.cache_remove_entry(&99u8);
         assert_eq!(count.load(Ordering::Relaxed), 1, "no fire for absent key");
+    }
+
+    #[test]
+    fn cache_remove_entry_with_panicking_on_evict_still_counts_eviction() {
+        // The entry is popped and counted BEFORE `on_evict` runs, so a panicking
+        // callback must not leave the removed entry uncounted.
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        let mut c: ExpiringLruCache<u8, ExpiredU8> = ExpiringLruCache::builder()
+            .max_size(4)
+            .on_evict(|_k: &u8, _v: &ExpiredU8| panic!("boom"))
+            .build()
+            .unwrap();
+        c.cache_set(1u8, 1u8); // live
+        let r = catch_unwind(AssertUnwindSafe(|| c.cache_remove_entry(&1u8)));
+        assert!(r.is_err(), "on_evict should have panicked");
+        assert_eq!(
+            c.cache_size(),
+            0,
+            "entry must still be removed from the store"
+        );
+        assert_eq!(
+            c.cache_evictions(),
+            Some(1),
+            "eviction must be counted even though on_evict panicked"
+        );
+    }
+
+    #[test]
+    fn retain_with_panicking_on_evict_still_counts_eviction() {
+        // Same invariant on the `retain` path: the predicate closure counts BEFORE
+        // notifying, so a panicking callback still leaves the eviction counted.
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        let mut c: ExpiringLruCache<u8, ExpiredU8> = ExpiringLruCache::builder()
+            .max_size(4)
+            .on_evict(|_k: &u8, _v: &ExpiredU8| panic!("boom"))
+            .build()
+            .unwrap();
+        c.cache_set(1u8, 1u8); // live
+        let r = catch_unwind(AssertUnwindSafe(|| c.retain(|_, _| false)));
+        assert!(r.is_err(), "on_evict should have panicked");
+        assert_eq!(
+            c.cache_evictions(),
+            Some(1),
+            "eviction must be counted even though on_evict panicked"
+        );
+    }
+
+    #[test]
+    fn cache_get_lazy_sweep_with_panicking_on_evict_still_counts_eviction() {
+        // `cache_get` on an expired entry pops it and counts the eviction BEFORE
+        // `on_evict` runs, so a panicking callback must not leave it uncounted.
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        let mut c: ExpiringLruCache<u8, ExpiredU8> = ExpiringLruCache::builder()
+            .max_size(4)
+            .on_evict(|_k: &u8, _v: &ExpiredU8| panic!("boom"))
+            .build()
+            .unwrap();
+        c.cache_set(1u8, 15u8); // already expired (>10)
+        let r = catch_unwind(AssertUnwindSafe(|| {
+            let _ = c.cache_get(&1u8);
+        }));
+        assert!(r.is_err(), "on_evict should have panicked");
+        assert_eq!(
+            c.cache_size(),
+            0,
+            "the expired entry must still be swept from the store"
+        );
+        assert_eq!(
+            c.cache_evictions(),
+            Some(1),
+            "eviction must be counted even though on_evict panicked"
+        );
+    }
+
+    #[test]
+    fn cache_set_over_expired_with_panicking_on_evict_still_counts_eviction() {
+        // Overwriting an expired entry fires `on_evict` for the displaced value;
+        // `cache_set` counts the eviction BEFORE notifying.
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        let mut c: ExpiringLruCache<u8, ExpiredU8> = ExpiringLruCache::builder()
+            .max_size(4)
+            .on_evict(|_k: &u8, _v: &ExpiredU8| panic!("boom"))
+            .build()
+            .unwrap();
+        c.cache_set(1u8, 15u8); // already expired (>10)
+        let r = catch_unwind(AssertUnwindSafe(|| c.cache_set(1u8, 1u8)));
+        assert!(r.is_err(), "on_evict should have panicked");
+        assert_eq!(
+            c.cache_evictions(),
+            Some(1),
+            "eviction must be counted even though on_evict panicked"
+        );
     }
 
     #[test]

--- a/src/stores/lru.rs
+++ b/src/stores/lru.rs
@@ -684,10 +684,12 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruCache<K, V, S> {
         let doomed = self.doomed_indices(&mut keep);
         for index in doomed {
             let (key, value) = self.remove_index(index);
+            // Count BEFORE notifying: a panicking callback must never leave an
+            // entry removed-but-uncounted.
+            self.evictions.fetch_add(1, Ordering::Relaxed);
             if let Some(on_evict) = &self.on_evict {
                 on_evict(&key, &value);
             }
-            self.evictions.fetch_add(1, Ordering::Relaxed);
         }
     }
 
@@ -948,10 +950,12 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruCache<K, V, S>
     {
         let removed = self.pop_raw(k);
         if let Some((ref key, ref value)) = removed {
+            // Count BEFORE notifying: a panicking callback must never leave an
+            // entry removed-but-uncounted.
+            self.evictions.fetch_add(1, Ordering::Relaxed);
             if let Some(on_evict) = &self.on_evict {
                 on_evict(key, value);
             }
-            self.evictions.fetch_add(1, Ordering::Relaxed);
         }
         removed
     }
@@ -2002,6 +2006,27 @@ mod tests {
     }
 
     #[test]
+    fn cache_remove_entry_with_panicking_on_evict_still_counts_eviction() {
+        // The entry is popped and counted BEFORE `on_evict` runs, so a panicking
+        // callback must not leave the removed entry uncounted.
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        let mut c = LruCache::builder()
+            .max_size(4)
+            .on_evict(|_k: &u32, _v: &u32| panic!("boom"))
+            .build()
+            .unwrap();
+        c.cache_set(1u32, 10u32);
+        let r = catch_unwind(AssertUnwindSafe(|| c.cache_remove_entry(&1u32)));
+        assert!(r.is_err(), "on_evict should have panicked");
+        assert_eq!(c.cache_get(&1u32), None, "entry must still be removed");
+        assert_eq!(
+            c.cache_evictions(),
+            Some(1),
+            "eviction must be counted even though on_evict panicked"
+        );
+    }
+
+    #[test]
     fn cache_remove_entry_increments_eviction_counter() {
         let mut c = LruCache::builder().max_size(4).build().unwrap();
         c.cache_set(1u32, 10u32);
@@ -2585,10 +2610,10 @@ mod tests {
 
     #[test]
     fn retain_with_panicking_on_evict_leaves_cache_consistent() {
-        // The rewrite removes the entry BEFORE notifying, so a panicking callback can
-        // never leave an entry half-removed. The remaining doomed entries stay (the
-        // loop unwinds) and `evictions` is not credited for the panicking entry --
-        // both match the pre-rewrite `cache_remove` loop.
+        // The entry is removed AND counted BEFORE notifying, so a panicking callback
+        // can never leave an entry half-removed or removed-but-uncounted. The
+        // remaining doomed entries stay (the loop unwinds), but `evictions` IS
+        // credited for the panicking entry since counting happens before the call.
         use std::panic::{AssertUnwindSafe, catch_unwind};
         use std::sync::{Arc, Mutex};
         let seen = Arc::new(Mutex::new(Vec::new()));
@@ -2616,8 +2641,8 @@ mod tests {
         assert_eq!(c.key_order(), vec![4, 2, 1, 0]);
         assert_eq!(
             c.cache_evictions(),
-            Some(0),
-            "evictions is credited after the callback, so a panicking callback skips it"
+            Some(1),
+            "evictions is credited BEFORE the callback, so a panicking callback still counts"
         );
         // No entry is both removed and still present.
         assert_store_and_order_agree(&c);
@@ -2626,7 +2651,7 @@ mod tests {
         c.retain(|k, _v| k % 2 == 0);
         assert_eq!(*seen.lock().unwrap(), vec![(3, 30), (1, 10)]);
         assert_eq!(c.key_order(), vec![4, 2, 0]);
-        assert_eq!(c.cache_evictions(), Some(1));
+        assert_eq!(c.cache_evictions(), Some(2));
         assert_store_and_order_agree(&c);
     }
 

--- a/src/stores/lru_ttl.rs
+++ b/src/stores/lru_ttl.rs
@@ -389,10 +389,12 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruTtlCache<K, V, S> {
         match self.store.cache_set_returning_entry(key, entry) {
             Some((_, old)) if Self::entry_live_at(old.expires_at, now) => Some(old.value),
             Some((stored_key, old)) => {
+                // Count BEFORE notifying: a panicking callback must never leave
+                // an entry removed-but-uncounted.
+                self.evictions.fetch_add(1, Ordering::Relaxed);
                 if let Some(on_evict) = &self.on_evict {
                     on_evict(&stored_key, &old.value);
                 }
-                self.evictions.fetch_add(1, Ordering::Relaxed);
                 None
             }
             None => None,
@@ -576,10 +578,12 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruTtlCache<K, V, S> {
             if Self::entry_live_at(entry.expires_at, now) {
                 true
             } else {
+                // Count BEFORE notifying: a panicking callback must never leave
+                // an entry removed-but-uncounted.
+                evictions.fetch_add(1, Ordering::Relaxed);
                 if let Some(on_evict) = on_evict {
                     on_evict(key, &entry.value);
                 }
-                evictions.fetch_add(1, Ordering::Relaxed);
                 removed += 1;
                 false
             }
@@ -608,10 +612,12 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> LruTtlCache<K, V, S> {
         self.store.retain_silent(|key, entry| {
             let expired = !Self::entry_live_at(entry.expires_at, now);
             if expired || !keep(key, &entry.value) {
+                // Count BEFORE notifying: a panicking callback must never leave
+                // an entry removed-but-uncounted.
+                evictions.fetch_add(1, Ordering::Relaxed);
                 if let Some(on_evict) = on_evict {
                     on_evict(key, &entry.value);
                 }
-                evictions.fetch_add(1, Ordering::Relaxed);
                 false
             } else {
                 true
@@ -680,10 +686,12 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
                 // sweep must not recompute it (this is the steady-state path -- every
                 // entry takes it exactly once).
                 if let Some((k, entry)) = self.store.pop_raw_with_hash(hash, key) {
+                    // Count BEFORE notifying: a panicking callback must never leave
+                    // an entry removed-but-uncounted.
+                    self.evictions.fetch_add(1, Ordering::Relaxed);
                     if let Some(on_evict) = &self.on_evict {
                         on_evict(&k, &entry.value);
                     }
-                    self.evictions.fetch_add(1, Ordering::Relaxed);
                 }
                 None
             }
@@ -720,10 +728,12 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
                 self.misses.fetch_add(1, Ordering::Relaxed);
                 // Reuse the probe's hash for the lazy sweep (as in `cache_get`).
                 if let Some((k, entry)) = self.store.pop_raw_with_hash(hash, key) {
+                    // Count BEFORE notifying: a panicking callback must never leave
+                    // an entry removed-but-uncounted.
+                    self.evictions.fetch_add(1, Ordering::Relaxed);
                     if let Some(on_evict) = &self.on_evict {
                         on_evict(&k, &entry.value);
                     }
-                    self.evictions.fetch_add(1, Ordering::Relaxed);
                 }
                 None
             }
@@ -765,10 +775,12 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
             self.hits.fetch_add(1, Ordering::Relaxed);
         } else {
             if let Some((old_key, old)) = old_entry {
+                // Count BEFORE notifying: a panicking callback must never leave
+                // an entry removed-but-uncounted.
+                self.evictions.fetch_add(1, Ordering::Relaxed);
                 if let Some(on_evict) = &self.on_evict {
                     on_evict(&old_key, &old.value);
                 }
-                self.evictions.fetch_add(1, Ordering::Relaxed);
             }
             self.misses.fetch_add(1, Ordering::Relaxed);
         }
@@ -814,10 +826,12 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
             // The miss was already counted by `setter`. On `Err` the expired entry is left
             // in place, so `on_evict` / `evictions` deliberately stay behind until a call
             // actually displaces it -- firing early would double-fire for one physical entry.
+            // Count BEFORE notifying: a panicking callback must never leave an entry
+            // removed-but-uncounted.
+            self.evictions.fetch_add(1, Ordering::Relaxed);
             if let Some(on_evict) = &self.on_evict {
                 on_evict(&old_key, &old.value);
             }
-            self.evictions.fetch_add(1, Ordering::Relaxed);
         }
         Ok(&mut entry.value)
     }
@@ -852,10 +866,12 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
         Q: std::hash::Hash + Eq + ?Sized,
     {
         if let Some((stored_k, entry)) = self.store.pop_raw(k) {
+            // Count BEFORE notifying: a panicking callback must never leave an
+            // entry removed-but-uncounted.
+            self.evictions.fetch_add(1, Ordering::Relaxed);
             if let Some(on_evict) = &self.on_evict {
                 on_evict(&stored_k, &entry.value);
             }
-            self.evictions.fetch_add(1, Ordering::Relaxed);
             if Self::entry_live(entry.expires_at) {
                 Some(entry.value)
             } else {
@@ -872,10 +888,12 @@ impl<K: Hash + Eq + Clone, V, S: BuildHasher> Cached<K, V> for LruTtlCache<K, V,
         Q: std::hash::Hash + Eq + ?Sized,
     {
         if let Some((stored_k, entry)) = self.store.pop_raw(k) {
+            // Count BEFORE notifying: a panicking callback must never leave an
+            // entry removed-but-uncounted.
+            self.evictions.fetch_add(1, Ordering::Relaxed);
             if let Some(on_evict) = &self.on_evict {
                 on_evict(&stored_k, &entry.value);
             }
-            self.evictions.fetch_add(1, Ordering::Relaxed);
             Some((stored_k, entry.value))
         } else {
             None
@@ -1104,10 +1122,12 @@ where
                 self.hits.fetch_add(1, Ordering::Relaxed);
             } else {
                 if let Some((old_key, old)) = old_entry {
+                    // Count BEFORE notifying: a panicking callback must never leave
+                    // an entry removed-but-uncounted.
+                    self.evictions.fetch_add(1, Ordering::Relaxed);
                     if let Some(on_evict) = &self.on_evict {
                         on_evict(&old_key, &old.value);
                     }
-                    self.evictions.fetch_add(1, Ordering::Relaxed);
                 }
                 self.misses.fetch_add(1, Ordering::Relaxed);
             }
@@ -1163,11 +1183,12 @@ where
             } else if let Some((old_key, old)) = old_entry {
                 // The miss was already counted by `setter`; on `Err` the expired entry is
                 // still stored, so the eviction side deliberately waits for the call that
-                // actually displaces it.
+                // actually displaces it. Count BEFORE notifying: a panicking callback must
+                // never leave an entry removed-but-uncounted.
+                self.evictions.fetch_add(1, Ordering::Relaxed);
                 if let Some(on_evict) = &self.on_evict {
                     on_evict(&old_key, &old.value);
                 }
-                self.evictions.fetch_add(1, Ordering::Relaxed);
             }
             Ok(&mut entry.value)
         }
@@ -1998,6 +2019,97 @@ mod tests {
 
         let _ = c.cache_remove_entry(&999u32);
         assert_eq!(count.load(Ordering::Relaxed), 1, "no fire for absent key");
+    }
+
+    #[test]
+    fn cache_remove_entry_with_panicking_on_evict_still_counts_eviction() {
+        // The entry is popped and counted BEFORE `on_evict` runs, so a panicking
+        // callback must not leave the removed entry uncounted.
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        let mut c = LruTtlCache::builder()
+            .max_size(4)
+            .ttl(Duration::from_secs(60))
+            .on_evict(|_k: &u32, _v: &u32| panic!("boom"))
+            .build()
+            .unwrap();
+        c.cache_set(1u32, 10u32);
+        let r = catch_unwind(AssertUnwindSafe(|| c.cache_remove_entry(&1u32)));
+        assert!(r.is_err(), "on_evict should have panicked");
+        assert_eq!(c.cache_get(&1u32), None, "entry must still be removed");
+        assert_eq!(
+            c.cache_evictions(),
+            Some(1),
+            "eviction must be counted even though on_evict panicked"
+        );
+    }
+
+    #[test]
+    fn retain_with_panicking_on_evict_still_counts_eviction() {
+        // The predicate closure passed to the inner `retain_silent` fires `on_evict`
+        // and counts the eviction before returning `false`, so a panicking callback
+        // still leaves the eviction counted.
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        let mut c = LruTtlCache::builder()
+            .max_size(4)
+            .ttl(Duration::from_secs(60))
+            .on_evict(|_k: &u32, _v: &u32| panic!("boom"))
+            .build()
+            .unwrap();
+        c.cache_set(1u32, 10u32);
+        let r = catch_unwind(AssertUnwindSafe(|| c.retain(|_, _| false)));
+        assert!(r.is_err(), "on_evict should have panicked");
+        assert_eq!(
+            c.cache_evictions(),
+            Some(1),
+            "eviction must be counted even though on_evict panicked"
+        );
+    }
+
+    #[test]
+    fn cache_get_lazy_sweep_with_panicking_on_evict_still_counts_eviction() {
+        // `cache_get`'s lazy-sweep path pops the expired entry and counts the
+        // eviction BEFORE `on_evict` runs, so a panicking callback must not leave
+        // the swept entry uncounted.
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        let mut c = LruTtlCache::builder()
+            .max_size(4)
+            .ttl(Duration::from_millis(20))
+            .on_evict(|_k: &u32, _v: &u32| panic!("boom"))
+            .build()
+            .unwrap();
+        c.cache_set(1u32, 10u32);
+        std::thread::sleep(std::time::Duration::from_millis(80));
+        let r = catch_unwind(AssertUnwindSafe(|| {
+            let _ = c.cache_get(&1u32);
+        }));
+        assert!(r.is_err(), "on_evict should have panicked");
+        assert_eq!(
+            c.cache_evictions(),
+            Some(1),
+            "eviction must be counted even though on_evict panicked"
+        );
+    }
+
+    #[test]
+    fn cache_set_over_expired_with_panicking_on_evict_still_counts_eviction() {
+        // Overwriting an already-expired entry fires `on_evict` for the displaced
+        // value; `set_entry` counts the eviction BEFORE notifying.
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        let mut c = LruTtlCache::builder()
+            .max_size(4)
+            .ttl(Duration::from_millis(20))
+            .on_evict(|_k: &u32, _v: &u32| panic!("boom"))
+            .build()
+            .unwrap();
+        c.cache_set(1u32, 10u32);
+        std::thread::sleep(std::time::Duration::from_millis(80));
+        let r = catch_unwind(AssertUnwindSafe(|| c.cache_set(1u32, 20u32)));
+        assert!(r.is_err(), "on_evict should have panicked");
+        assert_eq!(
+            c.cache_evictions(),
+            Some(1),
+            "eviction must be counted even though on_evict panicked"
+        );
     }
 
     #[test]

--- a/src/stores/sharded/expiring.rs
+++ b/src/stores/sharded/expiring.rs
@@ -443,6 +443,22 @@ where
     /// callbacks run between shard sweeps, an `on_evict` that inserts into a shard this call has
     /// not yet visited will have that entry filtered by the same in-flight `retain`.
     pub fn retain<F: FnMut(&K, &V) -> bool>(&self, mut keep: F) {
+        if self.inner.on_evict.is_none() {
+            // No callback: only the removed *count* is observable, so drop the filtered-out
+            // entries in place via `retain` and take the length delta -- no key clones, no
+            // `Vec` (matching `evict`'s no-callback fast path).
+            for shard in self.inner.shards.iter() {
+                let mut guard = shard.lock.write();
+                let before = guard.len();
+                guard.retain(|k, v| !v.is_expired() && keep(k, v));
+                let removed = before - guard.len();
+                drop(guard);
+                if removed > 0 {
+                    shard.evictions.fetch_add(removed as u64, Ordering::Relaxed);
+                }
+            }
+            return;
+        }
         for shard in self.inner.shards.iter() {
             // Collect under the write lock, fire callbacks after releasing it.
             let removed: Vec<(K, V)> = {
@@ -588,10 +604,12 @@ where
             // A displaced expired value is filtered from the return (matching cache_remove and
             // the single-owner expiring stores); fire on_evict and count an eviction for it.
             Some((key, old_v, true)) => {
+                // Count BEFORE notifying: a panicking callback must never leave an
+                // entry removed-but-uncounted.
+                shard.evictions.fetch_add(1, Ordering::Relaxed);
                 if let (Some(cb), Some(key)) = (&self.inner.on_evict, &key) {
                     cb(key, &old_v);
                 }
-                shard.evictions.fetch_add(1, Ordering::Relaxed);
                 Ok(None)
             }
             Some((_, old_v, false)) => Ok(Some(old_v)),

--- a/src/stores/sharded/lru_ttl.rs
+++ b/src/stores/sharded/lru_ttl.rs
@@ -787,10 +787,12 @@ where
         let removed = guard.pop_raw(k);
         drop(guard);
         if let Some((ref ek, ref entry)) = removed {
+            // Count BEFORE notifying: a panicking callback must never leave an
+            // entry removed-but-uncounted.
+            shard.evictions.fetch_add(1, Ordering::Relaxed);
             if let Some(cb) = &self.inner.on_evict {
                 cb(ek, &entry.value);
             }
-            shard.evictions.fetch_add(1, Ordering::Relaxed);
         }
         shard.misses.fetch_add(1, Ordering::Relaxed);
         Ok(None)
@@ -829,10 +831,12 @@ where
             // A displaced expired value is filtered from the return (matching cache_remove and
             // the single-owner TTL stores); fire on_evict and count an eviction for it.
             Some((key, entry, true)) => {
+                // Count BEFORE notifying: a panicking callback must never leave an
+                // entry removed-but-uncounted.
+                shard.evictions.fetch_add(1, Ordering::Relaxed);
                 if let (Some(on_evict), Some(key)) = (&self.inner.on_evict, &key) {
                     on_evict(key, &entry.value);
                 }
-                shard.evictions.fetch_add(1, Ordering::Relaxed);
                 Ok(None)
             }
             Some((_, entry, false)) => Ok(Some(entry.value)),

--- a/src/stores/sharded/ttl.rs
+++ b/src/stores/sharded/ttl.rs
@@ -493,6 +493,23 @@ where
     /// not yet visited will have that entry filtered by the same in-flight `retain`.
     pub fn retain<F: FnMut(&K, &V) -> bool>(&self, mut keep: F) {
         let now = Instant::now();
+        let Some(cb) = &self.inner.on_evict else {
+            // No callback: only the removed *count* is observable, so drop the filtered-out
+            // entries in place via `retain` and take the length delta -- no key clones, no
+            // `Vec` (matching `evict`'s no-callback fast path).
+            for shard in self.inner.shards.iter() {
+                let removed = {
+                    let mut guard = shard.lock.write();
+                    let before = guard.len();
+                    guard.retain(|k, entry| !expired_at(entry, now) && keep(k, &entry.value));
+                    before - guard.len()
+                };
+                if removed > 0 {
+                    shard.evictions.fetch_add(removed as u64, Ordering::Relaxed);
+                }
+            }
+            return;
+        };
         for shard in self.inner.shards.iter() {
             // Collect under the write lock, fire callbacks after releasing it.
             let removed: Vec<(K, TimedEntry<V>)> = {
@@ -505,10 +522,8 @@ where
                 shard
                     .evictions
                     .fetch_add(removed.len() as u64, Ordering::Relaxed);
-                if let Some(cb) = &self.inner.on_evict {
-                    for (k, entry) in &removed {
-                        cb(k, &entry.value);
-                    }
+                for (k, entry) in &removed {
+                    cb(k, &entry.value);
                 }
             }
         }
@@ -741,10 +756,12 @@ where
             // A displaced expired value is filtered from the return (matching cache_remove and
             // the single-owner TTL stores); fire on_evict and count an eviction for it.
             Some((key, entry, true)) => {
+                // Count BEFORE notifying: a panicking callback must never leave an
+                // entry removed-but-uncounted.
+                shard.evictions.fetch_add(1, Ordering::Relaxed);
                 if let (Some(cb), Some(key)) = (&self.inner.on_evict, &key) {
                     cb(key, &entry.value);
                 }
-                shard.evictions.fetch_add(1, Ordering::Relaxed);
                 Ok(None)
             }
             Some((_, entry, false)) => Ok(Some(entry.value)),

--- a/src/stores/ttl.rs
+++ b/src/stores/ttl.rs
@@ -290,10 +290,12 @@ impl<K: Hash + Eq, V, S: BuildHasher> TtlCache<K, V, S> {
                 if Self::entry_live_at(old.expires_at, now) {
                     Some(old.value)
                 } else {
+                    // Count BEFORE notifying: a panicking callback must never leave
+                    // an entry removed-but-uncounted.
+                    self.evictions.fetch_add(1, Ordering::Relaxed);
                     if let Some(on_evict) = &self.on_evict {
                         on_evict(occupied.key(), &old.value);
                     }
-                    self.evictions.fetch_add(1, Ordering::Relaxed);
                     None
                 }
             }
@@ -353,10 +355,12 @@ impl<K: Hash + Eq, V, S: BuildHasher> TtlCache<K, V, S> {
             if entry.expires_at.is_none_or(|t| now < t) {
                 true
             } else {
+                // Count BEFORE notifying: a panicking callback must never leave
+                // an entry removed-but-uncounted.
+                evictions.fetch_add(1, Ordering::Relaxed);
                 if let Some(on_evict) = on_evict {
                     on_evict(key, &entry.value);
                 }
-                evictions.fetch_add(1, Ordering::Relaxed);
                 removed += 1;
                 false
             }
@@ -382,10 +386,12 @@ impl<K: Hash + Eq, V, S: BuildHasher> TtlCache<K, V, S> {
         self.store.retain(|key, entry| {
             let expired = !Self::entry_live_at(entry.expires_at, now);
             if expired || !keep(key, &entry.value) {
+                // Count BEFORE notifying: a panicking callback must never leave
+                // an entry removed-but-uncounted.
+                evictions.fetch_add(1, Ordering::Relaxed);
                 if let Some(on_evict) = on_evict {
                     on_evict(key, &entry.value);
                 }
-                evictions.fetch_add(1, Ordering::Relaxed);
                 false
             } else {
                 true
@@ -425,10 +431,12 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for TtlCache<K, V, S> {
         };
         self.misses.fetch_add(1, Ordering::Relaxed);
         if expired_present && let Some((k, entry)) = self.store.remove_entry(key) {
+            // Count BEFORE notifying: a panicking callback must never leave
+            // an entry removed-but-uncounted.
+            self.evictions.fetch_add(1, Ordering::Relaxed);
             if let Some(on_evict) = &self.on_evict {
                 on_evict(&k, &entry.value);
             }
-            self.evictions.fetch_add(1, Ordering::Relaxed);
         }
         None
     }
@@ -457,10 +465,12 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for TtlCache<K, V, S> {
         };
         self.misses.fetch_add(1, Ordering::Relaxed);
         if expired_present && let Some((k, entry)) = self.store.remove_entry(key) {
+            // Count BEFORE notifying: a panicking callback must never leave
+            // an entry removed-but-uncounted.
+            self.evictions.fetch_add(1, Ordering::Relaxed);
             if let Some(on_evict) = &self.on_evict {
                 on_evict(&k, &entry.value);
             }
-            self.evictions.fetch_add(1, Ordering::Relaxed);
         }
         None
     }
@@ -485,10 +495,12 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for TtlCache<K, V, S> {
                     // so firing on_evict / counting here would double-fire when the
                     // next call finally evicts the same physical entry (EXP-3).
                     let val = f();
+                    // Count BEFORE notifying: a panicking callback must never leave
+                    // an entry removed-but-uncounted.
+                    self.evictions.fetch_add(1, Ordering::Relaxed);
                     if let Some(on_evict) = &self.on_evict {
                         on_evict(occupied.key(), &occupied.get().value);
                     }
-                    self.evictions.fetch_add(1, Ordering::Relaxed);
                     let now = Instant::now();
                     let expires_at = Self::compute_expires_at(self.ttl, now);
                     occupied.insert(TimedEntry {
@@ -537,10 +549,12 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for TtlCache<K, V, S> {
                     // firing on_evict / counting here would double-fire when the
                     // next call finally evicts the same physical entry (EXP-3).
                     let val = f()?;
+                    // Count BEFORE notifying: a panicking callback must never leave
+                    // an entry removed-but-uncounted.
+                    self.evictions.fetch_add(1, Ordering::Relaxed);
                     if let Some(on_evict) = &self.on_evict {
                         on_evict(occupied.key(), &occupied.get().value);
                     }
-                    self.evictions.fetch_add(1, Ordering::Relaxed);
                     let now = Instant::now();
                     let expires_at = Self::compute_expires_at(self.ttl, now);
                     occupied.insert(TimedEntry {
@@ -589,10 +603,12 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for TtlCache<K, V, S> {
         Q: std::hash::Hash + Eq + ?Sized,
     {
         if let Some((stored_k, entry)) = self.store.remove_entry(k) {
+            // Count BEFORE notifying: a panicking callback must never leave
+            // an entry removed-but-uncounted.
+            self.evictions.fetch_add(1, Ordering::Relaxed);
             if let Some(on_evict) = &self.on_evict {
                 on_evict(&stored_k, &entry.value);
             }
-            self.evictions.fetch_add(1, Ordering::Relaxed);
             if Self::entry_live(entry.expires_at) {
                 Some(entry.value)
             } else {
@@ -609,10 +625,12 @@ impl<K: Hash + Eq, V, S: BuildHasher> Cached<K, V> for TtlCache<K, V, S> {
         Q: std::hash::Hash + Eq + ?Sized,
     {
         if let Some((stored_k, entry)) = self.store.remove_entry(k) {
+            // Count BEFORE notifying: a panicking callback must never leave
+            // an entry removed-but-uncounted.
+            self.evictions.fetch_add(1, Ordering::Relaxed);
             if let Some(on_evict) = &self.on_evict {
                 on_evict(&stored_k, &entry.value);
             }
-            self.evictions.fetch_add(1, Ordering::Relaxed);
             Some((stored_k, entry.value))
         } else {
             None
@@ -817,10 +835,12 @@ where
                         // expiry after the factory resolves so a slow factory does
                         // not eat into the fresh entry's TTL (CORE-3).
                         let val = f().await;
+                        // Count BEFORE notifying: a panicking callback must never
+                        // leave an entry removed-but-uncounted.
+                        self.evictions.fetch_add(1, Ordering::Relaxed);
                         if let Some(on_evict) = &self.on_evict {
                             on_evict(occupied.key(), &occupied.get().value);
                         }
-                        self.evictions.fetch_add(1, Ordering::Relaxed);
                         let now = Instant::now();
                         let expires_at = Self::compute_expires_at(self.ttl, now);
                         occupied.insert(TimedEntry {
@@ -878,10 +898,12 @@ where
                         // (CORE-3). On `Err` the expired entry is left in place
                         // and nothing is fired, so the next call evicts it once.
                         let val = f().await?;
+                        // Count BEFORE notifying: a panicking callback must never
+                        // leave an entry removed-but-uncounted.
+                        self.evictions.fetch_add(1, Ordering::Relaxed);
                         if let Some(on_evict) = &self.on_evict {
                             on_evict(occupied.key(), &occupied.get().value);
                         }
-                        self.evictions.fetch_add(1, Ordering::Relaxed);
                         let now = Instant::now();
                         let expires_at = Self::compute_expires_at(self.ttl, now);
                         occupied.insert(TimedEntry {
@@ -1790,6 +1812,96 @@ mod tests {
             c.cache_peek(&2),
             Some(&20),
             "live entry kept by the predicate must survive"
+        );
+    }
+
+    #[test]
+    fn retain_with_panicking_on_evict_still_counts_eviction() {
+        // The entry is removed from the map and counted BEFORE `on_evict` runs
+        // (`HashMap::retain` returns `false`, dropping the entry, only after the
+        // closure -- but the counter increment happens before the callback inside
+        // that closure), so a panicking callback must not leave the eviction
+        // uncounted.
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        let mut c: TtlCache<u32, u32> = TtlCache::builder()
+            .ttl(crate::time::Duration::from_secs(60))
+            .on_evict(|_k: &u32, _v: &u32| panic!("boom"))
+            .build()
+            .unwrap();
+        c.cache_set(1, 10);
+        let r = catch_unwind(AssertUnwindSafe(|| c.retain(|_, _| false)));
+        assert!(r.is_err(), "on_evict should have panicked");
+        assert_eq!(
+            c.cache_evictions(),
+            Some(1),
+            "eviction must be counted even though on_evict panicked"
+        );
+    }
+
+    #[test]
+    fn cache_remove_entry_with_panicking_on_evict_still_counts_eviction() {
+        // The entry is popped from the map and counted BEFORE `on_evict` runs, so a
+        // panicking callback must not leave the removed entry uncounted.
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        let mut c: TtlCache<u32, u32> = TtlCache::builder()
+            .ttl(crate::time::Duration::from_secs(60))
+            .on_evict(|_k: &u32, _v: &u32| panic!("boom"))
+            .build()
+            .unwrap();
+        c.cache_set(1, 10);
+        let r = catch_unwind(AssertUnwindSafe(|| c.cache_remove_entry(&1u32)));
+        assert!(r.is_err(), "on_evict should have panicked");
+        assert_eq!(c.cache_peek(&1), None, "entry must still be removed");
+        assert_eq!(
+            c.cache_evictions(),
+            Some(1),
+            "eviction must be counted even though on_evict panicked"
+        );
+    }
+
+    #[test]
+    fn cache_get_lazy_sweep_with_panicking_on_evict_still_counts_eviction() {
+        // `cache_get`'s lazy-sweep path removes the expired entry from the map and
+        // counts the eviction BEFORE `on_evict` runs, so a panicking callback must
+        // not leave the swept entry uncounted.
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        let mut c: TtlCache<u32, u32> = TtlCache::builder()
+            .ttl(crate::time::Duration::from_millis(20))
+            .on_evict(|_k: &u32, _v: &u32| panic!("boom"))
+            .build()
+            .unwrap();
+        c.cache_set(1, 10);
+        std::thread::sleep(std::time::Duration::from_millis(80));
+        let r = catch_unwind(AssertUnwindSafe(|| {
+            let _ = c.cache_get(&1u32);
+        }));
+        assert!(r.is_err(), "on_evict should have panicked");
+        assert_eq!(
+            c.cache_evictions(),
+            Some(1),
+            "eviction must be counted even though on_evict panicked"
+        );
+    }
+
+    #[test]
+    fn cache_set_over_expired_with_panicking_on_evict_still_counts_eviction() {
+        // Overwriting an already-expired entry fires `on_evict` for the displaced
+        // value; `set_entry` counts the eviction BEFORE notifying, so a panicking
+        // callback must not leave it uncounted.
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        let mut c: TtlCache<u32, u32> = TtlCache::builder()
+            .ttl(crate::time::Duration::from_millis(20))
+            .on_evict(|_k: &u32, _v: &u32| panic!("boom"))
+            .build()
+            .unwrap();
+        c.cache_set(1, 10);
+        std::thread::sleep(std::time::Duration::from_millis(80));
+        let r = catch_unwind(AssertUnwindSafe(|| c.cache_set(1, 20)));
+        assert!(r.is_err(), "on_evict should have panicked");
+        assert_eq!(
+            c.cache_evictions(),
+            Some(1),
+            "eviction must be counted even though on_evict panicked"
         );
     }
 

--- a/src/stores/ttl_sorted.rs
+++ b/src/stores/ttl_sorted.rs
@@ -881,10 +881,12 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> TtlSortedCache<K, V, S> {
             // it is dropped silently from the caller's view; fire `on_evict` and count an
             // eviction so cleanup and metrics stay consistent with the other removal paths.
             Some(entry) if entry.is_expired_at(now) => {
+                // Count BEFORE notifying: a panicking callback must never leave
+                // an entry removed-but-uncounted.
+                self.evictions.fetch_add(1, AtomicOrdering::Relaxed);
                 if let Some(on_evict) = &self.on_evict {
                     on_evict(entry.key.0.as_ref(), &entry.value);
                 }
-                self.evictions.fetch_add(1, AtomicOrdering::Relaxed);
                 None
             }
             Some(entry) => Some(entry.value),
@@ -955,10 +957,12 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> TtlSortedCache<K, V, S> {
     {
         if let Some(entry) = self.map.remove(key) {
             self.keys.remove(&entry.as_stamped());
+            // Count BEFORE notifying: a panicking callback must never leave an
+            // entry removed-but-uncounted.
+            self.evictions.fetch_add(1, AtomicOrdering::Relaxed);
             if let Some(on_evict) = &self.on_evict {
                 on_evict(entry.key.0.as_ref(), &entry.value);
             }
-            self.evictions.fetch_add(1, AtomicOrdering::Relaxed);
         }
     }
 
@@ -1155,10 +1159,12 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> Cached<K, V> for TtlSortedCa
                 self.keys.remove(&removed.as_stamped());
                 // The stored key `Arc` derefs to `&K` directly: no clone is needed to hand the
                 // callback a reference (and the clone previously ran even without a callback).
+                // Count BEFORE notifying: a panicking callback must never leave an entry
+                // removed-but-uncounted.
+                self.evictions.fetch_add(1, AtomicOrdering::Relaxed);
                 if let Some(on_evict) = &self.on_evict {
                     on_evict(removed.key.0.as_ref(), &removed.value);
                 }
-                self.evictions.fetch_add(1, AtomicOrdering::Relaxed);
                 if expired { None } else { Some(removed.value) }
             }
         }
@@ -1174,10 +1180,12 @@ impl<K: Hash + Eq + Ord + Clone, V, S: BuildHasher> Cached<K, V> for TtlSortedCa
             Some(removed) => {
                 self.keys.remove(&removed.as_stamped());
                 let stored_k = (*removed.key.0).clone();
+                // Count BEFORE notifying: a panicking callback must never leave an
+                // entry removed-but-uncounted.
+                self.evictions.fetch_add(1, AtomicOrdering::Relaxed);
                 if let Some(on_evict) = &self.on_evict {
                     on_evict(&stored_k, &removed.value);
                 }
-                self.evictions.fetch_add(1, AtomicOrdering::Relaxed);
                 Some((stored_k, removed.value))
             }
         }
@@ -2371,6 +2379,90 @@ mod test {
 
         let _ = c.cache_remove_entry(&999u32);
         assert_eq!(count.load(Ordering::Relaxed), 1, "no fire for absent key");
+    }
+
+    #[test]
+    fn cache_remove_entry_with_panicking_on_evict_still_counts_eviction() {
+        // The entry is popped from the map and index and counted BEFORE `on_evict`
+        // runs, so a panicking callback must not leave the removed entry uncounted.
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        let mut c = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .on_evict(|_k: &u32, _v: &u32| panic!("boom"))
+            .build()
+            .unwrap();
+        c.cache_set(1u32, 10u32);
+        let r = catch_unwind(AssertUnwindSafe(|| c.cache_remove_entry(&1u32)));
+        assert!(r.is_err(), "on_evict should have panicked");
+        assert_eq!(c.cache_get(&1u32), None, "entry must still be removed");
+        assert_eq!(
+            c.cache_evictions(),
+            Some(1),
+            "eviction must be counted even though on_evict panicked"
+        );
+    }
+
+    #[test]
+    fn cache_remove_with_panicking_on_evict_still_counts_eviction() {
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        let mut c = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_secs(60))
+            .on_evict(|_k: &u32, _v: &u32| panic!("boom"))
+            .build()
+            .unwrap();
+        c.cache_set(1u32, 10u32);
+        let r = catch_unwind(AssertUnwindSafe(|| c.cache_remove(&1u32)));
+        assert!(r.is_err(), "on_evict should have panicked");
+        assert_eq!(c.cache_get(&1u32), None, "entry must still be removed");
+        assert_eq!(
+            c.cache_evictions(),
+            Some(1),
+            "eviction must be counted even though on_evict panicked"
+        );
+    }
+
+    #[test]
+    fn cache_get_lazy_sweep_with_panicking_on_evict_still_counts_eviction() {
+        // `remove_expired_entry` (the lazy-sweep path used by `cache_get`/`cache_get_mut`)
+        // removes the entry from the map and index and counts the eviction BEFORE
+        // `on_evict` runs.
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        let mut c = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_millis(20))
+            .on_evict(|_k: &u32, _v: &u32| panic!("boom"))
+            .build()
+            .unwrap();
+        c.cache_set(1u32, 10u32);
+        std::thread::sleep(std::time::Duration::from_millis(80));
+        let r = catch_unwind(AssertUnwindSafe(|| {
+            let _ = c.cache_get(&1u32);
+        }));
+        assert!(r.is_err(), "on_evict should have panicked");
+        assert_eq!(
+            c.cache_evictions(),
+            Some(1),
+            "eviction must be counted even though on_evict panicked"
+        );
+    }
+
+    #[test]
+    fn cache_set_over_expired_with_panicking_on_evict_still_counts_eviction() {
+        // `set_inner`'s displaced-expired-value branch counts BEFORE notifying.
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        let mut c = TtlSortedCache::<u32, u32>::builder()
+            .ttl(Duration::from_millis(20))
+            .on_evict(|_k: &u32, _v: &u32| panic!("boom"))
+            .build()
+            .unwrap();
+        c.cache_set(1u32, 10u32);
+        std::thread::sleep(std::time::Duration::from_millis(80));
+        let r = catch_unwind(AssertUnwindSafe(|| c.cache_set(1u32, 20u32)));
+        assert!(r.is_err(), "on_evict should have panicked");
+        assert_eq!(
+            c.cache_evictions(),
+            Some(1),
+            "eviction must be counted even though on_evict panicked"
+        );
     }
 
     #[test]

--- a/src/stores/unbound.rs
+++ b/src/stores/unbound.rs
@@ -1083,7 +1083,7 @@ mod tests {
         assert_eq!(c.cache_hits(), Some(2));
     }
 
-    #[cfg(feature = "async")]
+    #[cfg(feature = "async_core")]
     #[tokio::test]
     async fn async_get_or_set_with_hits_and_misses_are_counted() {
         use crate::CachedGetOrSetAsync;

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -8870,27 +8870,37 @@ fn redb_default_cache_contains_is_expiry_aware() {
     use cached::time::Duration;
     use cached::{ConcurrentCached, RedbCache};
 
-    // Very short TTL: after it lapses, cache_get returns None for the entry,
-    // so the default cache_contains must report false.
-    let cache = RedbCache::<String, u32>::builder("redb_default_contains_expiry")
-        .ttl(Duration::from_millis(50))
+    // The live and expired halves use separate caches so neither assertion can
+    // race the clock. A disk round-trip on a loaded CI runner can take longer
+    // than a short TTL, so the live half gets a TTL nothing realistic outruns;
+    // the expired half keeps a short TTL, where being slow only helps.
+    let live = RedbCache::<String, u32>::builder("redb_default_contains_live")
+        .ttl(Duration::from_secs(60))
         .build()
         .expect("build redb cache");
-    ConcurrentCached::cache_clear(&cache).expect("clear");
+    ConcurrentCached::cache_clear(&live).expect("clear");
 
-    ConcurrentCached::cache_set(&cache, "k".to_string(), 1).expect("set");
+    ConcurrentCached::cache_set(&live, "k".to_string(), 1).expect("set");
     assert!(
-        ConcurrentCached::cache_contains(&cache, &"k".to_string()).expect("live contains"),
+        ConcurrentCached::cache_contains(&live, &"k".to_string()).expect("live contains"),
         "freshly-set redb entry must be contained"
     );
 
+    let expiring = RedbCache::<String, u32>::builder("redb_default_contains_expiry")
+        .ttl(Duration::from_millis(50))
+        .build()
+        .expect("build redb cache");
+    ConcurrentCached::cache_clear(&expiring).expect("clear");
+
+    ConcurrentCached::cache_set(&expiring, "k".to_string(), 1).expect("set");
     std::thread::sleep(std::time::Duration::from_millis(80));
     assert!(
-        !ConcurrentCached::cache_contains(&cache, &"k".to_string()).expect("expired contains"),
+        !ConcurrentCached::cache_contains(&expiring, &"k".to_string()).expect("expired contains"),
         "expired redb entry must NOT be contained (default path follows cache_get)"
     );
 
-    ConcurrentCached::cache_clear(&cache).expect("clean up");
+    ConcurrentCached::cache_clear(&live).expect("clean up");
+    ConcurrentCached::cache_clear(&expiring).expect("clean up");
 }
 
 // ── Certification gap-fill: peek_with_expiry_status aliases on EXPIRED entries. ─

--- a/tests/cached.rs
+++ b/tests/cached.rs
@@ -91,6 +91,17 @@ fn compile_fail_cached_with_cached_flag_return_type_requires_clone() {
     t.compile_fail("tests/ui/cached_with_cached_flag_return_type_requires_clone.rs");
 }
 
+// Companion to `compile_fail_cached_return_type_requires_clone` for `#[once]`:
+// `#[once]` has the identical `.clone()` failure mode (on cache-set and on a
+// cache hit) as `#[cached]`, so it gets the same return-type `Clone`
+// assertion and must produce the same clear, precisely-spanned diagnostic.
+#[test]
+#[cfg(feature = "proc_macro")]
+fn compile_fail_once_return_type_requires_clone() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/once_return_type_requires_clone.rs");
+}
+
 // One negative trybuild case per *semantic* compile error the macros raise
 // (i.e. errors we define for invalid attribute/signature states). Pure
 // syn-parser pass-through messages for malformed user strings (bad `ty` /

--- a/tests/ui/once_return_type_requires_clone.rs
+++ b/tests/ui/once_return_type_requires_clone.rs
@@ -1,0 +1,17 @@
+use cached::macros::once;
+
+// `#[once]` clones the cached value on every cache-set and on a cache hit
+// (`.clone()`), the same failure mode as `#[cached]`, so the return type must
+// implement `Clone`. The dedicated assertion emits a clear diagnostic spanned
+// at the return type ahead of the opaque errors that still follow from deep
+// inside macro-generated internals.
+struct NotClone {
+    _value: u32,
+}
+
+#[once]
+fn not_clone_once_return() -> NotClone {
+    NotClone { _value: 0 }
+}
+
+fn main() {}

--- a/tests/ui/once_return_type_requires_clone.stderr
+++ b/tests/ui/once_return_type_requires_clone.stderr
@@ -1,0 +1,50 @@
+error[E0277]: the trait bound `NotClone: Clone` is not satisfied
+  --> tests/ui/once_return_type_requires_clone.rs:13:31
+   |
+13 | fn not_clone_once_return() -> NotClone {
+   |                               ^^^^^^^^ the trait `Clone` is not implemented for `NotClone`
+   |
+note: required by a bound in `__cached_assert_return_type_implements_clone`
+  --> tests/ui/once_return_type_requires_clone.rs:13:31
+   |
+13 | fn not_clone_once_return() -> NotClone {
+   |                               ^^^^^^^^ required by this bound in `__cached_assert_return_type_implements_clone`
+help: consider annotating `NotClone` with `#[derive(Clone)]`
+   |
+ 8 + #[derive(Clone)]
+ 9 | struct NotClone {
+   |
+
+error[E0308]: mismatched types
+  --> tests/ui/once_return_type_requires_clone.rs:12:1
+   |
+12 | #[once]
+   | ^^^^^^^ expected `NotClone`, found `&NotClone`
+13 | fn not_clone_once_return() -> NotClone {
+   |                               -------- expected `NotClone` because of return type
+   |
+note: `NotClone` does not implement `Clone`, so `&NotClone` was cloned instead
+  --> tests/ui/once_return_type_requires_clone.rs:12:1
+   |
+12 | #[once]
+   | ^^^^^^^
+   = note: this error originates in the attribute macro `once` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `NotClone` with `#[derive(Clone)]`
+   |
+ 8 + #[derive(Clone)]
+ 9 | struct NotClone {
+   |
+
+error[E0599]: no method named `clone` found for struct `NotClone` in the current scope
+  --> tests/ui/once_return_type_requires_clone.rs:12:1
+   |
+ 8 | struct NotClone {
+   | --------------- method `clone` not found for this struct
+...
+12 | #[once]
+   | ^^^^^^^ method not found in `NotClone`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `clone`, perhaps you need to implement it:
+           candidate #1: `Clone`
+   = note: this error originates in the attribute macro `once` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/v3_retain_sharded_map.rs
+++ b/tests/v3_retain_sharded_map.rs
@@ -389,6 +389,61 @@ fn sharded_ttl_retain_keeps_never_expiring_entries() {
     assert_eq!(fired.len(), 16);
 }
 
+// No `on_evict` configured: exercises the in-place `HashMap::retain` fast path (no `Vec`
+// collection, no key clones) added alongside `evict`'s existing no-callback fast path.
+// Covers predicate filtering, expired-entry removal regardless of the predicate, and
+// eviction counting, all without a callback to fire.
+#[cfg(feature = "time_stores")]
+#[test]
+fn sharded_ttl_retain_no_callback_fast_path_filters_and_removes_expired() {
+    let c = ShardedTtlCache::<u32, u32>::builder()
+        .shards(4)
+        .ttl(Duration::from_millis(30))
+        .build()
+        .expect("build ShardedTtlCache");
+
+    for i in 0..16u32 {
+        c.set(i, i * 10);
+    }
+    std::thread::sleep(std::time::Duration::from_millis(80));
+    assert!(
+        populated_shards(&c.shard_sizes()) >= 2,
+        "cross-shard precondition: expired entries must span at least two shards, got {:?}",
+        c.shard_sizes()
+    );
+
+    // Long TTL for the live cohort; only even keys are kept by the predicate.
+    c.set_ttl(Duration::from_secs(3600));
+    for i in 100..116u32 {
+        c.set(i, i * 10);
+    }
+    let before = c
+        .metrics()
+        .evictions
+        .expect("ShardedTtlCache tracks evictions");
+
+    c.retain(|k, _v| k % 2 == 0);
+
+    // The 16 expired entries are gone regardless of the predicate; among the 16 live
+    // entries (100..116), only the even keys survive the predicate.
+    assert_eq!(c.len(), 8, "expired entries swept, odd live keys filtered");
+    for i in 0..16u32 {
+        assert_eq!(c.peek(&i), None, "expired key {i} must be gone");
+    }
+    for i in 100..116u32 {
+        let expected = if i % 2 == 0 { Some(i * 10) } else { None };
+        assert_eq!(c.peek(&i), expected, "live key {i} survivor mismatch");
+    }
+    assert_eq!(
+        c.metrics()
+            .evictions
+            .expect("ShardedTtlCache tracks evictions")
+            - before,
+        24,
+        "16 expired + 8 predicate-filtered removals all count as evictions"
+    );
+}
+
 // ── ShardedExpiringCache ─────────────────────────────────────────────────────
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -574,6 +629,61 @@ fn sharded_expiring_retain_is_visible_through_a_shared_clone_handle() {
     assert_eq!(c.len(), 4, "the original handle observes the same store");
     assert_eq!(c.peek(&0), Some(live(0)));
     assert_eq!(c.peek(&31), None);
+}
+
+// No `on_evict` configured: exercises the in-place `HashMap::retain` fast path (no `Vec`
+// collection, no key clones) added alongside `evict`'s existing no-callback fast path.
+// Covers predicate filtering, expired-entry removal regardless of the predicate, and
+// eviction counting, all without a callback to fire.
+#[test]
+fn sharded_expiring_retain_no_callback_fast_path_filters_and_removes_expired() {
+    let c = ShardedExpiringCache::<u32, Val>::builder()
+        .shards(4)
+        .build()
+        .expect("build ShardedExpiringCache");
+
+    // Even keys expired, odd keys live — both cohorts spread over the shards.
+    for i in 0..32u32 {
+        if i % 2 == 0 {
+            c.set(i, dead(i * 10));
+        } else {
+            c.set(i, live(i * 10));
+        }
+    }
+    assert!(
+        populated_shards(&c.shard_sizes()) >= 2,
+        "cross-shard precondition: entries must span at least two shards, got {:?}",
+        c.shard_sizes()
+    );
+    let before = c
+        .metrics()
+        .evictions
+        .expect("ShardedExpiringCache tracks evictions");
+
+    // Predicate additionally filters out live keys below 100 (i.e. i < 10).
+    c.retain(|_k, v| v.v >= 100);
+
+    // Expired (even) keys are gone regardless of the predicate; among the 16 live (odd)
+    // keys, only those with value >= 100 (i >= 11, odd) survive the predicate.
+    let expected_survivors = (0..32u32).filter(|i| i % 2 != 0 && i * 10 >= 100).count();
+    assert_eq!(c.len(), expected_survivors);
+    for i in 0..32u32 {
+        let expected = if i % 2 != 0 && i * 10 >= 100 {
+            Some(live(i * 10))
+        } else {
+            None
+        };
+        assert_eq!(c.peek(&i), expected, "key {i} survivor mismatch");
+    }
+    let expected_removed = 32 - expected_survivors;
+    assert_eq!(
+        c.metrics()
+            .evictions
+            .expect("ShardedExpiringCache tracks evictions")
+            - before,
+        expected_removed as u64,
+        "expired + predicate-filtered removals all count as evictions"
+    );
 }
 
 // ── Zero-removal fast paths: empty cache, and a hot shard alongside empty shards ────
@@ -1342,6 +1452,220 @@ fn sharded_expiring_retain_races_concurrent_set_get_evict_without_double_fire() 
         sizes.iter().sum::<usize>(),
         c.len(),
         "post-race shard sizes must still sum to the total length"
+    );
+}
+
+// ── Concurrency: the NO-callback retain fast path racing set/get/evict ─────────────
+//
+// The two race tests above build the cache WITH an `on_evict`, so they only exercise the
+// callback branch of `retain` (collect-under-lock, fire-after-release). The no-callback
+// fast path is a *different* code path: it drops filtered entries in place via
+// `HashMap::retain` and counts the length delta (`before - after`) under the same write
+// lock, with no `Vec` collection and no callback. These tests drive that path under the
+// same contention (concurrent set/get/evict) and certify:
+//   * no torn shard / no lost entries -- `shard_sizes().sum() == len()` post-race, and
+//   * exact eviction counting with no double-count -- a final, uncontended drain removes
+//     every remaining entry and bumps `metrics().evictions` by exactly that many. A
+//     `before - after` delta that ever over- or under-counted (e.g. if the subtraction
+//     were moved outside the write lock, or the retain double-visited an entry) would
+//     break this exact-count check.
+
+#[cfg(feature = "time_stores")]
+#[test]
+fn sharded_ttl_retain_no_callback_races_concurrent_set_get_evict() {
+    const SHARDS: usize = 4;
+    const KEYS: u32 = 16;
+    const ROUNDS: u32 = 150;
+    const WRITERS: usize = 3;
+    const READERS: usize = 3;
+
+    let next_id = Arc::new(AtomicU64::new(0));
+    // No `on_evict`: this exercises the in-place `HashMap::retain` + length-delta fast path.
+    let c = Arc::new(
+        ShardedTtlCache::<u32, u64>::builder()
+            .shards(SHARDS)
+            .ttl(Duration::from_millis(3))
+            .build()
+            .expect("build ShardedTtlCache"),
+    );
+
+    let gate = Arc::new(Barrier::new(WRITERS + READERS + 1));
+    let mut handles = Vec::new();
+
+    for _ in 0..WRITERS {
+        let c = c.clone();
+        let gate = gate.clone();
+        let next_id = next_id.clone();
+        handles.push(std::thread::spawn(move || {
+            gate.wait();
+            for r in 0..ROUNDS {
+                let k = r % KEYS;
+                let id = next_id.fetch_add(1, Ordering::Relaxed);
+                c.set(k, id);
+            }
+        }));
+    }
+    for _ in 0..READERS {
+        let c = c.clone();
+        let gate = gate.clone();
+        handles.push(std::thread::spawn(move || {
+            gate.wait();
+            for r in 0..ROUNDS {
+                let k = r % KEYS;
+                let _ = c.get(&k);
+            }
+        }));
+    }
+    {
+        let c = c.clone();
+        let gate = gate.clone();
+        handles.push(std::thread::spawn(move || {
+            gate.wait();
+            for r in 0..ROUNDS {
+                c.retain(|k, _v| (*k + r) % 2 == 0);
+                let _ = c.evict();
+            }
+        }));
+    }
+
+    for h in handles {
+        h.join().expect("worker thread must not panic");
+    }
+
+    // No torn shard: shard_sizes() (each acquired independently) must still sum to len().
+    let sizes = c.shard_sizes();
+    assert_eq!(
+        sizes.iter().sum::<usize>(),
+        c.len(),
+        "post-race shard sizes must still sum to the total length"
+    );
+
+    // Exact no-callback counting: sweep expired first (deterministic now that the workers
+    // have joined), then a keep-nothing retain must remove exactly the live remainder and
+    // bump the eviction counter by exactly that many -- no double-count, no undercount.
+    c.retain(|_k, _v| true);
+    let live = c.len();
+    let before_drain = c
+        .metrics()
+        .evictions
+        .expect("ShardedTtlCache tracks evictions");
+    c.retain(|_k, _v| false);
+    assert_eq!(c.len(), 0, "keep-nothing retain must empty the cache");
+    assert_eq!(
+        c.metrics()
+            .evictions
+            .expect("ShardedTtlCache tracks evictions")
+            - before_drain,
+        live as u64,
+        "the no-callback fast path must count exactly one eviction per drained entry"
+    );
+    let sizes = c.shard_sizes();
+    assert_eq!(
+        sizes.iter().sum::<usize>(),
+        0,
+        "drained cache has empty shards"
+    );
+}
+
+#[test]
+fn sharded_expiring_retain_no_callback_races_concurrent_set_get_evict() {
+    const SHARDS: usize = 4;
+    const KEYS: u32 = 16;
+    const ROUNDS: u32 = 150;
+    const WRITERS: usize = 3;
+    const READERS: usize = 3;
+
+    let next_id = Arc::new(AtomicU64::new(0));
+    // No `on_evict`: this exercises the in-place `HashMap::retain` + length-delta fast path.
+    let c = Arc::new(
+        ShardedExpiringCache::<u32, Val>::builder()
+            .shards(SHARDS)
+            .build()
+            .expect("build ShardedExpiringCache"),
+    );
+
+    let gate = Arc::new(Barrier::new(WRITERS + READERS + 1));
+    let mut handles = Vec::new();
+
+    for _ in 0..WRITERS {
+        let c = c.clone();
+        let gate = gate.clone();
+        let next_id = next_id.clone();
+        handles.push(std::thread::spawn(move || {
+            gate.wait();
+            for r in 0..ROUNDS {
+                let k = r % KEYS;
+                let id = next_id.fetch_add(1, Ordering::Relaxed);
+                // Roughly a third of inserts are born already-expired, so lazy-expiry
+                // removal (via cache_get), evict(), and retain()'s forced expired-removal
+                // all race to remove the very same entries.
+                if id.is_multiple_of(3) {
+                    c.set(k, dead(id as u32));
+                } else {
+                    c.set(k, live(id as u32));
+                }
+            }
+        }));
+    }
+    for _ in 0..READERS {
+        let c = c.clone();
+        let gate = gate.clone();
+        handles.push(std::thread::spawn(move || {
+            gate.wait();
+            for r in 0..ROUNDS {
+                let k = r % KEYS;
+                let _ = c.get(&k);
+            }
+        }));
+    }
+    {
+        let c = c.clone();
+        let gate = gate.clone();
+        handles.push(std::thread::spawn(move || {
+            gate.wait();
+            for r in 0..ROUNDS {
+                c.retain(|k, _v| (*k + r) % 2 == 0);
+                let _ = c.evict();
+            }
+        }));
+    }
+
+    for h in handles {
+        h.join().expect("worker thread must not panic");
+    }
+
+    // No torn shard: shard_sizes() (each acquired independently) must still sum to len().
+    let sizes = c.shard_sizes();
+    assert_eq!(
+        sizes.iter().sum::<usize>(),
+        c.len(),
+        "post-race shard sizes must still sum to the total length"
+    );
+
+    // Exact no-callback counting: sweep already-expired values first (deterministic now
+    // that the workers have joined), then a keep-nothing retain must remove exactly the
+    // live remainder and bump the eviction counter by exactly that many.
+    c.retain(|_k, _v| true);
+    let live = c.len();
+    let before_drain = c
+        .metrics()
+        .evictions
+        .expect("ShardedExpiringCache tracks evictions");
+    c.retain(|_k, _v| false);
+    assert_eq!(c.len(), 0, "keep-nothing retain must empty the cache");
+    assert_eq!(
+        c.metrics()
+            .evictions
+            .expect("ShardedExpiringCache tracks evictions")
+            - before_drain,
+        live as u64,
+        "the no-callback fast path must count exactly one eviction per drained entry"
+    );
+    let sizes = c.shard_sizes();
+    assert_eq!(
+        sizes.iter().sum::<usize>(),
+        0,
+        "drained cache has empty shards"
     );
 }
 


### PR DESCRIPTION
# Count evictions before `on_evict`, clear `Clone` error for `#[once]`, no-callback `retain` fast path

- Increment the `evictions` counter before invoking `on_evict` on every removal path of every in-memory store (evict/retain sweeps, `cache_remove` / `cache_remove_entry`, lazy expiry removal in `cache_get`, `cache_set` over an expired entry, capacity eviction, the `get_or_set` families), so a panicking callback cannot remove an entry without counting it. Previously `LruCache`, `TtlCache`, `LruTtlCache`, `ExpiringCache`, and `ExpiringLruCache` counted after the callback on most paths, and a few `TtlSortedCache` and sharded paths did too. Specced as METRIC-4 in specs/metrics.md; entries added to the CHANGELOG and both migration guides. Panic-path tests cover retain, remove, lazy-sweep, and set-over-expired per store.
- Emit the clear `Clone`-bound error from `#[once]` on a non-`Clone` return type, matching `#[cached]`; trybuild golden added.
- Skip the removed-entry collection in `retain` on `ShardedTtlCache` / `ShardedExpiringCache` when no `on_evict` is configured, matching `evict`; adds no-callback contention tests.
- Document that inherent `capacity()` on the always-bounded LRU stores shadows the `CachedExt` / `ConcurrentCachedExt` `capacity` aliases at concrete call sites.
- Gate the unbound async get-or-set metrics test on `async_core` instead of `async`.
- Mark design 0037 implemented in the specs/design index.
