### PR TITLE
docs: correct the backfill claim in `tag-release.sh`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,9 +71,10 @@ jobs:
       env:
         CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
     - name: Tag and create GitHub releases
-      # Tags every publishable workspace crate that lacks a tag or release yet,
-      # including backfilling crates published in earlier runs; idempotent
-      # (skips tags and releases that already exist on the remote).
+      # Tags and releases every publishable workspace crate whose CURRENT
+      # version lacks a tag or release; idempotent (skips whichever of the two
+      # already exists on the remote). It does not backfill historical
+      # versions - see the comment in bin/tag-release.sh.
       #
       # Runs whenever publishing did not fail, so a re-run of a release that
       # published but died before tagging still gets its tags and releases.

--- a/bin/tag-release.sh
+++ b/bin/tag-release.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 
-# Create a git tag and GitHub release for every workspace crate whose current
-# version is not yet tagged on the remote.
+# Create a git tag and GitHub release for every workspace crate whose CURRENT
+# version is not yet tagged and released on the remote.
 #
-# Idempotent: a crate whose tag/release already exists is skipped. The script
-# tags every publishable workspace crate that lacks a tag or release, which
-# includes backfilling crates published in earlier runs as well as those just
-# published. It leaves crates that are already fully tagged and released alone.
+# Idempotent: a crate with both a tag and a release is skipped, and a crate with
+# one but not the other gets only the missing half. That covers a run that
+# published but died before tagging: re-running creates the tag and release for
+# whatever version is in Cargo.toml now.
+#
+# It does NOT backfill historical versions. Only the version currently in each
+# Cargo.toml is considered, so a release from an earlier version that never got
+# a GitHub release stays missing however many times this runs. Create those by
+# hand, keeping the newest release flagged latest:
+#
+#   gh release create <tag> --title "<tag>" --notes-file <notes> --latest=false
 #
 # Tag naming:
 #   - root crate `cached`  -> vX.Y.Z          (bare, kept for back-compat)


### PR DESCRIPTION
Comment-only change; no behavior change.

`bin/tag-release.sh` claimed it backfills "crates published in earlier runs". It does not. The loop is driven by `cargo metadata`, so only the version currently in each `Cargo.toml` is ever considered. A version that shipped earlier and never got a GitHub release stays missing no matter how many times the script runs. That is why `v3.0.0-rc.9` had a tag and no release until it was created by hand, and why six pre-automation tags (`0.4.3`, `0.4.4`, `0.5.0`, `0.6.1`, `0.6.2`, `0.8.0`) still have none.

What it actually does, now stated accurately:

- Considers only each crate's current version.
- Skips a crate that has both a tag and a release; creates only the missing half when it has one but not the other. That is the real recovery path, for a run that published but died before tagging.
- Points at the manual command for historical versions, including `--latest=false` so backfilling an old release does not displace the newest one.

The same overstatement in the `release.yml` step comment is corrected to match.
