### PR TITLE
ci: trigger the release on an unpublished version, fail on partial publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,54 @@ on:
       - main
   workflow_dispatch:
 jobs:
+  # Decide whether there is anything to release, from the actual signal: the
+  # root crate's version is not on crates.io yet.
+  #
+  # This deliberately does NOT key off the commit message. The previous guard
+  # required the head commit message to start with "release:", which
+  # squash-merging a release PR silently defeats: the squash replaces the commit
+  # message with the PR title, the prefix is lost, and the workflow skips while
+  # still reporting success. A version that is not on the index is the condition
+  # that actually means "publish", and it cannot be lost by a merge strategy.
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.decide.outputs.should_publish }}
+      version: ${{ steps.decide.outputs.version }}
+    steps:
+    - uses: actions/checkout@v6
+    - name: Check whether the root crate version is already published
+      id: decide
+      run: |
+        set -euo pipefail
+        version=$(cargo metadata --no-deps --format-version 1 \
+          | jq -r '.packages[] | select(.name == "cached") | .version')
+        if [ -z "$version" ]; then
+          echo "Could not determine the root crate version." >&2
+          exit 1
+        fi
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
+        # A network or API failure must fail loudly rather than silently
+        # resolving to "nothing to publish", which would skip a real release.
+        body=$(curl -sS --fail-with-body \
+          -H "User-Agent: jaemk-cached-release-workflow" \
+          "https://crates.io/api/v1/crates/cached/versions")
+
+        if jq -e --arg v "$version" '.versions[] | select(.num == $v)' >/dev/null <<<"$body"; then
+          echo "cached $version is already on crates.io - nothing to release."
+          echo "should_publish=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "cached $version is not on crates.io - releasing."
+          echo "should_publish=true" >> "$GITHUB_OUTPUT"
+        fi
+
   publish:
-    # Only request release-environment approval for actual release commits
-    # (or a manual dispatch); other merges to master skip the job entirely.
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'release:')
+    needs: check
+    # Only request release-environment approval when there is actually a new
+    # version to publish (or on a manual dispatch, the escape hatch for
+    # re-running a release whose earlier attempt failed partway).
+    if: github.event_name == 'workflow_dispatch' || needs.check.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     environment: release  # Optional: for enhanced security
     permissions:
@@ -30,8 +74,12 @@ jobs:
       # Tags every publishable workspace crate that lacks a tag or release yet,
       # including backfilling crates published in earlier runs; idempotent
       # (skips tags and releases that already exist on the remote).
-      if: steps.publish.outcome == 'success'
+      #
+      # Runs whenever publishing did not fail, so a re-run of a release that
+      # published but died before tagging still gets its tags and releases.
+      # `publish.sh` treats an already-published version as a benign skip, so
+      # this is reached on a re-run.
+      if: success()
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: bash bin/tag-release.sh
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,33 @@ Follow with a one-sentence summary (e.g. "Pushing 2 commits touching src/lib.rs 
 
 ---
 
+## Releasing
+
+`.github/workflows/release.yml` publishes when the root crate's version in `Cargo.toml` is not
+yet on crates.io. The commit message is irrelevant, and so is the merge strategy: bump the
+version, land it on master, and the release runs.
+
+Two consequences worth knowing:
+
+- **Merging a version bump releases it.** There is no separate confirmation beyond the
+  `environment: release` approval gate. Do not land a version bump you are not ready to publish.
+- **Re-running is safe.** `bin/publish.sh` treats a version already on the index as a benign
+  skip, and `bin/tag-release.sh` skips tags and releases that already exist, so a release that
+  died partway can be re-run with `gh workflow run release.yml --ref master`.
+
+`bin/publish.sh` publishes in dependency order (`cached_proc_macro_types` ->
+`cached_proc_macro` -> `cached`) and fails the release if any crate fails for a reason other
+than "already published". Do not relax that: publishing the root crate while a bumped subcrate
+failed would put `cached` on the index depending on a `cached_proc_macro*` version that does not
+exist.
+
+This guard used to require the head commit message to start with `release:`. That is fragile and
+was dropped: squash-merging a release PR replaces the commit message with the PR title, silently
+losing the prefix, and the workflow then skips while still reporting success. Do not reintroduce
+a message-based trigger.
+
+---
+
 ## Temp Files
 Write any scratch files, research dumps, or intermediate agent outputs to `local/` — it is gitignored and always safe to write to. Do not create temp files elsewhere in the repo.
 

--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -1,33 +1,67 @@
 #!/bin/bash
 
-# Publish order:
+# Publish every workspace crate to crates.io, in dependency order:
 # 1. cached_proc_macro_types
 # 2. cached_proc_macro
 # 3. cached (root)
+#
+# Exit status is the point of this script. A crate whose current version is
+# already on the index is a benign skip: the version did not change since the
+# last release, so there is nothing to publish and a re-run of this script must
+# stay idempotent. Any OTHER failure is fatal and fails the release.
+#
+# This distinction matters. An earlier version treated "at least one crate
+# published" as success, which reported a green release while two of three
+# crates had failed, and the tagging step then ran against a half-published
+# workspace. Publishing the root crate while a bumped subcrate silently failed
+# would leave `cached` on the index depending on a version of
+# `cached_proc_macro*` that does not exist.
 
-# Total number of crates
-TOTAL_CRATES=3
-SUCCESS_COUNT=0
+set -uo pipefail
+
+ALREADY_PUBLISHED_RE="already exists on crates.io index"
+
+published=0
+skipped=0
+failed=0
 
 publish_crate() {
     local dir=$1
+    local out status
     echo "Publishing crate in directory: $dir..."
-    if (cd "$dir" && cargo publish); then
-        echo "Successfully published crate in $dir"
-        ((SUCCESS_COUNT++))
-    else
-        echo "Failed to publish crate in $dir"
+    out=$( (cd "$dir" && cargo publish) 2>&1 )
+    status=$?
+
+    if [ $status -eq 0 ]; then
+        echo "$out"
+        echo "Published crate in $dir"
+        published=$((published + 1))
+        return 0
     fi
+
+    if grep -qF -- "$ALREADY_PUBLISHED_RE" <<<"$out"; then
+        echo "Version in $dir is already on the index - nothing to publish."
+        skipped=$((skipped + 1))
+        return 0
+    fi
+
+    echo "$out" >&2
+    echo "Failed to publish crate in $dir" >&2
+    failed=$((failed + 1))
+    return 1
 }
 
-publish_crate "cached_proc_macro_types"
-publish_crate "cached_proc_macro"
-publish_crate "."
+# Do not abort on the first failure: attempting the remaining crates makes the
+# log show every problem in one run instead of one per re-run.
+publish_crate "cached_proc_macro_types" || true
+publish_crate "cached_proc_macro" || true
+publish_crate "." || true
 
-if [ $SUCCESS_COUNT -gt 0 ]; then
-    echo "At least one crate published successfully ($SUCCESS_COUNT/$TOTAL_CRATES)."
-    exit 0
-else
-    echo "All cargo publish commands failed."
+echo "Publish summary: $published published, $skipped already current, $failed failed."
+
+if [ $failed -gt 0 ]; then
+    echo "Release failed: $failed crate(s) could not be published." >&2
     exit 1
 fi
+
+exit 0


### PR DESCRIPTION
Two defects in the release pipeline, both of which have already fired.

## The trigger could be silently lost

`release.yml` published only when the head commit message started with `release:`. Squash-merging a release PR replaces the commit message with the PR title, so the prefix is discarded and the workflow skips. It still reports success, having done nothing. That happened on #302: rc.10 was merged and nothing published.

The guard now keys off the actual signal, in a `check` job: publish when the root crate's version is not on crates.io. The commit message and the merge strategy no longer matter.

Verified against the live index:

```
3.0.0-rc.10 -> should_publish=false   (already published)
3.0.0-rc.9  -> should_publish=false
3.0.0       -> should_publish=true
```

A network or API failure during the check fails the job rather than resolving to "nothing to publish", so a transient error cannot silently skip a release.

## A partial publish reported success

`publish.sh` exited 0 if any crate published. The rc.9 run shows the consequence:

```
error: crate cached_proc_macro_types@3.0.0-rc.8 already exists on crates.io index
Failed to publish crate in cached_proc_macro_types
error: crate cached_proc_macro@3.0.0-rc.8 already exists on crates.io index
Failed to publish crate in cached_proc_macro
```

Two of three crates "failed", the root published, the script exited 0. `v3.0.0-rc.9` still has a git tag with no GitHub release because the tagging step then died partway.

`publish.sh` now separates the two cases: a version already on the index is a benign skip that keeps re-runs idempotent, and any other failure fails the release. Publishing the root crate while a bumped subcrate failed would put `cached` on the index depending on a `cached_proc_macro*` version that does not exist.

## Notes

- Merging this does not publish anything: `Cargo.toml` is at `3.0.0-rc.10`, which is already on crates.io, so `should_publish` is false.
- The tagging step now runs whenever publishing did not fail, so a release that published but died before tagging picks up its tags on a re-run.
- `workflow_dispatch` is unchanged and still bypasses the check, which is what recovered rc.10.
